### PR TITLE
feat(#6): 最小 AssetCheck 与 classify_gate_result 纯函数

### DIFF
--- a/src/orchestrator/checks/__init__.py
+++ b/src/orchestrator/checks/__init__.py
@@ -1,1 +1,29 @@
+"""Gate check classifier and Dagster check exports."""
 
+from orchestrator.checks.classifier import UnknownGateFailure, classify_gate_result
+from orchestrator.checks.models import GateDecision
+from orchestrator.policy import FailureClass, GateAction, PhaseEnum
+
+
+def __getattr__(name: str) -> object:
+    if name == "GatePolicyResource":
+        from orchestrator.checks.resources import GatePolicyResource
+
+        return GatePolicyResource
+    if name == "phase0_ping_check":
+        from orchestrator.checks.asset_checks import phase0_ping_check
+
+        return phase0_ping_check
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [
+    "FailureClass",
+    "GateAction",
+    "GateDecision",
+    "GatePolicyResource",
+    "PhaseEnum",
+    "UnknownGateFailure",
+    "classify_gate_result",
+    "phase0_ping_check",
+]

--- a/src/orchestrator/checks/asset_checks.py
+++ b/src/orchestrator/checks/asset_checks.py
@@ -1,0 +1,20 @@
+"""Dagster AssetCheck wiring for Phase 0."""
+
+from __future__ import annotations
+
+from dagster import AssetCheckResult, asset_check
+
+from orchestrator.checks.classifier import classify_gate_result
+from orchestrator.checks.resources import GatePolicyResource
+from orchestrator.policy import GateAction, PhaseEnum
+
+
+@asset_check(asset="phase0_readiness_ping")
+def phase0_ping_check(gate_policy: GatePolicyResource) -> AssetCheckResult:
+    """Minimal policy-backed check node for the Phase 0 skeleton."""
+
+    decision = classify_gate_result(PhaseEnum.PHASE0, None, gate_policy.policy)
+    return AssetCheckResult(passed=decision.action is GateAction.CONTINUE)
+
+
+__all__ = ["phase0_ping_check"]

--- a/src/orchestrator/checks/classifier.py
+++ b/src/orchestrator/checks/classifier.py
@@ -1,0 +1,43 @@
+"""Pure gate failure classifier."""
+
+from __future__ import annotations
+
+from orchestrator.checks.models import GateDecision
+from orchestrator.policy import FailureClass, GateAction, GatePolicyProfile, PhaseEnum
+
+
+class UnknownGateFailure(Exception):
+    """Raised when a policy has no row for a phase/failure-class pair."""
+
+
+def classify_gate_result(
+    phase: PhaseEnum,
+    failure_class: FailureClass | None,
+    policy: GatePolicyProfile,
+) -> GateDecision:
+    """Classify a gate event by looking up the configured policy matrix."""
+
+    if failure_class is None:
+        return GateDecision(
+            phase=phase,
+            failure_class=None,
+            action=GateAction.CONTINUE,
+        )
+
+    for entry in policy.phase_matrix:
+        if entry.phase is phase and entry.failure_class is failure_class:
+            return GateDecision(
+                phase=phase,
+                failure_class=failure_class,
+                action=entry.action,
+                reason=entry.description,
+            )
+
+    msg = (
+        "unknown gate failure policy entry for "
+        f"phase={phase.value} failure_class={failure_class.value}"
+    )
+    raise UnknownGateFailure(msg)
+
+
+__all__ = ["UnknownGateFailure", "classify_gate_result"]

--- a/src/orchestrator/checks/models.py
+++ b/src/orchestrator/checks/models.py
@@ -1,0 +1,20 @@
+"""Runtime gate decision models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from orchestrator.policy import FailureClass, GateAction, PhaseEnum
+
+
+@dataclass(frozen=True, slots=True)
+class GateDecision:
+    """Decision produced by classifying a gate failure event."""
+
+    phase: PhaseEnum
+    failure_class: FailureClass | None
+    action: GateAction
+    reason: str | None = None
+
+
+__all__ = ["GateDecision"]

--- a/src/orchestrator/checks/resources.py
+++ b/src/orchestrator/checks/resources.py
@@ -1,0 +1,29 @@
+"""Dagster resources for gate checks."""
+
+from __future__ import annotations
+
+from pydantic import PrivateAttr
+
+from dagster import ConfigurableResource, InitResourceContext
+
+from orchestrator.policy import GatePolicyProfile, load_gate_policy
+
+
+class GatePolicyResource(ConfigurableResource):
+    """Load a versioned gate policy for Dagster check execution."""
+
+    policy_path: str
+
+    _policy: GatePolicyProfile | None = PrivateAttr(default=None)
+
+    def setup_for_execution(self, context: InitResourceContext) -> None:
+        self._policy = load_gate_policy(self.policy_path)
+
+    @property
+    def policy(self) -> GatePolicyProfile:
+        if self._policy is None:
+            self._policy = load_gate_policy(self.policy_path)
+        return self._policy
+
+
+__all__ = ["GatePolicyResource"]

--- a/src/orchestrator/policy/schema.py
+++ b/src/orchestrator/policy/schema.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from orchestrator.policy.contracts_adapter import FailureClass, GateAction, PhaseEnum
 
@@ -32,6 +32,21 @@ class GatePolicyProfile(BaseModel):
     thresholds: dict[str, float]
     alert_channels: list[str]
     updated_at: datetime
+
+    @model_validator(mode="after")
+    def reject_duplicate_phase_matrix_entries(self) -> "GatePolicyProfile":
+        seen: set[tuple[PhaseEnum, FailureClass]] = set()
+        for entry in self.phase_matrix:
+            key = (entry.phase, entry.failure_class)
+            if key in seen:
+                msg = (
+                    "duplicate phase_matrix entry for "
+                    f"phase={entry.phase.value} "
+                    f"failure_class={entry.failure_class.value}"
+                )
+                raise ValueError(msg)
+            seen.add(key)
+        return self
 
 
 __all__ = ["GatePolicyProfile", "PhaseMatrixEntry"]

--- a/tests/checks/test_classifier.py
+++ b/tests/checks/test_classifier.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from dataclasses import fields
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from orchestrator.checks import GateDecision, UnknownGateFailure, classify_gate_result
+from orchestrator.policy import FailureClass, GateAction, PhaseEnum, load_gate_policy
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LITE_POLICY_PATH = REPO_ROOT / "config" / "policy" / "gate_policy.lite.yaml"
+
+
+@pytest.fixture
+def gate_policy() -> Any:
+    return load_gate_policy(LITE_POLICY_PATH)
+
+
+def _load_lite_policy_data() -> dict[str, Any]:
+    return yaml.safe_load(LITE_POLICY_PATH.read_text(encoding="utf-8"))
+
+
+def _write_policy(tmp_path: Path, policy_data: dict[str, Any]) -> Path:
+    policy_path = tmp_path / "gate_policy.yaml"
+    policy_path.write_text(yaml.safe_dump(policy_data), encoding="utf-8")
+    return policy_path
+
+
+def test_gate_decision_fields_match_runtime_model() -> None:
+    assert [field.name for field in fields(GateDecision)] == [
+        "phase",
+        "failure_class",
+        "action",
+        "reason",
+    ]
+
+
+def test_classify_phase0_without_failure_continues(gate_policy: Any) -> None:
+    decision = classify_gate_result(PhaseEnum.PHASE0, None, gate_policy)
+
+    assert decision == GateDecision(
+        phase=PhaseEnum.PHASE0,
+        failure_class=None,
+        action=GateAction.CONTINUE,
+    )
+
+
+def test_classify_phase0_infra_fails_run(gate_policy: Any) -> None:
+    decision = classify_gate_result(
+        PhaseEnum.PHASE0,
+        FailureClass.INFRA,
+        gate_policy,
+    )
+
+    assert decision.phase is PhaseEnum.PHASE0
+    assert decision.failure_class is FailureClass.INFRA
+    assert decision.action is GateAction.FAIL_RUN
+    assert decision.reason == "LLM health check failed; stop before Phase 1."
+
+
+def test_classify_phase2_task_level_marks_inconclusive(gate_policy: Any) -> None:
+    decision = classify_gate_result(
+        PhaseEnum.PHASE2,
+        FailureClass.TASK_LEVEL,
+        gate_policy,
+    )
+
+    assert decision.phase is PhaseEnum.PHASE2
+    assert decision.failure_class is FailureClass.TASK_LEVEL
+    assert decision.action is GateAction.MARK_INCONCLUSIVE
+    assert (
+        decision.reason
+        == "A single-stock LLM task failed within tolerance; continue the pool."
+    )
+
+
+def test_classify_phase3_infra_repairs_manifest(gate_policy: Any) -> None:
+    decision = classify_gate_result(
+        PhaseEnum.PHASE3,
+        FailureClass.INFRA,
+        gate_policy,
+    )
+
+    assert decision.action is GateAction.REPAIR_MANIFEST
+
+
+def test_unknown_policy_combination_raises(gate_policy: Any) -> None:
+    with pytest.raises(
+        UnknownGateFailure,
+        match="phase=phase1 failure_class=infra",
+    ):
+        classify_gate_result(PhaseEnum.PHASE1, FailureClass.INFRA, gate_policy)
+
+
+def test_duplicate_phase_matrix_entries_are_rejected(tmp_path: Path) -> None:
+    policy_data = _load_lite_policy_data()
+    policy_data["phase_matrix"].append(dict(policy_data["phase_matrix"][0]))
+
+    with pytest.raises(
+        ValidationError,
+        match="duplicate phase_matrix entry for phase=phase0",
+    ):
+        load_gate_policy(_write_policy(tmp_path, policy_data))
+
+
+def test_phase0_ping_check_is_dagster_asset_check_definition() -> None:
+    dagster = pytest.importorskip("dagster", reason="dagster is not installed")
+
+    from orchestrator.checks import phase0_ping_check
+
+    definitions = dagster.Definitions(asset_checks=[phase0_ping_check])
+
+    assert definitions is not None


### PR DESCRIPTION
Closes #6

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `Makefile`, `src/orchestrator/jobs/phase0.py`, `src/orchestrator/policy/schema.py`, `src/orchestrator/resources/bundle.py`


---
## 背景与目标
根据 §11.2 Gate 分类算法与 §16.1 `classify_gate_result()`，编排层需要把"某次失败事件 + phase + policy"映射为 `GateDecision`。本 issue 先实现**纯函数版本**（无 Dagster 依赖），再用一个最小 Dagster `@asset_check` 包一层，让 Phase 0 骨架能在 Dagster UI 中看到 1 个检查节点并得到 `continue` / `fail_run` 结论。分类表严格查 policy，不写任何业务判断逻辑。

## 所属模块
`orchestrator.checks` / `orchestrator.checks.classifier` / `orchestrator.checks.asset_checks`

## 实现范围
- 创建 `src/orchestrator/checks/classifier.py`，实现纯函数 `classify_gate_result(phase: PhaseEnum, failure_class: FailureClass | None, policy: GatePolicyProfile) -> GateDecision`：若 `failure_class is None` 返回 `action=CONTINUE`；否则查 `policy.phase_matrix` 中 `(phase, failure_class)` 对应条目，返回 `GateDecision(phase=..., failure_class=..., action=entry.action, reason=entry.description)`；未命中抛 `UnknownGateFailure` 异常。
- 创建 `src/orchestrator/checks/models.py`：定义 `GateDecision` dataclass（字段见 §9.3，不含 `decision_id` / `cycle_id`——由调用方填入）。
- 创建 `src/orchestrator/checks/asset_checks.py`：用 `@asset_check(asset="phase0_readiness_ping")` 装饰一个函数 `phase0_ping_check`，内部调用 `classify_gate_result(PhaseEnum.PHASE0, None, policy)`，返回 `AssetCheckResult(passed=True)`。policy 通过 Dagster resource 注入（key: `gate_policy`）。
- 创建 `src/orchestrator/checks/resources.py`：定义 `GatePolicyResource(ConfigurableResource)`，字段 `policy_path: str`，`setup_for_execution` 中调用 `load_gate_policy`。
- 编写 `tests/checks/test_classifier.py`：至少 6 条用例——`(PHASE0, None)` → continue；`(PHASE0, INFRA)` → fail_run；`(PHASE2, TASK_LEVEL)` → mark_inconclusive；未知组合抛 `UnknownGateFailure`；policy 中同时存在两条相同 `(phase, failure_class)` 时加载阶段应已拒绝（回归测试）。
- 在 `src/orchestrator/checks/__init__.py` re-export `classify_gate_result`、`GateDecision`、`UnknownGateFailure`、`phase0_ping_check`、`GatePolicyResource`。

## 不在本次范围
- 不实现 `plan_partial_rerun()`（阶段 1）。
- 不写告警下发（#9）。
- 不做多 phase 并发分类。
- `AssetCheck` 不做真实数据校验（只做 policy 查表）。

## 关键交付物
- `classify_gate_result` 签名与行为见上；**纯函数，无 IO**。
- `GateDecision` dataclass，字段严格对齐 §9.3。
- `UnknownGateFailure(Exception)` 自定义异常，消息包含 `phase` 与 `failure_cla