### PR TITLE
feat(#3): 定义 contracts 消费适配层（禁止自定义类型）

### DIFF
--- a/src/orchestrator/policy/__init__.py
+++ b/src/orchestrator/policy/__init__.py
@@ -1,1 +1,15 @@
+"""Policy contract adapter exports."""
 
+from orchestrator.policy.contracts_adapter import (
+    CONTRACTS_VERSION,
+    FailureClass,
+    GateAction,
+    PhaseEnum,
+)
+
+__all__ = [
+    "CONTRACTS_VERSION",
+    "FailureClass",
+    "GateAction",
+    "PhaseEnum",
+]

--- a/src/orchestrator/policy/contracts_adapter.py
+++ b/src/orchestrator/policy/contracts_adapter.py
@@ -1,0 +1,54 @@
+"""Adapter for gate-related enum types owned by the contracts package."""
+
+# TODO(contracts): replace local Enum with `from contracts.gate import ...` once contracts package is published.
+
+from enum import Enum
+
+
+CONTRACTS_VERSION: str = "stub-0.1"
+
+
+class PhaseEnum(Enum):
+    """Execution phases exposed by the contracts boundary."""
+
+    PHASE0 = "phase0"
+    PHASE1 = "phase1"
+    PHASE2 = "phase2"
+    PHASE3 = "phase3"
+
+
+class FailureClass(Enum):
+    """Gate failure classes exposed by the contracts boundary."""
+
+    INFRA = "infra"
+    DATA_QUALITY = "data_quality"
+    TASK_LEVEL = "task_level"
+    PUBLISH = "publish"
+
+
+class GateAction(Enum):
+    """Gate actions exposed by the contracts boundary."""
+
+    CONTINUE = "continue"
+    FAIL_RUN = "fail_run"
+    PARTIAL_RERUN = "partial_rerun"
+    MARK_INCONCLUSIVE = "mark_inconclusive"
+    REPAIR_MANIFEST = "repair_manifest"
+
+
+ALL_PHASE_NAMES: tuple[str, ...] = tuple(phase.value for phase in PhaseEnum)
+ALL_FAILURE_CLASSES: tuple[str, ...] = tuple(
+    failure_class.value for failure_class in FailureClass
+)
+ALL_ACTIONS: tuple[str, ...] = tuple(action.value for action in GateAction)
+
+
+__all__ = [
+    "ALL_ACTIONS",
+    "ALL_FAILURE_CLASSES",
+    "ALL_PHASE_NAMES",
+    "CONTRACTS_VERSION",
+    "FailureClass",
+    "GateAction",
+    "PhaseEnum",
+]

--- a/tests/policy/test_contracts_adapter.py
+++ b/tests/policy/test_contracts_adapter.py
@@ -1,0 +1,66 @@
+from orchestrator.policy import CONTRACTS_VERSION, FailureClass, GateAction, PhaseEnum
+from orchestrator.policy.contracts_adapter import (
+    ALL_ACTIONS,
+    ALL_FAILURE_CLASSES,
+    ALL_PHASE_NAMES,
+)
+
+
+def test_contracts_version_is_stub() -> None:
+    assert CONTRACTS_VERSION == "stub-0.1"
+
+
+def test_phase_enum_matches_contract_table() -> None:
+    assert len(PhaseEnum) == 4
+    assert tuple(phase.name for phase in PhaseEnum) == (
+        "PHASE0",
+        "PHASE1",
+        "PHASE2",
+        "PHASE3",
+    )
+    assert ALL_PHASE_NAMES == ("phase0", "phase1", "phase2", "phase3")
+    assert tuple(phase.value for phase in PhaseEnum) == ALL_PHASE_NAMES
+
+
+def test_failure_class_matches_contract_table() -> None:
+    assert len(FailureClass) == 4
+    assert tuple(failure_class.name for failure_class in FailureClass) == (
+        "INFRA",
+        "DATA_QUALITY",
+        "TASK_LEVEL",
+        "PUBLISH",
+    )
+    assert ALL_FAILURE_CLASSES == (
+        "infra",
+        "data_quality",
+        "task_level",
+        "publish",
+    )
+    assert (
+        tuple(failure_class.value for failure_class in FailureClass)
+        == ALL_FAILURE_CLASSES
+    )
+
+
+def test_gate_action_matches_contract_table() -> None:
+    assert len(GateAction) == 5
+    assert tuple(action.name for action in GateAction) == (
+        "CONTINUE",
+        "FAIL_RUN",
+        "PARTIAL_RERUN",
+        "MARK_INCONCLUSIVE",
+        "REPAIR_MANIFEST",
+    )
+    assert ALL_ACTIONS == (
+        "continue",
+        "fail_run",
+        "partial_rerun",
+        "mark_inconclusive",
+        "repair_manifest",
+    )
+    assert tuple(action.value for action in GateAction) == ALL_ACTIONS
+
+
+def test_acceptance_values_are_addressable() -> None:
+    assert PhaseEnum.PHASE0.value == "phase0"
+    assert GateAction.MARK_INCONCLUSIVE.value == "mark_inconclusive"


### PR DESCRIPTION
Closes #3

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `Makefile`, `src/orchestrator/jobs/phase0.py`, `src/orchestrator/resources/bundle.py`


---
## 背景与目标
根据 §5.4 与 CLAUDE.md 核心约束 3，Gate 类型、错误分类、阶段枚举必须来自 `contracts`，`orchestrator` 只能消费不能自定义第二套。由于当前 monorepo 中 `contracts` 仍在建设，本 issue 在 `orchestrator.policy` 内建立**适配层**，用 `typing.Protocol` 或可替换 stub 定义 `PhaseEnum`、`FailureClassEnum`、`ActionEnum` 等类型别名，在 `contracts` 就绪后一行替换即可切换。目的是提前冻结"只能从单一来源取类型"的依赖约束。

## 所属模块
`orchestrator.policy` / `orchestrator.policy.contracts_adapter`

## 实现范围
- 创建 `src/orchestrator/policy/contracts_adapter.py`：定义 `PhaseEnum`（`PHASE0`/`PHASE1`/`PHASE2`/`PHASE3`）、`FailureClass`（`INFRA`/`DATA_QUALITY`/`TASK_LEVEL`/`PUBLISH`）、`GateAction`（`CONTINUE`/`FAIL_RUN`/`PARTIAL_RERUN`/`MARK_INCONCLUSIVE`/`REPAIR_MANIFEST`）。
- 在文件头注释中显式标注 `# TODO(contracts): replace local Enum with `from contracts.gate import ...` once contracts package is published.`。
- 提供 `CONTRACTS_VERSION: str = "stub-0.1"` 常量，并导出 `ALL_PHASE_NAMES`、`ALL_FAILURE_CLASSES`、`ALL_ACTIONS` 元组便于校验。
- 编写 `tests/policy/test_contracts_adapter.py`：断言 4 个 phase、4 个 failure class、5 个 action 数量与名称完全匹配 §9.3 / §12.3 表格。
- 在 `src/orchestrator/policy/__init__.py` 中 re-export 三个 Enum 与 `CONTRACTS_VERSION`。

## 不在本次范围
- 不 import 真正的 `contracts` package（尚未就绪）。
- 不定义 Gate 策略具体数值、阈值或 YAML schema（见 #4）。
- 不在 asset/check 代码中直接使用这些 enum（见 #6）。

## 关键交付物
- `PhaseEnum(Enum)`：成员 `PHASE0 = "phase0"`、`PHASE1 = "phase1"`、`PHASE2 = "phase2"`、`PHASE3 = "phase3"`。
- `FailureClass(Enum)`：4 个成员，值为 snake_case 字符串。
- `GateAction(Enum)`：5 个成员，值与 §9.3 `GateDecision.action` 字段枚举一致。
- `ALL_PHASE_NAMES: tuple[str, ...] = ("phase0", "phase1", "phase2", "phase3")`。
- `CONTRACTS_VERSION` 字符串常量，供 policy 文件在加载时做版本对齐校验。
- Adapter 文件顶部必须有 `TODO(contracts)` 注释指明替换点。

## 验收标准
- [ ] `from orchestrator.policy import PhaseEnum, FailureClass, GateAction, CONTRACTS_VERSION` 成功。
- [ ] `len(PhaseEnum) == 4 and len(FailureClass) == 4 and len(GateAction) == 5`。
- [ ] `PhaseEnum.PHASE0.value == "phase0"`、`GateAction.MARK_INCONCLUSIVE.value == "mark_inconclusive"`。
- [ ] `tests/policy/test_contracts_adapter.py` 全部通过。
- [ ] Grep `rg "class.*Enu