### PR TITLE
feat(#8): 交易日 schedule 与最小 sensor 骨架

### DIFF
--- a/src/orchestrator/schedules/daily_cycle.py
+++ b/src/orchestrator/schedules/daily_cycle.py
@@ -5,10 +5,13 @@ from dagster import ScheduleDefinition
 from orchestrator.jobs.cycle import daily_cycle_job
 
 
+_DAILY_CYCLE_CRON = "0 17 * * 1-5"
+_DAILY_CYCLE_TIMEZONE = "Asia/Shanghai"
+
 daily_cycle_schedule = ScheduleDefinition(
     job=daily_cycle_job,
-    cron_schedule="0 17 * * 1-5",
-    execution_timezone="Asia/Shanghai",
+    cron_schedule=_DAILY_CYCLE_CRON,
+    execution_timezone=_DAILY_CYCLE_TIMEZONE,
     name="daily_cycle_schedule",
 )
 

--- a/src/orchestrator/sensors/data_readiness.py
+++ b/src/orchestrator/sensors/data_readiness.py
@@ -5,9 +5,12 @@ from dagster import SkipReason, sensor
 from orchestrator.jobs.cycle import daily_cycle_job
 
 
+_READINESS_DEFERRED_MESSAGE = "readiness wiring deferred to milestone-1"
+
+
 @sensor(job=daily_cycle_job, name="data_readiness_sensor")
 def data_readiness_sensor() -> SkipReason:
-    return SkipReason("readiness wiring deferred to milestone-1")
+    return SkipReason(_READINESS_DEFERRED_MESSAGE)
 
 
 __all__ = ["data_readiness_sensor"]

--- a/tests/schedules/test_daily_cycle.py
+++ b/tests/schedules/test_daily_cycle.py
@@ -1,0 +1,30 @@
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def daily_cycle_schedule_definition() -> Any:
+    pytest.importorskip("dagster", reason="dagster is not installed")
+
+    from orchestrator.schedules import daily_cycle_schedule
+
+    return daily_cycle_schedule
+
+
+def test_daily_cycle_schedule_cron(
+    daily_cycle_schedule_definition: Any,
+) -> None:
+    assert daily_cycle_schedule_definition.cron_schedule == "0 17 * * 1-5"
+
+
+def test_daily_cycle_schedule_timezone(
+    daily_cycle_schedule_definition: Any,
+) -> None:
+    assert daily_cycle_schedule_definition.execution_timezone == "Asia/Shanghai"
+
+
+def test_daily_cycle_schedule_name(
+    daily_cycle_schedule_definition: Any,
+) -> None:
+    assert daily_cycle_schedule_definition.name == "daily_cycle_schedule"

--- a/tests/sensors/test_data_readiness.py
+++ b/tests/sensors/test_data_readiness.py
@@ -1,0 +1,27 @@
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def sensor_exports() -> dict[str, Any]:
+    dagster = pytest.importorskip("dagster", reason="dagster is not installed")
+
+    from orchestrator.sensors import data_readiness_sensor
+
+    return {
+        "SkipReason": dagster.SkipReason,
+        "data_readiness_sensor": data_readiness_sensor,
+    }
+
+
+def test_data_readiness_sensor_skips_until_milestone_1(
+    sensor_exports: dict[str, Any],
+) -> None:
+    data_readiness_sensor = sensor_exports["data_readiness_sensor"]
+    SkipReason = sensor_exports["SkipReason"]
+
+    result = data_readiness_sensor.evaluation_fn()
+
+    assert isinstance(result, SkipReason)
+    assert "milestone-1" in result.skip_message

--- a/tests/sensors/test_data_readiness.py
+++ b/tests/sensors/test_data_readiness.py
@@ -10,6 +10,7 @@ def sensor_exports() -> dict[str, Any]:
     from orchestrator.sensors import data_readiness_sensor
 
     return {
+        "Definitions": dagster.Definitions,
         "SkipReason": dagster.SkipReason,
         "data_readiness_sensor": data_readiness_sensor,
     }
@@ -25,3 +26,26 @@ def test_data_readiness_sensor_skips_until_milestone_1(
 
     assert isinstance(result, SkipReason)
     assert "milestone-1" in result.skip_message
+
+
+def test_data_readiness_sensor_name(sensor_exports: dict[str, Any]) -> None:
+    data_readiness_sensor = sensor_exports["data_readiness_sensor"]
+
+    assert data_readiness_sensor.name == "data_readiness_sensor"
+
+
+def test_schedule_and_sensor_can_be_collected_together(
+    sensor_exports: dict[str, Any],
+) -> None:
+    from orchestrator.schedules import daily_cycle_schedule
+
+    Definitions = sensor_exports["Definitions"]
+    data_readiness_sensor = sensor_exports["data_readiness_sensor"]
+
+    defs = Definitions(
+        schedules=[daily_cycle_schedule],
+        sensors=[data_readiness_sensor],
+    )
+
+    assert daily_cycle_schedule in defs.schedules
+    assert data_readiness_sensor in defs.sensors


### PR DESCRIPTION
Closes #8

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `Makefile`, `pyproject.toml`, `src/orchestrator/jobs/phase0.py`, `src/orchestrator/resources/bundle.py`, `tests/test_definitions.py`


---
## 背景与目标
根据 §12.1 触发源类型与 §21 阶段 0 退出条件"1 个 schedule"，需要定义 1 条日频 schedule 与 1 个状态感知 sensor 骨架。schedule 固定每个交易日 17:00 触发（只用 cron 表达式，不做交易日历过滤——交易日过滤逻辑属于业务）。sensor 只挂一个 `data_readiness_sensor` 骨架，永远返回 `SkipReason("not wired in P1a")`，阶段 1 再接入真实 readiness 信号。

## 所属模块
`orchestrator.schedules` / `orchestrator.sensors`

## 实现范围
- 创建 `src/orchestrator/schedules/daily_cycle.py`：`daily_cycle_schedule = ScheduleDefinition(job=daily_cycle_job, cron_schedule="0 17 * * 1-5", execution_timezone="Asia/Shanghai", name="daily_cycle_schedule")`；job 引用见 #9。
- 创建 `src/orchestrator/sensors/data_readiness.py`：`@sensor(job=daily_cycle_job, name="data_readiness_sensor")` 装饰的函数，永远返回 `SkipReason("readiness wiring deferred to milestone-1")`。
- 在 `src/orchestrator/schedules/__init__.py` / `sensors/__init__.py` 分别 re-export。
- 编写 `tests/schedules/test_daily_cycle.py`：断言 `cron_schedule == "0 17 * * 1-5"`、`execution_timezone == "Asia/Shanghai"`、`name == "daily_cycle_schedule"`。
- 编写 `tests/sensors/test_data_readiness.py`：调用 sensor 的 `evaluation_fn` 后断言返回 `SkipReason`。

## 不在本次范围
- 不实现交易日历过滤（业务逻辑，不在编排层）。
- 不接真实 readiness 信号（阶段 1）。
- 不做 manual rerun sensor（阶段 1）。
- 不做 Temporal signal sensor（阶段 4）。

## 关键交付物
- `daily_cycle_schedule: ScheduleDefinition`，cron 严格为 `"0 17 * * 1-5"`，timezone `Asia/Shanghai`。
- `data_readiness_sensor: SensorDefinition`，`evaluation_fn` 固定返回 `SkipReason`。
- 两个 `name` 字段在 Dagster 命名空间中唯一且与文件名一致。
- 单元测试直接调用 sensor 函数无需 Dagster instance。

## 验收标准
- [ ] `daily_cycle_schedule.cron_schedule == "0 17 * * 1-5"` 且 `execution_timezone == "Asia/Shanghai"`。
- [ ] `data_readiness_sensor` 的评估结果是 `SkipReason` 类型，消息包含 `"milestone-1"`。
- [ ] `pytest tests/schedules/ tests/sensors/ -v` 全绿。
- [ ] 两个定义可被 `Definitions(schedules=[daily_cycle_schedule], sensors=[data_readiness_sensor])` 收集且 `dagster dev` 不抛错。

## 验证命令
```bash
cd /Users/fanjie/Desktop/Cowork/project-ult/orchestrator
pytest tests/schedules/ tests/sensors/ -v
python -c "from orchestrator.schedules import daily_cycle_schedule; print(