### PR TITLE
feat(#10): alerting 骨架（logging 通道 + runbook payload）

### DIFF
--- a/src/orchestrator/alerting/__init__.py
+++ b/src/orchestrator/alerting/__init__.py
@@ -1,1 +1,4 @@
+from orchestrator.alerting.dispatcher import dispatch_alert
+from orchestrator.alerting.payload import AlertPayload
 
+__all__ = ["AlertPayload", "dispatch_alert"]

--- a/src/orchestrator/alerting/dispatcher.py
+++ b/src/orchestrator/alerting/dispatcher.py
@@ -1,0 +1,20 @@
+import dataclasses
+import json
+import logging
+from collections.abc import Iterable
+
+from orchestrator.alerting.payload import AlertPayload
+
+logger = logging.getLogger(__name__)
+
+
+def dispatch_alert(
+    payload: AlertPayload,
+    channels: Iterable[str] = ("logging",),
+) -> None:
+    for channel in channels:
+        if channel == "logging":
+            logger.warning(json.dumps(dataclasses.asdict(payload)))
+            continue
+
+        logger.warning("unknown alert channel: %s", channel)

--- a/src/orchestrator/alerting/payload.py
+++ b/src/orchestrator/alerting/payload.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class AlertPayload:
+    cycle_id: str
+    phase: str
+    status: str
+    failed_node: str | None
+    action: str
+    summary: str
+    runbook_url: str | None = None

--- a/tests/alerting/test_dispatcher.py
+++ b/tests/alerting/test_dispatcher.py
@@ -1,0 +1,87 @@
+import dataclasses
+import json
+import logging
+
+import pytest
+
+from orchestrator.alerting import AlertPayload, dispatch_alert
+
+
+def test_dispatch_alert_logging_channel_writes_json(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    payload = AlertPayload(
+        cycle_id="c1",
+        phase="phase0",
+        status="failed",
+        failed_node="phase0_readiness_ping",
+        action="fail_run",
+        summary="test",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        dispatch_alert(payload)
+
+    record = caplog.records[-1]
+    logged_payload = json.loads(record.message)
+
+    assert record.levelno == logging.WARNING
+    assert logged_payload["cycle_id"] == "c1"
+    assert logged_payload["action"] == "fail_run"
+
+
+def test_dispatch_alert_unknown_channel_warns_without_raising(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    payload = AlertPayload(
+        cycle_id="c1",
+        phase="phase0",
+        status="failed",
+        failed_node="phase0_readiness_ping",
+        action="fail_run",
+        summary="test",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        dispatch_alert(payload, channels=("unknown",))
+
+    assert caplog.records[-1].message == "unknown alert channel: unknown"
+
+
+def test_alert_payload_optional_fields_allow_none() -> None:
+    payload = AlertPayload(
+        cycle_id="c1",
+        phase="phase0",
+        status="failed",
+        failed_node=None,
+        action="fail_run",
+        summary="test",
+    )
+
+    assert payload.failed_node is None
+    assert payload.runbook_url is None
+
+
+def test_alert_payload_field_set_matches_runbook_payload() -> None:
+    field_names = {field.name for field in dataclasses.fields(AlertPayload)}
+
+    assert field_names == {
+        "cycle_id",
+        "phase",
+        "status",
+        "failed_node",
+        "action",
+        "summary",
+        "runbook_url",
+    }
+
+
+def test_alert_payload_required_fields_are_required() -> None:
+    with pytest.raises(TypeError):
+        AlertPayload(
+            cycle_id="c1",
+            phase="phase0",
+            status="failed",
+            failed_node=None,
+            action="fail_run",
+        )


### PR DESCRIPTION
Closes #10

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `Makefile`, `src/orchestrator/jobs/phase0.py`, `src/orchestrator/resources/bundle.py`


---
## 背景与目标
根据 §13.3 Runbook / Alert Payload 与 §15 "告警输出 logging / Webhook（Lite 模式足够简单）"，Phase 0 骨架需要有一条最简告警路径，以便 #6 的 `classify_gate_result` 在产出 `fail_run` 时有去向。本 issue 只实现 **logging 通道**（不做 Webhook、Slack），并冻结 `AlertPayload` dataclass 结构，阶段 3 再落多通道 dispatcher。

## 所属模块
`orchestrator.alerting`

## 实现范围
- 创建 `src/orchestrator/alerting/payload.py`：dataclass `AlertPayload`（字段见 §13.3：`cycle_id: str`、`phase: str`、`status: str`、`failed_node: str | None`、`action: str`、`summary: str`、`runbook_url: str | None = None`）。
- 创建 `src/orchestrator/alerting/dispatcher.py`：`dispatch_alert(payload: AlertPayload, channels: Iterable[str] = ("logging",)) -> None`。仅实现 `logging` 通道：`logger.warning(json.dumps(dataclasses.asdict(payload)))`。未知通道打 warning 但不 raise（P1a 宽松模式）。
- 在 `src/orchestrator/alerting/__init__.py` re-export `AlertPayload`、`dispatch_alert`。
- 编写 `tests/alerting/test_dispatcher.py`：用 `caplog` 验证 `dispatch_alert` 在 `logging` 通道下写出包含 `cycle_id` 与 `action` 字段的 JSON；未知通道时产生 `logger.warning("unknown alert channel: X")`。
- 在 `src/orchestrator/checks/asset_checks.py` 中不直接调 `dispatch_alert`（避免 AssetCheck 带副作用），只在 `GateDecision.action == FAIL_RUN` 时通过 op-level hook 触发（本 issue 只做 dispatcher 与 payload；hook 在阶段 1 接入）。

## 不在本次范围
- 不实现 Slack / Webhook / PagerDuty 通道（阶段 3）。
- 不做 runbook URL 自动渲染（阶段 3）。
- 不做告警去重与节流（阶段 3）。
- 不做 Dagster op-level hook 连线（阶段 1）。

## 关键交付物
- `AlertPayload` dataclass，7 字段与 §13.3 对齐。
- `dispatch_alert(payload, channels)`：默认 `("logging",)` 通道。
- JSON 序列化输出可被 `json.loads` 反序列化。
- 至少 3 条单元测试：logging 通道写出、未知通道 warning、空 payload 字段校验。

## 验收标准
- [ ] `dispatch_alert(AlertPayload(cycle_id="c1", phase="phase0", status="failed", failed_node="phase0_readiness_ping", action="fail_run", summary="test"))` 在 `caplog` 中产生 WARNING 级记录且 JSON 可解析。
- [ ] 调用 `dispatch_alert(payload, channels=("unknown",))` 不抛异常，但 warning 日志包含 `"unknown alert channel"`。
- [ ] `AlertPayload` 的 `failed_node` / `runbook_url` 允许为 `None`，其余字段必填。
- [ ] `pytest tests/alerting/ -v` 全绿，≥3 条用例。
- [ ] `AlertPayl