### PR TITLE
feat(#11): P1a 端到端集成测试（1 API 占位 + 1 dbt model + 1 check）

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test lint dagster-dev dbt-compile
+.PHONY: install test integration-test lint dagster-dev dbt-compile
 
 install:
 	python3 -m pip install -e ".[dev]"
@@ -6,11 +6,15 @@ install:
 test:
 	python3 -m pytest -q
 
+integration-test:
+	python3 -m pytest tests/integration -v --tb=short
+
 lint:
 	python3 -m mypy src tests
 
 dagster-dev:
 	DAGSTER_HOME=./dagster_home dagster dev -m orchestrator.definitions
 
-dbt-compile:
+dbt-compile:  ## requires the dev extra: dbt-core + dbt-duckdb
+	mkdir -p dbt_stub/dagster_home
 	cd dbt_stub && dbt compile --profiles-dir . --project-dir .

--- a/docs/RUNBOOK_P1A.md
+++ b/docs/RUNBOOK_P1A.md
@@ -1,0 +1,40 @@
+# P1a 最小骨架 Runbook
+
+### 本地启动
+
+1. 安装开发依赖：
+   ```bash
+   python3 -m pip install -e ".[dev]"
+   ```
+2. 编译占位 dbt project：
+   ```bash
+   make dbt-compile
+   ```
+3. 跑 P1a 端到端集成测试：
+   ```bash
+   make integration-test
+   ```
+4. 需要看 Dagster UI 时再启动：
+   ```bash
+   make dagster-dev
+   ```
+
+### 常见错误
+
+- `dagster is not installed`：当前环境没有安装开发依赖，重新执行 `python3 -m pip install -e ".[dev]"`。
+- `dbt CLI is not installed`：确认 dev extra 中的 `dbt-core` 与 `dbt-duckdb` 已安装。
+- `manifest.json` 缺失：先执行 `make dbt-compile`，或删除 `dbt_stub/target` 后重新编译。
+- DuckDB 文件无法创建：确认工作区可写，`dbt_stub/dagster_home` 可由当前用户创建。
+
+### 替换点
+
+- `dbt_stub/` 只用于 P1a 骨架；接入 `data-platform` 后替换为其公开 dbt project 入口。
+- `phase0_readiness_ping` 是 API 占位 asset；接入真实 readiness API 时保持 orchestrator 只装配，不复制业务逻辑。
+- `phase0_ping_check` 只做 Gate policy wiring；真实检查函数应由上游 `PureCheckProvider` 暴露。
+- `GatePolicyResource` 当前读取 `config/policy/gate_policy.lite.yaml`；环境装配交给 `assembly` 后只替换 policy 路径。
+
+### 回滚步骤
+
+1. 删除 `tests/integration/` 与 `docs/RUNBOOK_P1A.md`。
+2. 从 `Makefile` 移除 `integration-test` 目标。
+3. 如不再需要本地 dbt 骨架，移除 dev extra 中的 dbt 依赖。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "dbt-core",
+    "dbt-duckdb",
     "pytest",
     "pytest-asyncio",
     "mypy",

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""P1a integration tests."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DBT_STUB_DIR = _REPO_ROOT / "dbt_stub"
+
+
+def _clear_phase0_imports() -> None:
+    for module_name in list(sys.modules):
+        if module_name == "orchestrator.definitions":
+            sys.modules.pop(module_name, None)
+        elif module_name == "orchestrator.jobs":
+            sys.modules.pop(module_name, None)
+        elif module_name.startswith("orchestrator.jobs."):
+            sys.modules.pop(module_name, None)
+
+
+@pytest.fixture
+def dagster_instance() -> Iterator[object]:
+    dagster = pytest.importorskip("dagster", reason="dagster is not installed")
+
+    with dagster.DagsterInstance.ephemeral() as instance:
+        yield instance
+
+
+@pytest.fixture
+def stub_policy_path() -> str:
+    return str(_REPO_ROOT / "config" / "policy" / "gate_policy.lite.yaml")
+
+
+@pytest.fixture(scope="session")
+def _compiled_dbt_project(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    dbt_executable = shutil.which("dbt")
+    if dbt_executable is None:
+        pytest.skip("dbt CLI is not installed; install the project dev dependencies")
+
+    project_dir = tmp_path_factory.mktemp("orchestrator_dbt") / "dbt_stub"
+    shutil.copytree(_DBT_STUB_DIR, project_dir)
+    shutil.rmtree(project_dir / "target", ignore_errors=True)
+    shutil.rmtree(project_dir / "dbt_packages", ignore_errors=True)
+    (project_dir / "dagster_home").mkdir(exist_ok=True)
+
+    completed = subprocess.run(
+        [
+            dbt_executable,
+            "compile",
+            "--profiles-dir",
+            ".",
+            "--project-dir",
+            ".",
+        ],
+        cwd=project_dir,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+        timeout=45,
+    )
+    if completed.returncode != 0:
+        pytest.fail(f"dbt compile failed:\n{completed.stdout}")
+
+    manifest_path = project_dir / "target" / "manifest.json"
+    if not manifest_path.exists():
+        pytest.fail(f"dbt compile did not produce {manifest_path}")
+
+    return project_dir
+
+
+@pytest.fixture
+def tmp_dbt_project(
+    _compiled_dbt_project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[Path]:
+    monkeypatch.setenv("ORCHESTRATOR_DBT_PROJECT_DIR", str(_compiled_dbt_project))
+    _clear_phase0_imports()
+
+    yield _compiled_dbt_project
+
+    _clear_phase0_imports()

--- a/tests/integration/test_phase0_minimal_cycle.py
+++ b/tests/integration/test_phase0_minimal_cycle.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FORBIDDEN_BUSINESS_IMPORT = re.compile(
+    r"^(graph_engine|main_core|data_platform|audit_eval)\.",
+)
+
+
+def test_materialize_phase0_readiness_ping(
+    dagster_instance: object,
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+) -> None:
+    dagster = pytest.importorskip("dagster", reason="dagster is not installed")
+    pytest.importorskip("dagster_dbt", reason="dagster-dbt is not installed")
+
+    from orchestrator.checks.resources import GatePolicyResource
+    from orchestrator.jobs.phase0 import phase0_readiness_ping
+
+    result = dagster.materialize(
+        [phase0_readiness_ping],
+        resources={
+            "gate_policy": GatePolicyResource(policy_path=stub_policy_path),
+        },
+        instance=dagster_instance,
+    )
+
+    assert result.success is True
+
+
+def test_asset_check_passes(stub_policy_path: str) -> None:
+    pytest.importorskip("dagster", reason="dagster is not installed")
+
+    from orchestrator.checks.asset_checks import phase0_ping_check
+    from orchestrator.checks.resources import GatePolicyResource
+
+    result = execute_asset_check(
+        phase0_ping_check,
+        gate_policy=GatePolicyResource(policy_path=stub_policy_path),
+    )
+
+    assert result.passed is True
+
+
+def test_definitions_loads_without_errors(
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+) -> None:
+    dagster = pytest.importorskip("dagster", reason="dagster is not installed")
+    pytest.importorskip("dagster_dbt", reason="dagster-dbt is not installed")
+
+    from orchestrator.definitions import build_definitions
+
+    defs = build_definitions(policy_path=stub_policy_path)
+
+    assert isinstance(defs, dagster.Definitions)
+
+
+def test_daily_cycle_job_executes_in_process(
+    dagster_instance: object,
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+) -> None:
+    dagster = pytest.importorskip("dagster", reason="dagster is not installed")
+    dagster_dbt = pytest.importorskip(
+        "dagster_dbt",
+        reason="dagster-dbt is not installed",
+    )
+
+    from orchestrator.checks.asset_checks import phase0_ping_check
+    from orchestrator.checks.resources import GatePolicyResource
+    from orchestrator.jobs.cycle import daily_cycle_job
+    from orchestrator.jobs.phase0 import (
+        DBT_PROFILES_DIR,
+        DBT_PROJECT_DIR,
+        dbt_phase0_assets,
+        phase0_readiness_ping,
+    )
+
+    defs = dagster.Definitions(
+        assets=[phase0_readiness_ping, dbt_phase0_assets],
+        asset_checks=[phase0_ping_check],
+        jobs=[daily_cycle_job],
+        resources={
+            "gate_policy": GatePolicyResource(policy_path=stub_policy_path),
+            "dbt": dagster_dbt.DbtCliResource(
+                project_dir=str(DBT_PROJECT_DIR),
+                profiles_dir=str(DBT_PROFILES_DIR),
+            ),
+        },
+    )
+    result = defs.get_job_def("daily_cycle_job").execute_in_process(
+        instance=dagster_instance,
+    )
+    materializations = [
+        event
+        for event in result.all_events
+        if getattr(event, "is_step_materialization", False)
+        or getattr(event, "event_type_value", None) == "ASSET_MATERIALIZATION"
+    ]
+
+    assert result.success is True
+    assert len(materializations) >= 1
+
+
+def test_no_business_imports() -> None:
+    violations: list[str] = []
+
+    for path in sorted((_REPO_ROOT / "src" / "orchestrator").rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for module_name, lineno in _absolute_imports(tree):
+            if _FORBIDDEN_BUSINESS_IMPORT.match(module_name):
+                relative_path = path.relative_to(_REPO_ROOT)
+                violations.append(f"{relative_path}:{lineno}: {module_name}")
+
+    assert violations == []
+
+
+def _absolute_imports(tree: ast.AST) -> list[tuple[str, int]]:
+    imports: list[tuple[str, int]] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend((alias.name, node.lineno) for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            imports.append((node.module, node.lineno))
+
+    return imports
+
+
+def execute_asset_check(check_def: Any, **resource_kwargs: object) -> Any:
+    if not callable(check_def):
+        pytest.fail("asset check definition is not directly executable")
+
+    return check_def(**resource_kwargs)


### PR DESCRIPTION
Closes #11

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `Makefile`, `pyproject.toml`, `src/orchestrator/jobs/phase0.py`, `src/orchestrator/resources/bundle.py`, `tests/test_definitions.py`


---
## 背景与目标
根据 §18.2 集成测试表首行"1 API + 1 dbt model + 1 个 Phase 0 check"与 §21 阶段 0 退出条件"Dagster UI 中可看到最小依赖图并成功执行"，本 issue 提供**可重复运行的端到端骨架验证**：用 Dagster 的 `materialize` 与 `execute_in_process` API 在单次 pytest 中跑通 Phase 0 最小 cycle，断言 asset 物化成功、asset_check 通过、告警未被错误触发。同时作为阶段 0 与阶段 1 之间的 regression baseline。

## 所属模块
`tests/integration`（仓库新增目录）

## 实现范围
- 创建 `tests/integration/__init__.py`、`tests/integration/conftest.py`：定义 `dagster_instance` fixture（`DagsterInstance.ephemeral()`）、`stub_policy_path` fixture（指向 `config/policy/gate_policy.lite.yaml`）、`tmp_dbt_project` fixture（复制 `dbt_stub/` 到 `tmp_path` 并运行 `dbt compile`）。
- 创建 `tests/integration/test_phase0_minimal_cycle.py`：
  - 用例 1 `test_materialize_phase0_readiness_ping`：`materialize([phase0_readiness_ping], resources={"gate_policy": GatePolicyResource(policy_path=stub_policy_path)})`，断言 `result.success is True`。
  - 用例 2 `test_asset_check_passes`：对 `phase0_ping_check` 执行 `execute_asset_check`，断言 `result.passed is True`。
  - 用例 3 `test_definitions_loads_without_errors`：`build_definitions(policy_path=stub_policy_path)` 不抛异常，返回 `Definitions` 实例。
  - 用例 4 `test_daily_cycle_job_executes_in_process`：`daily_cycle_job.execute_in_process(resources={...})`，断言 `result.success` 且至少物化 1 个 asset。
  - 用例 5 `test_no_business_imports`：遍历 `src/orchestrator/` 所有 `.py` 文件，断言没有 `import`/`from` 引用 `graph_engine.` / `main_core.` / `data_platform.` 的内部子模块（只允许公开入口）。
- 在 `Makefile` 增加目标 `integration-test`：`pytest tests/integration -v --tb=short`。
- 在 `docs/` 下新增 `docs/RUNBOOK_P1A.md`，写清"如何本地跑通 P1a 骨架、常见报错、依赖 contracts/data-platform 的替换点"（不超过 100 行）。

## 不在本次范围
- 不做 Phase 1/2/3 端到端测试（阶段 1-2）。
- 不做失败注入测试（阶段 3）。
- 不接 CI（阶段 3 或由 `assembly` 负责）。
- 不对 dbt 做真实数据断言（只验 compile + 1 model）。

## 关键交付物
- 5 条集成测试用例，全部可在本机 `pytest tests/integration -v` 通过。
- `dagster_instance` fixture 确保测试隔离（每个用例用独立 ephemeral instance）。
- `test_no_business_imports` 用 `ast.parse` 扫描 `src/orchestrator/`，拒绝任何 `graph_engine.internal.*` / `main_core.internal.*` / `data_platform.inter