### PR TITLE
feat(#50): [milestone-0 review] P0: Core public APIs do not match the project contract

### DIFF
--- a/src/orchestrator/__init__.py
+++ b/src/orchestrator/__init__.py
@@ -2,13 +2,30 @@
 
 __version__ = "0.1.0"
 
+_PUBLIC_API_IMPORTS = {
+    "build_daily_cycle_jobs": ("orchestrator.jobs.cycle", "build_daily_cycle_jobs"),
+    "build_definitions": ("orchestrator.definitions", "build_definitions"),
+    "build_resource_bundle": ("orchestrator.resources", "build_resource_bundle"),
+    "classify_gate_result": ("orchestrator.checks", "classify_gate_result"),
+    "load_gate_policy": ("orchestrator.policy", "load_gate_policy"),
+    "plan_partial_rerun": ("orchestrator.rerun", "plan_partial_rerun"),
+}
+
 
 def __getattr__(name: str) -> object:
-    if name == "build_definitions":
-        from orchestrator.definitions import build_definitions
+    if name in _PUBLIC_API_IMPORTS:
+        from importlib import import_module
 
-        return build_definitions
+        module_name, attribute_name = _PUBLIC_API_IMPORTS[name]
+        return getattr(import_module(module_name), attribute_name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-__all__ = ["build_definitions"]
+__all__ = [
+    "build_daily_cycle_jobs",
+    "build_definitions",
+    "build_resource_bundle",
+    "classify_gate_result",
+    "load_gate_policy",
+    "plan_partial_rerun",
+]

--- a/src/orchestrator/checks/classifier.py
+++ b/src/orchestrator/checks/classifier.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from typing import Any
+
 from orchestrator.checks.models import GateDecision
 from orchestrator.policy import FailureClass, GateAction, GatePolicyProfile, PhaseEnum
 
@@ -12,11 +15,12 @@ class UnknownGateFailure(Exception):
 
 def classify_gate_result(
     phase: PhaseEnum,
-    failure_class: FailureClass | None,
+    event: object | None,
     policy: GatePolicyProfile,
 ) -> GateDecision:
     """Classify a gate event by looking up the configured policy matrix."""
 
+    failure_class = _failure_class_from_event(event)
     if failure_class is None:
         return GateDecision(
             phase=phase,
@@ -38,6 +42,31 @@ def classify_gate_result(
         f"phase={phase.value} failure_class={failure_class.value}"
     )
     raise UnknownGateFailure(msg)
+
+
+def _failure_class_from_event(event: object | None) -> FailureClass | None:
+    if event is None:
+        return None
+    if isinstance(event, Mapping):
+        if "failure_class" not in event:
+            raise TypeError("gate event mapping must include failure_class")
+        return _coerce_failure_class(event["failure_class"])
+    if hasattr(event, "failure_class"):
+        return _coerce_failure_class(getattr(event, "failure_class"))
+    raise TypeError("gate event must expose failure_class")
+
+
+def _coerce_failure_class(value: Any) -> FailureClass | None:
+    if value is None:
+        return None
+    if isinstance(value, FailureClass):
+        return value
+    if isinstance(value, str):
+        try:
+            return FailureClass(value)
+        except ValueError as exc:
+            raise ValueError(f"unknown failure_class: {value}") from exc
+    raise TypeError("failure_class must be a FailureClass or string")
 
 
 __all__ = ["UnknownGateFailure", "classify_gate_result"]

--- a/src/orchestrator/definitions.py
+++ b/src/orchestrator/definitions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Iterable
+from pathlib import Path
 
 from dagster import Definitions
 from dagster_dbt import DbtCliResource
@@ -16,8 +17,9 @@ from orchestrator.jobs.phase0 import (
     dbt_phase0_assets,
     phase0_readiness_ping,
 )
-from orchestrator.resources import AssetFactoryProvider, build_resource_bundle
+from orchestrator.resources import AssetFactoryProvider
 from orchestrator.resources._stub_provider import StubProvider
+from orchestrator.resources.bundle import _collect_resource_definitions
 from orchestrator.schedules import daily_cycle_schedule
 from orchestrator.sensors import data_readiness_sensor
 
@@ -26,30 +28,32 @@ _RESERVED_RESOURCE_KEYS = ("gate_policy", "dbt")
 
 
 def build_definitions(
-    policy_path: str | None = None,
-    providers: Iterable[AssetFactoryProvider] | None = None,
+    module_factories: Iterable[AssetFactoryProvider] | None = None,
+    policy_path: str | Path | None = None,
 ) -> Definitions:
     if policy_path is None:
         policy_path = os.environ.get(
             "ORCHESTRATOR_POLICY_PATH",
             DEFAULT_POLICY_PATH,
         )
-    provider_list = tuple(providers) if providers is not None else (StubProvider(),)
+    module_factory_list = (
+        tuple(module_factories) if module_factories is not None else (StubProvider(),)
+    )
 
-    provider_resources = build_resource_bundle(policy_path, provider_list)
+    provider_resources = _collect_resource_definitions(module_factory_list)
     for reserved in _RESERVED_RESOURCE_KEYS:
         if reserved in provider_resources:
             raise ValueError(f"duplicate resource key: {reserved}")
 
     provider_assets = [
         asset
-        for provider in provider_list
-        for asset in provider.get_assets()
+        for module_factory in module_factory_list
+        for asset in module_factory.get_assets()
     ]
     provider_checks = [
         check
-        for provider in provider_list
-        for check in provider.get_checks()
+        for module_factory in module_factory_list
+        for check in module_factory.get_checks()
     ]
 
     return Definitions(
@@ -66,7 +70,7 @@ def build_definitions(
         schedules=[daily_cycle_schedule],
         sensors=[data_readiness_sensor],
         resources={
-            "gate_policy": GatePolicyResource(policy_path=policy_path),
+            "gate_policy": GatePolicyResource(policy_path=str(policy_path)),
             "dbt": DbtCliResource(
                 project_dir=str(DBT_PROJECT_DIR),
                 profiles_dir=str(DBT_PROFILES_DIR),

--- a/src/orchestrator/jobs/__init__.py
+++ b/src/orchestrator/jobs/__init__.py
@@ -1,6 +1,11 @@
 """Dagster job and asset group exports."""
 
-from orchestrator.jobs.cycle import daily_cycle_job
+from orchestrator.jobs.cycle import build_daily_cycle_jobs, daily_cycle_job
 from orchestrator.jobs.phase0 import dbt_phase0_assets, phase0_readiness_ping
 
-__all__ = ["daily_cycle_job", "dbt_phase0_assets", "phase0_readiness_ping"]
+__all__ = [
+    "build_daily_cycle_jobs",
+    "daily_cycle_job",
+    "dbt_phase0_assets",
+    "phase0_readiness_ping",
+]

--- a/src/orchestrator/jobs/cycle.py
+++ b/src/orchestrator/jobs/cycle.py
@@ -1,5 +1,8 @@
 """Daily cycle Dagster job definitions."""
 
+from collections.abc import Mapping
+from typing import Any
+
 from dagster import AssetSelection, define_asset_job
 
 
@@ -9,4 +12,12 @@ daily_cycle_job = define_asset_job(
 )
 
 
-__all__ = ["daily_cycle_job"]
+def build_daily_cycle_jobs(
+    phase_config: Mapping[str, Any] | None,
+) -> tuple[object, ...]:
+    """Build P1a daily cycle jobs from the phase configuration facade."""
+
+    return (daily_cycle_job,)
+
+
+__all__ = ["build_daily_cycle_jobs", "daily_cycle_job"]

--- a/src/orchestrator/policy/loader.py
+++ b/src/orchestrator/policy/loader.py
@@ -12,11 +12,11 @@ from orchestrator.policy.schema import GatePolicyProfile
 logger = logging.getLogger(__name__)
 
 
-def load_gate_policy(path: Path | str) -> GatePolicyProfile:
+def load_gate_policy(policy_path: Path | str) -> GatePolicyProfile:
     """Load and validate a gate policy profile from YAML."""
 
-    policy_path = Path(path)
-    raw_policy = yaml.safe_load(policy_path.read_text(encoding="utf-8"))
+    policy_file = Path(policy_path)
+    raw_policy = yaml.safe_load(policy_file.read_text(encoding="utf-8"))
     profile = GatePolicyProfile.model_validate(raw_policy)
 
     if profile.contract_version != CONTRACTS_VERSION:

--- a/src/orchestrator/rerun.py
+++ b/src/orchestrator/rerun.py
@@ -1,0 +1,37 @@
+"""Partial rerun planning facade."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+
+@dataclass(frozen=True, slots=True)
+class PartialRerunPlan:
+    """Minimal rerun selection for a failed node."""
+
+    run_id: str
+    failed_node: str
+    rerun_selection: tuple[str, ...]
+    requires_manual_ack: bool
+    generated_at: datetime
+
+
+def plan_partial_rerun(run_id: str, failed_node: str) -> PartialRerunPlan:
+    """Generate the P1a-minimal rerun plan for a failed node."""
+
+    if not run_id:
+        raise ValueError("run_id is required")
+    if not failed_node:
+        raise ValueError("failed_node is required")
+
+    return PartialRerunPlan(
+        run_id=run_id,
+        failed_node=failed_node,
+        rerun_selection=(failed_node,),
+        requires_manual_ack=True,
+        generated_at=datetime.now(timezone.utc),
+    )
+
+
+__all__ = ["PartialRerunPlan", "plan_partial_rerun"]

--- a/src/orchestrator/resources/bundle.py
+++ b/src/orchestrator/resources/bundle.py
@@ -1,8 +1,9 @@
 """Resource bundle assembly for Dagster definitions."""
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import FrozenInstanceError, dataclass
-from datetime import datetime
+from datetime import datetime, timezone
+from typing import Any
 
 from orchestrator.resources.providers import AssetFactoryProvider, ResourceDefinition
 
@@ -27,15 +28,61 @@ class ResourceBundle:
 
 
 def build_resource_bundle(
-    config_ref: str,
-    providers: Iterable[AssetFactoryProvider],
+    env_config: Mapping[str, Any] | str | None,
+    module_factories: Iterable[AssetFactoryProvider],
+) -> ResourceBundle:
+    module_factory_list = tuple(module_factories)
+    resources = _collect_resource_definitions(module_factory_list)
+    return _resource_bundle_from(
+        env_config=env_config,
+        module_factories=module_factory_list,
+        resource_keys=tuple(resources),
+    )
+
+
+def _collect_resource_definitions(
+    module_factories: Iterable[AssetFactoryProvider],
 ) -> dict[str, ResourceDefinition]:
     resources: dict[str, ResourceDefinition] = {}
 
-    for provider in providers:
-        for key, resource in provider.get_resources().items():
+    for module_factory in module_factories:
+        for key, resource in module_factory.get_resources().items():
             if key in resources:
                 raise ValueError(f"duplicate resource key: {key}")
             resources[key] = resource
 
     return resources
+
+
+def _resource_bundle_from(
+    env_config: Mapping[str, Any] | str | None,
+    module_factories: Iterable[AssetFactoryProvider],
+    resource_keys: tuple[str, ...],
+) -> ResourceBundle:
+    return ResourceBundle(
+        resource_keys=resource_keys,
+        source_modules=_source_modules(module_factories),
+        config_ref=_config_ref(env_config),
+        injected_at=datetime.now(timezone.utc),
+        read_only=True,
+    )
+
+
+def _source_modules(
+    module_factories: Iterable[AssetFactoryProvider],
+) -> tuple[str, ...]:
+    modules: dict[str, None] = {}
+    for module_factory in module_factories:
+        modules[module_factory.__class__.__module__] = None
+    return tuple(modules)
+
+
+def _config_ref(env_config: Mapping[str, Any] | str | None) -> str:
+    if env_config is None:
+        return "default"
+    if isinstance(env_config, str):
+        return env_config
+    for key in ("config_ref", "environment", "env", "name"):
+        if key in env_config:
+            return str(env_config[key])
+    return "inline-env-config"

--- a/tests/checks/test_classifier.py
+++ b/tests/checks/test_classifier.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import fields
+from dataclasses import dataclass, fields
+from inspect import signature
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +15,11 @@ from orchestrator.policy import FailureClass, GateAction, PhaseEnum, load_gate_p
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 LITE_POLICY_PATH = REPO_ROOT / "config" / "policy" / "gate_policy.lite.yaml"
+
+
+@dataclass(frozen=True, slots=True)
+class GateEvent:
+    failure_class: FailureClass | str | None
 
 
 @pytest.fixture
@@ -40,6 +46,14 @@ def test_gate_decision_fields_match_runtime_model() -> None:
     ]
 
 
+def test_classify_gate_result_signature_matches_contract() -> None:
+    assert list(signature(classify_gate_result).parameters) == [
+        "phase",
+        "event",
+        "policy",
+    ]
+
+
 def test_classify_phase0_without_failure_continues(gate_policy: Any) -> None:
     decision = classify_gate_result(PhaseEnum.PHASE0, None, gate_policy)
 
@@ -53,7 +67,7 @@ def test_classify_phase0_without_failure_continues(gate_policy: Any) -> None:
 def test_classify_phase0_infra_fails_run(gate_policy: Any) -> None:
     decision = classify_gate_result(
         PhaseEnum.PHASE0,
-        FailureClass.INFRA,
+        GateEvent(failure_class=FailureClass.INFRA),
         gate_policy,
     )
 
@@ -66,7 +80,7 @@ def test_classify_phase0_infra_fails_run(gate_policy: Any) -> None:
 def test_classify_phase2_task_level_marks_inconclusive(gate_policy: Any) -> None:
     decision = classify_gate_result(
         PhaseEnum.PHASE2,
-        FailureClass.TASK_LEVEL,
+        {"failure_class": FailureClass.TASK_LEVEL},
         gate_policy,
     )
 
@@ -82,7 +96,7 @@ def test_classify_phase2_task_level_marks_inconclusive(gate_policy: Any) -> None
 def test_classify_phase3_infra_repairs_manifest(gate_policy: Any) -> None:
     decision = classify_gate_result(
         PhaseEnum.PHASE3,
-        FailureClass.INFRA,
+        GateEvent(failure_class="infra"),
         gate_policy,
     )
 
@@ -94,7 +108,16 @@ def test_unknown_policy_combination_raises(gate_policy: Any) -> None:
         UnknownGateFailure,
         match="phase=phase1 failure_class=infra",
     ):
-        classify_gate_result(PhaseEnum.PHASE1, FailureClass.INFRA, gate_policy)
+        classify_gate_result(
+            PhaseEnum.PHASE1,
+            GateEvent(failure_class=FailureClass.INFRA),
+            gate_policy,
+        )
+
+
+def test_classify_rejects_non_event_failure_class(gate_policy: Any) -> None:
+    with pytest.raises(TypeError, match="gate event must expose failure_class"):
+        classify_gate_result(PhaseEnum.PHASE0, FailureClass.INFRA, gate_policy)
 
 
 def test_duplicate_phase_matrix_entries_are_rejected(tmp_path: Path) -> None:

--- a/tests/policy/test_loader.py
+++ b/tests/policy/test_loader.py
@@ -1,4 +1,5 @@
 import logging
+from inspect import signature
 from pathlib import Path
 from typing import Any
 
@@ -27,6 +28,10 @@ def _write_policy(tmp_path: Path, policy_data: dict[str, Any]) -> Path:
     policy_path = tmp_path / "gate_policy.yaml"
     policy_path.write_text(yaml.safe_dump(policy_data), encoding="utf-8")
     return policy_path
+
+
+def test_load_gate_policy_signature_matches_contract() -> None:
+    assert list(signature(load_gate_policy).parameters) == ["policy_path"]
 
 
 def test_load_gate_policy_lite_success() -> None:

--- a/tests/resources/test_bundle.py
+++ b/tests/resources/test_bundle.py
@@ -1,5 +1,6 @@
 from dataclasses import FrozenInstanceError, fields, replace
 from datetime import datetime, timezone
+from inspect import signature
 from typing import Any
 
 import pytest
@@ -47,17 +48,30 @@ def test_stub_provider_injects_bootstrap_resource(
     resource_exports: dict[str, Any],
 ) -> None:
     AssetFactoryProvider = resource_exports["AssetFactoryProvider"]
+    ResourceBundle = resource_exports["ResourceBundle"]
     StubProvider = resource_exports["StubProvider"]
     build_resource_bundle = resource_exports["build_resource_bundle"]
     provider = StubProvider()
 
-    resources = build_resource_bundle("lite", [provider])
+    bundle = build_resource_bundle({"config_ref": "lite"}, [provider])
 
     assert isinstance(provider, AssetFactoryProvider)
-    assert tuple(resources) == ("orchestration_context_stub",)
-    assert resources["orchestration_context_stub"].create_resource(None) == {
-        "mode": "stub"
-    }
+    assert isinstance(bundle, ResourceBundle)
+    assert bundle.resource_keys == ("orchestration_context_stub",)
+    assert bundle.source_modules == ("orchestrator.resources._stub_provider",)
+    assert bundle.config_ref == "lite"
+    assert bundle.read_only is True
+
+
+def test_build_resource_bundle_signature_matches_contract(
+    resource_exports: dict[str, Any],
+) -> None:
+    build_resource_bundle = resource_exports["build_resource_bundle"]
+
+    assert list(signature(build_resource_bundle).parameters) == [
+        "env_config",
+        "module_factories",
+    ]
 
 
 def test_duplicate_resource_key_raises_value_error(
@@ -70,7 +84,10 @@ def test_duplicate_resource_key_raises_value_error(
         ValueError,
         match="duplicate resource key: orchestration_context_stub",
     ):
-        build_resource_bundle("lite", [StubProvider(), StubProvider()])
+        build_resource_bundle(
+            {"config_ref": "lite"},
+            [StubProvider(), StubProvider()],
+        )
 
 
 def test_read_only_resource_bundle_rejects_field_mutation(

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -1,3 +1,4 @@
+from inspect import signature
 from pathlib import Path
 from typing import Any
 
@@ -15,12 +16,13 @@ def definitions_exports() -> dict[str, Any]:
         pytest.skip("dbt manifest is not compiled; run make dbt-compile")
 
     from orchestrator.definitions import build_definitions
-    from orchestrator.jobs.cycle import daily_cycle_job
+    from orchestrator.jobs.cycle import build_daily_cycle_jobs, daily_cycle_job
     from orchestrator.jobs.phase0 import dbt_phase0_assets, phase0_readiness_ping
 
     return {
         "AssetKey": dagster.AssetKey,
         "Definitions": dagster.Definitions,
+        "build_daily_cycle_jobs": build_daily_cycle_jobs,
         "build_definitions": build_definitions,
         "daily_cycle_job": daily_cycle_job,
         "dbt_phase0_assets": dbt_phase0_assets,
@@ -40,6 +42,17 @@ def test_build_definitions_collects_p1a_surface(
     assert len(defs.sensors) == 1
     assert "gate_policy" in defs.resources
     assert "orchestration_context_stub" in defs.resources
+
+
+def test_build_definitions_signature_matches_contract(
+    definitions_exports: dict[str, Any],
+) -> None:
+    build_definitions = definitions_exports["build_definitions"]
+
+    assert list(signature(build_definitions).parameters) == [
+        "module_factories",
+        "policy_path",
+    ]
 
 
 def test_build_definitions_is_loadable(
@@ -66,6 +79,18 @@ def test_daily_cycle_job_selects_phase0_readiness_ping(
     assert AssetKey(["phase0_readiness_ping"]) in selected_keys
 
 
+def test_build_daily_cycle_jobs_signature_and_p1a_job(
+    definitions_exports: dict[str, Any],
+) -> None:
+    build_daily_cycle_jobs = definitions_exports["build_daily_cycle_jobs"]
+    daily_cycle_job = definitions_exports["daily_cycle_job"]
+
+    assert list(signature(build_daily_cycle_jobs).parameters) == ["phase_config"]
+    assert build_daily_cycle_jobs({"enabled_phases": ["phase0"]}) == (
+        daily_cycle_job,
+    )
+
+
 def test_provider_cannot_override_reserved_resource_keys(
     definitions_exports: dict[str, Any],
 ) -> None:
@@ -82,4 +107,4 @@ def test_provider_cannot_override_reserved_resource_keys(
             return {"dbt": object()}
 
     with pytest.raises(ValueError, match="duplicate resource key: dbt"):
-        build_definitions(providers=[DbtOverrideProvider()])
+        build_definitions(module_factories=[DbtOverrideProvider()])

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,24 @@
+import orchestrator
+
+
+def test_package_exports_contract_facades() -> None:
+    assert set(orchestrator.__all__) == {
+        "build_daily_cycle_jobs",
+        "build_definitions",
+        "build_resource_bundle",
+        "classify_gate_result",
+        "load_gate_policy",
+        "plan_partial_rerun",
+    }
+
+
+def test_pure_contract_facades_are_importable_from_package_root() -> None:
+    from orchestrator import (
+        classify_gate_result,
+        load_gate_policy,
+        plan_partial_rerun,
+    )
+
+    assert callable(classify_gate_result)
+    assert callable(load_gate_policy)
+    assert callable(plan_partial_rerun)

--- a/tests/test_rerun.py
+++ b/tests/test_rerun.py
@@ -1,0 +1,42 @@
+from dataclasses import FrozenInstanceError, fields
+from inspect import signature
+
+import pytest
+
+from orchestrator.rerun import PartialRerunPlan, plan_partial_rerun
+
+
+def test_partial_rerun_plan_fields_match_runtime_model() -> None:
+    assert [field.name for field in fields(PartialRerunPlan)] == [
+        "run_id",
+        "failed_node",
+        "rerun_selection",
+        "requires_manual_ack",
+        "generated_at",
+    ]
+
+
+def test_plan_partial_rerun_signature_matches_contract() -> None:
+    assert list(signature(plan_partial_rerun).parameters) == [
+        "run_id",
+        "failed_node",
+    ]
+
+
+def test_plan_partial_rerun_returns_minimal_failed_node_selection() -> None:
+    plan = plan_partial_rerun("run-1", "phase0_readiness_ping")
+
+    assert plan.run_id == "run-1"
+    assert plan.failed_node == "phase0_readiness_ping"
+    assert plan.rerun_selection == ("phase0_readiness_ping",)
+    assert plan.requires_manual_ack is True
+    assert plan.generated_at.tzinfo is not None
+    with pytest.raises(FrozenInstanceError):
+        plan.failed_node = "other"
+
+
+def test_plan_partial_rerun_rejects_empty_contract_inputs() -> None:
+    with pytest.raises(ValueError, match="run_id is required"):
+        plan_partial_rerun("", "node")
+    with pytest.raises(ValueError, match="failed_node is required"):
+        plan_partial_rerun("run-1", "")


### PR DESCRIPTION
Closes #50

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `src/orchestrator/checks/asset_checks.py`, `src/orchestrator/jobs/phase0.py`, `src/orchestrator/resources/bundle.py`, `tests/integration/conftest.py`, `tests/integration/test_phase0_minimal_cycle.py`, `tests/test_definitions.py`


---
## 背景与目标
Milestone review for milestone-0 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The milestone implements several §16.1 interfaces with different shapes than the documented contract: build_definitions takes policy_path/providers instead of module_factories/policy_path, build_resource_bundle returns a raw Dagster resource dict instead of assembling the ResourceBundle boundary, classify_gate_result takes a FailureClass directly instead of an event, and build_daily_cycle_jobs plus plan_partial_rerun are not exposed at all. These are cross-cutting public seams that later milestones will build on, so locking in the wrong signatures now will force either churn or adapters across every upstream module integration.

## 实现范围
- 修改文件: `cross-cutting`
- Add the exact §16.1 façade functions now, even if some return P1a-minimal implementations. Keep internal provider/resource helper names private if needed, but export and test build_definitions(module_factories, policy_path), build_daily_cycle_jobs(phase_config), load_gate_policy(policy_path), classify_gate_result(phase, event, policy), plan_partial_rerun(run_id, failed_node), and build_resource_bundle(env_config, module_factories) with contract-shape tests.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
python3 -m pytest
```
