### PR TITLE
feat(#17): plan_partial_rerun 纯函数与单元测试

### DIFF
--- a/src/orchestrator/__init__.py
+++ b/src/orchestrator/__init__.py
@@ -3,10 +3,18 @@
 __version__ = "0.1.0"
 
 _PUBLIC_API_IMPORTS = {
+    "PartialRerunNotAllowed": ("orchestrator.rerun", "PartialRerunNotAllowed"),
+    "PartialRerunPlan": ("orchestrator.rerun", "PartialRerunPlan"),
+    "RunHistorySnapshot": ("orchestrator.rerun", "RunHistorySnapshot"),
+    "UnknownFailedNode": ("orchestrator.rerun", "UnknownFailedNode"),
     "build_daily_cycle_jobs": ("orchestrator.jobs.cycle", "build_daily_cycle_jobs"),
     "build_definitions": ("orchestrator.definitions", "build_definitions"),
     "build_resource_bundle": ("orchestrator.resources", "build_resource_bundle"),
     "classify_gate_result": ("orchestrator.checks", "classify_gate_result"),
+    "compute_partial_rerun_plan": (
+        "orchestrator.rerun",
+        "compute_partial_rerun_plan",
+    ),
     "load_gate_policy": ("orchestrator.policy", "load_gate_policy"),
     "plan_partial_rerun": ("orchestrator.rerun", "plan_partial_rerun"),
 }
@@ -22,10 +30,15 @@ def __getattr__(name: str) -> object:
 
 
 __all__ = [
+    "PartialRerunNotAllowed",
+    "PartialRerunPlan",
+    "RunHistorySnapshot",
+    "UnknownFailedNode",
     "build_daily_cycle_jobs",
     "build_definitions",
     "build_resource_bundle",
     "classify_gate_result",
+    "compute_partial_rerun_plan",
     "load_gate_policy",
     "plan_partial_rerun",
 ]

--- a/src/orchestrator/policy/schema.py
+++ b/src/orchestrator/policy/schema.py
@@ -1,11 +1,14 @@
 """Pydantic schema for gate policy profiles."""
 
 from datetime import datetime
-from typing import Literal
+from typing import Literal, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
 from orchestrator.policy.contracts_adapter import FailureClass, GateAction, PhaseEnum
+
+
+RerunMode: TypeAlias = Literal["repair_only", "asset_only", "phase_only"]
 
 
 class PhaseMatrixEntry(BaseModel):
@@ -18,6 +21,7 @@ class PhaseMatrixEntry(BaseModel):
     action: GateAction
     allow_partial_rerun: bool
     description: str
+    rerun_mode: RerunMode | None = None
 
 
 class GatePolicyProfile(BaseModel):
@@ -49,4 +53,4 @@ class GatePolicyProfile(BaseModel):
         return self
 
 
-__all__ = ["GatePolicyProfile", "PhaseMatrixEntry"]
+__all__ = ["GatePolicyProfile", "PhaseMatrixEntry", "RerunMode"]

--- a/src/orchestrator/rerun.py
+++ b/src/orchestrator/rerun.py
@@ -1,9 +1,21 @@
-"""Partial rerun planning facade."""
+"""Pure partial rerun selection planner."""
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
+
+from orchestrator.policy import FailureClass, GateAction, GatePolicyProfile, PhaseEnum
+from orchestrator.policy.schema import PhaseMatrixEntry, RerunMode
+
+
+class PartialRerunNotAllowed(Exception):
+    """Raised when policy or run history forbids a partial rerun."""
+
+
+class UnknownFailedNode(Exception):
+    """Raised when a failed node is absent from the run history snapshot."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -15,23 +27,279 @@ class PartialRerunPlan:
     rerun_selection: tuple[str, ...]
     requires_manual_ack: bool
     generated_at: datetime
+    rerun_mode: RerunMode
+
+
+@dataclass(frozen=True, slots=True)
+class RunHistorySnapshot:
+    """Pure run graph snapshot used to compute a rerun selection."""
+
+    run_id: str
+    node_to_phase: Mapping[str, PhaseEnum]
+    node_dependencies: Mapping[str, tuple[str, ...]]
+    failed_nodes: tuple[str, ...]
+    repairable_nodes: Mapping[str, str]
+    node_failure_classes: Mapping[str, FailureClass | str] | None = None
+
+
+def compute_partial_rerun_plan(
+    run_id: str,
+    failed_node: str,
+    run_history: RunHistorySnapshot,
+    policy: GatePolicyProfile,
+) -> PartialRerunPlan:
+    """Compute a minimal partial rerun plan without side effects."""
+
+    _validate_inputs(run_id, failed_node)
+    if run_history.run_id != run_id:
+        msg = (
+            "run history snapshot does not match requested run_id: "
+            f"requested={run_id} snapshot={run_history.run_id}"
+        )
+        raise PartialRerunNotAllowed(msg)
+    if failed_node not in run_history.node_to_phase:
+        raise UnknownFailedNode(
+            f"unknown failed node for run_id={run_id}: failed_node={failed_node}"
+        )
+    if failed_node not in run_history.failed_nodes:
+        msg = (
+            "failed_node is not marked failed in run history: "
+            f"run_id={run_id} failed_node={failed_node}"
+        )
+        raise PartialRerunNotAllowed(msg)
+
+    phase = run_history.node_to_phase[failed_node]
+    entry = _policy_entry_for_failed_node(phase, failed_node, run_history, policy)
+    if not entry.allow_partial_rerun:
+        msg = (
+            "partial rerun is not allowed by policy: "
+            f"run_id={run_id} failed_node={failed_node} "
+            f"phase={phase.value} failure_class={entry.failure_class.value}"
+        )
+        raise PartialRerunNotAllowed(msg)
+
+    rerun_mode = _rerun_mode_for_entry(entry)
+    if rerun_mode == "repair_only":
+        rerun_selection = _repair_only_selection(run_id, failed_node, run_history)
+    elif rerun_mode == "asset_only":
+        rerun_selection = (failed_node,)
+    else:
+        rerun_selection = _phase_only_selection(phase, run_history)
+
+    return PartialRerunPlan(
+        run_id=run_id,
+        failed_node=failed_node,
+        rerun_selection=rerun_selection,
+        requires_manual_ack=rerun_mode != "asset_only",
+        generated_at=datetime.now(timezone.utc),
+        rerun_mode=rerun_mode,
+    )
 
 
 def plan_partial_rerun(run_id: str, failed_node: str) -> PartialRerunPlan:
-    """Generate the P1a-minimal rerun plan for a failed node."""
+    """Generate the P1a-minimal facade plan for a failed node."""
 
-    if not run_id:
-        raise ValueError("run_id is required")
-    if not failed_node:
-        raise ValueError("failed_node is required")
+    _validate_inputs(run_id, failed_node)
 
     return PartialRerunPlan(
         run_id=run_id,
         failed_node=failed_node,
         rerun_selection=(failed_node,),
-        requires_manual_ack=True,
+        requires_manual_ack=False,
         generated_at=datetime.now(timezone.utc),
+        rerun_mode="asset_only",
     )
 
 
-__all__ = ["PartialRerunPlan", "plan_partial_rerun"]
+def _validate_inputs(run_id: str, failed_node: str) -> None:
+    if not run_id:
+        raise ValueError("run_id is required")
+    if not failed_node:
+        raise ValueError("failed_node is required")
+
+
+def _policy_entry_for_failed_node(
+    phase: PhaseEnum,
+    failed_node: str,
+    run_history: RunHistorySnapshot,
+    policy: GatePolicyProfile,
+) -> PhaseMatrixEntry:
+    failure_class = _failure_class_for_failed_node(failed_node, run_history)
+    phase_entries = [entry for entry in policy.phase_matrix if entry.phase is phase]
+
+    if failure_class is not None:
+        for entry in phase_entries:
+            if entry.failure_class is failure_class:
+                return entry
+        msg = (
+            "policy has no partial rerun row for failed node: "
+            f"run_id={run_history.run_id} failed_node={failed_node} "
+            f"phase={phase.value} failure_class={failure_class.value}"
+        )
+        raise PartialRerunNotAllowed(msg)
+
+    if len(phase_entries) == 1:
+        return phase_entries[0]
+
+    partial_entries = [entry for entry in phase_entries if entry.allow_partial_rerun]
+    if len(partial_entries) == 1:
+        return partial_entries[0]
+
+    msg = (
+        "failed node requires an explicit failure_class for policy lookup: "
+        f"run_id={run_history.run_id} failed_node={failed_node} phase={phase.value}"
+    )
+    raise PartialRerunNotAllowed(msg)
+
+
+def _failure_class_for_failed_node(
+    failed_node: str,
+    run_history: RunHistorySnapshot,
+) -> FailureClass | None:
+    if run_history.node_failure_classes is None:
+        return None
+    value = run_history.node_failure_classes.get(failed_node)
+    if value is None:
+        return None
+    if isinstance(value, FailureClass):
+        return value
+    try:
+        return FailureClass(value)
+    except (TypeError, ValueError) as exc:
+        raise PartialRerunNotAllowed(
+            f"unknown failure_class for failed_node={failed_node}: {value}"
+        ) from exc
+
+
+def _rerun_mode_for_entry(entry: PhaseMatrixEntry) -> RerunMode:
+    if entry.rerun_mode is not None:
+        return entry.rerun_mode
+    if entry.action is GateAction.REPAIR_MANIFEST:
+        return "repair_only"
+    return "asset_only"
+
+
+def _repair_only_selection(
+    run_id: str,
+    failed_node: str,
+    run_history: RunHistorySnapshot,
+) -> tuple[str, ...]:
+    repair_node = run_history.repairable_nodes.get(failed_node)
+    if repair_node is None:
+        msg = (
+            "repair-only rerun requires a repairable node mapping: "
+            f"run_id={run_id} failed_node={failed_node}"
+        )
+        raise PartialRerunNotAllowed(msg)
+    return (repair_node,)
+
+
+def _phase_only_selection(
+    phase: PhaseEnum,
+    run_history: RunHistorySnapshot,
+) -> tuple[str, ...]:
+    seeds = tuple(
+        node
+        for node in run_history.failed_nodes
+        if run_history.node_to_phase.get(node) is phase
+    )
+    if not seeds:
+        raise PartialRerunNotAllowed(
+            f"phase-only rerun has no failed nodes in phase={phase.value}"
+        )
+
+    downstream = _downstream_index(run_history.node_dependencies)
+    selected: set[str] = set()
+    stack = list(reversed(seeds))
+    while stack:
+        node = stack.pop()
+        if node in selected:
+            continue
+        if run_history.node_to_phase.get(node) is not phase:
+            continue
+        selected.add(node)
+        next_nodes = tuple(
+            downstream_node
+            for downstream_node in downstream.get(node, ())
+            if run_history.node_to_phase.get(downstream_node) is phase
+        )
+        stack.extend(reversed(next_nodes))
+
+    return _stable_topological_selection(selected, run_history)
+
+
+def _downstream_index(
+    node_dependencies: Mapping[str, tuple[str, ...]],
+) -> dict[str, tuple[str, ...]]:
+    downstream: dict[str, list[str]] = {}
+    for node, dependencies in node_dependencies.items():
+        for dependency in dependencies:
+            downstream.setdefault(dependency, []).append(node)
+    return {node: tuple(nodes) for node, nodes in downstream.items()}
+
+
+def _stable_topological_selection(
+    selected: set[str],
+    run_history: RunHistorySnapshot,
+) -> tuple[str, ...]:
+    order = _stable_node_order(run_history)
+    order_index = {node: index for index, node in enumerate(order)}
+    visited: set[str] = set()
+    output: list[str] = []
+
+    def visit(node: str) -> None:
+        if node in visited:
+            return
+        visited.add(node)
+        dependencies = sorted(
+            (
+                dependency
+                for dependency in run_history.node_dependencies.get(node, ())
+                if dependency in selected
+            ),
+            key=lambda dependency: order_index.get(dependency, len(order_index)),
+        )
+        for dependency in dependencies:
+            visit(dependency)
+        output.append(node)
+
+    for node in sorted(
+        selected,
+        key=lambda item: order_index.get(item, len(order_index)),
+    ):
+        visit(node)
+
+    return tuple(output)
+
+
+def _stable_node_order(run_history: RunHistorySnapshot) -> tuple[str, ...]:
+    ordered: list[str] = []
+    seen: set[str] = set()
+
+    def append(node: str) -> None:
+        if node not in seen:
+            seen.add(node)
+            ordered.append(node)
+
+    for node, dependencies in run_history.node_dependencies.items():
+        for dependency in dependencies:
+            append(dependency)
+        append(node)
+    for node in run_history.node_to_phase:
+        append(node)
+    for node in run_history.failed_nodes:
+        append(node)
+    for repair_node in run_history.repairable_nodes.values():
+        append(repair_node)
+
+    return tuple(ordered)
+
+
+__all__ = [
+    "PartialRerunNotAllowed",
+    "PartialRerunPlan",
+    "RunHistorySnapshot",
+    "UnknownFailedNode",
+    "compute_partial_rerun_plan",
+    "plan_partial_rerun",
+]

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -3,10 +3,15 @@ import orchestrator
 
 def test_package_exports_contract_facades() -> None:
     assert set(orchestrator.__all__) == {
+        "PartialRerunNotAllowed",
+        "PartialRerunPlan",
+        "RunHistorySnapshot",
+        "UnknownFailedNode",
         "build_daily_cycle_jobs",
         "build_definitions",
         "build_resource_bundle",
         "classify_gate_result",
+        "compute_partial_rerun_plan",
         "load_gate_policy",
         "plan_partial_rerun",
     }
@@ -14,11 +19,17 @@ def test_package_exports_contract_facades() -> None:
 
 def test_pure_contract_facades_are_importable_from_package_root() -> None:
     from orchestrator import (
+        PartialRerunPlan,
+        RunHistorySnapshot,
         classify_gate_result,
+        compute_partial_rerun_plan,
         load_gate_policy,
         plan_partial_rerun,
     )
 
+    assert PartialRerunPlan.__name__ == "PartialRerunPlan"
+    assert RunHistorySnapshot.__name__ == "RunHistorySnapshot"
     assert callable(classify_gate_result)
+    assert callable(compute_partial_rerun_plan)
     assert callable(load_gate_policy)
     assert callable(plan_partial_rerun)

--- a/tests/test_rerun.py
+++ b/tests/test_rerun.py
@@ -1,9 +1,49 @@
 from dataclasses import FrozenInstanceError, fields
-from inspect import signature
+from datetime import datetime, timezone
+from inspect import getsource, signature
 
 import pytest
 
-from orchestrator.rerun import PartialRerunPlan, plan_partial_rerun
+from orchestrator.policy import FailureClass, GateAction, GatePolicyProfile, PhaseEnum
+from orchestrator.policy.schema import PhaseMatrixEntry
+from orchestrator.rerun import (
+    PartialRerunNotAllowed,
+    PartialRerunPlan,
+    RunHistorySnapshot,
+    UnknownFailedNode,
+    compute_partial_rerun_plan,
+    plan_partial_rerun,
+)
+
+
+def _policy(*entries: PhaseMatrixEntry) -> GatePolicyProfile:
+    return GatePolicyProfile(
+        policy_version="test",
+        contract_version="stub-0.1",
+        execution_backend="dagster_only",
+        phase_matrix=list(entries),
+        thresholds={},
+        alert_channels=[],
+        updated_at=datetime(2026, 4, 16, tzinfo=timezone.utc),
+    )
+
+
+def _entry(
+    phase: PhaseEnum,
+    failure_class: FailureClass,
+    action: GateAction,
+    *,
+    allow_partial_rerun: bool,
+    rerun_mode: str | None = None,
+) -> PhaseMatrixEntry:
+    return PhaseMatrixEntry(
+        phase=phase,
+        failure_class=failure_class,
+        action=action,
+        allow_partial_rerun=allow_partial_rerun,
+        description="test policy row",
+        rerun_mode=rerun_mode,
+    )
 
 
 def test_partial_rerun_plan_fields_match_runtime_model() -> None:
@@ -13,6 +53,7 @@ def test_partial_rerun_plan_fields_match_runtime_model() -> None:
         "rerun_selection",
         "requires_manual_ack",
         "generated_at",
+        "rerun_mode",
     ]
 
 
@@ -23,16 +64,254 @@ def test_plan_partial_rerun_signature_matches_contract() -> None:
     ]
 
 
-def test_plan_partial_rerun_returns_minimal_failed_node_selection() -> None:
+def test_compute_partial_rerun_plan_signature_matches_pure_contract() -> None:
+    assert list(signature(compute_partial_rerun_plan).parameters) == [
+        "run_id",
+        "failed_node",
+        "run_history",
+        "policy",
+    ]
+
+
+def test_plan_partial_rerun_facade_remains_importable_and_frozen() -> None:
     plan = plan_partial_rerun("run-1", "phase0_readiness_ping")
 
     assert plan.run_id == "run-1"
     assert plan.failed_node == "phase0_readiness_ping"
     assert plan.rerun_selection == ("phase0_readiness_ping",)
-    assert plan.requires_manual_ack is True
+    assert plan.requires_manual_ack is False
+    assert plan.rerun_mode == "asset_only"
     assert plan.generated_at.tzinfo is not None
     with pytest.raises(FrozenInstanceError):
         plan.failed_node = "other"
+
+
+def test_asset_only_returns_failed_node_without_manual_ack() -> None:
+    run_history = RunHistorySnapshot(
+        run_id="run-asset",
+        node_to_phase={"phase2_score_AAPL": PhaseEnum.PHASE2},
+        node_dependencies={"phase2_score_AAPL": ()},
+        failed_nodes=("phase2_score_AAPL",),
+        repairable_nodes={},
+        node_failure_classes={"phase2_score_AAPL": FailureClass.TASK_LEVEL},
+    )
+    policy = _policy(
+        _entry(
+            PhaseEnum.PHASE2,
+            FailureClass.TASK_LEVEL,
+            GateAction.PARTIAL_RERUN,
+            allow_partial_rerun=True,
+            rerun_mode="asset_only",
+        )
+    )
+
+    plan = compute_partial_rerun_plan(
+        "run-asset",
+        "phase2_score_AAPL",
+        run_history,
+        policy,
+    )
+
+    assert plan.rerun_selection == ("phase2_score_AAPL",)
+    assert plan.requires_manual_ack is False
+    assert plan.rerun_mode == "asset_only"
+
+
+def test_phase_only_returns_same_phase_downstream_closure() -> None:
+    run_history = RunHistorySnapshot(
+        run_id="run-phase",
+        node_to_phase={
+            "phase2_source": PhaseEnum.PHASE2,
+            "phase2_transform": PhaseEnum.PHASE2,
+            "phase2_score": PhaseEnum.PHASE2,
+            "phase2_unrelated": PhaseEnum.PHASE2,
+            "phase3_publish": PhaseEnum.PHASE3,
+        },
+        node_dependencies={
+            "phase2_score": ("phase2_transform",),
+            "phase3_publish": ("phase2_score",),
+            "phase2_transform": ("phase2_source",),
+            "phase2_unrelated": (),
+        },
+        failed_nodes=("phase2_transform",),
+        repairable_nodes={},
+        node_failure_classes={"phase2_transform": FailureClass.TASK_LEVEL},
+    )
+    policy = _policy(
+        _entry(
+            PhaseEnum.PHASE2,
+            FailureClass.TASK_LEVEL,
+            GateAction.PARTIAL_RERUN,
+            allow_partial_rerun=True,
+            rerun_mode="phase_only",
+        )
+    )
+
+    plan = compute_partial_rerun_plan(
+        "run-phase",
+        "phase2_transform",
+        run_history,
+        policy,
+    )
+
+    assert plan.rerun_selection == ("phase2_transform", "phase2_score")
+    assert plan.requires_manual_ack is True
+    assert plan.rerun_mode == "phase_only"
+
+
+def test_repair_only_returns_repair_node_without_upstream_business_assets() -> None:
+    run_history = RunHistorySnapshot(
+        run_id="run-repair",
+        node_to_phase={
+            "formal_table_commit": PhaseEnum.PHASE3,
+            "publish_manifest": PhaseEnum.PHASE3,
+            "phase2_score": PhaseEnum.PHASE2,
+        },
+        node_dependencies={
+            "formal_table_commit": ("phase2_score",),
+            "publish_manifest": ("formal_table_commit",),
+        },
+        failed_nodes=("publish_manifest",),
+        repairable_nodes={"publish_manifest": "repair_publish_manifest"},
+        node_failure_classes={"publish_manifest": FailureClass.INFRA},
+    )
+    policy = _policy(
+        _entry(
+            PhaseEnum.PHASE3,
+            FailureClass.INFRA,
+            GateAction.REPAIR_MANIFEST,
+            allow_partial_rerun=True,
+        )
+    )
+
+    plan = compute_partial_rerun_plan(
+        "run-repair",
+        "publish_manifest",
+        run_history,
+        policy,
+    )
+
+    assert plan.rerun_selection == ("repair_publish_manifest",)
+    assert "formal_table_commit" not in plan.rerun_selection
+    assert "phase2_score" not in plan.rerun_selection
+    assert plan.rerun_mode == "repair_only"
+
+
+def test_unknown_failed_node_mentions_run_id_and_node() -> None:
+    run_history = RunHistorySnapshot(
+        run_id="run-unknown",
+        node_to_phase={},
+        node_dependencies={},
+        failed_nodes=("missing_node",),
+        repairable_nodes={},
+    )
+    policy = _policy(
+        _entry(
+            PhaseEnum.PHASE2,
+            FailureClass.TASK_LEVEL,
+            GateAction.PARTIAL_RERUN,
+            allow_partial_rerun=True,
+        )
+    )
+
+    with pytest.raises(UnknownFailedNode) as exc_info:
+        compute_partial_rerun_plan(
+            "run-unknown",
+            "missing_node",
+            run_history,
+            policy,
+        )
+
+    message = str(exc_info.value)
+    assert "run-unknown" in message
+    assert "missing_node" in message
+
+
+def test_policy_not_allowing_partial_rerun_raises() -> None:
+    run_history = RunHistorySnapshot(
+        run_id="run-denied",
+        node_to_phase={"phase0_market_data": PhaseEnum.PHASE0},
+        node_dependencies={"phase0_market_data": ()},
+        failed_nodes=("phase0_market_data",),
+        repairable_nodes={},
+        node_failure_classes={"phase0_market_data": FailureClass.DATA_QUALITY},
+    )
+    policy = _policy(
+        _entry(
+            PhaseEnum.PHASE0,
+            FailureClass.DATA_QUALITY,
+            GateAction.FAIL_RUN,
+            allow_partial_rerun=False,
+        )
+    )
+
+    with pytest.raises(PartialRerunNotAllowed, match="partial rerun is not allowed"):
+        compute_partial_rerun_plan(
+            "run-denied",
+            "phase0_market_data",
+            run_history,
+            policy,
+        )
+
+
+def test_phase_only_selection_order_is_stable_and_unique() -> None:
+    run_history = RunHistorySnapshot(
+        run_id="run-stable",
+        node_to_phase={
+            "phase1_root": PhaseEnum.PHASE1,
+            "phase1_mid_a": PhaseEnum.PHASE1,
+            "phase1_mid_b": PhaseEnum.PHASE1,
+            "phase1_leaf": PhaseEnum.PHASE1,
+        },
+        node_dependencies={
+            "phase1_leaf": ("phase1_mid_b", "phase1_mid_a"),
+            "phase1_mid_b": ("phase1_root",),
+            "phase1_mid_a": ("phase1_root",),
+        },
+        failed_nodes=("phase1_root",),
+        repairable_nodes={},
+        node_failure_classes={"phase1_root": FailureClass.TASK_LEVEL},
+    )
+    policy = _policy(
+        _entry(
+            PhaseEnum.PHASE1,
+            FailureClass.TASK_LEVEL,
+            GateAction.PARTIAL_RERUN,
+            allow_partial_rerun=True,
+            rerun_mode="phase_only",
+        )
+    )
+
+    first_plan = compute_partial_rerun_plan(
+        "run-stable",
+        "phase1_root",
+        run_history,
+        policy,
+    )
+    second_plan = compute_partial_rerun_plan(
+        "run-stable",
+        "phase1_root",
+        run_history,
+        policy,
+    )
+
+    assert first_plan.rerun_selection == (
+        "phase1_root",
+        "phase1_mid_b",
+        "phase1_mid_a",
+        "phase1_leaf",
+    )
+    assert first_plan.rerun_selection == second_plan.rerun_selection
+    assert len(first_plan.rerun_selection) == len(set(first_plan.rerun_selection))
+
+
+def test_compute_partial_rerun_plan_source_has_no_storage_or_process_calls() -> None:
+    source = getsource(compute_partial_rerun_plan)
+
+    assert "DagsterInstance" not in source
+    assert "open(" not in source
+    assert "requests" not in source
+    assert "subprocess" not in source
 
 
 def test_plan_partial_rerun_rejects_empty_contract_inputs() -> None:


### PR DESCRIPTION
Closes #17

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `src/orchestrator/checks/asset_checks.py`, `src/orchestrator/checks/classifier.py`, `src/orchestrator/jobs/phase0.py`, `tests/integration/conftest.py`, `tests/integration/test_phase0_minimal_cycle.py`


---
### 1. 背景与目标
根据 §11.3 与 §16.1，部分重跑选择算法需要把失败节点、运行历史和 policy 约束转成最小 `PartialRerunPlan`。当前 `origin/main` 没有 rerun planner 文件；#50 会先补齐 `plan_partial_rerun(run_id, failed_node)` 的 public facade，但 milestone-1 仍需要实际纯函数算法和测试。目标是在不读取 Dagster storage、不提交 rerun 的前提下，实现可单元测试的 selection planner，覆盖 `repair_only`、`asset_only`、`phase_only` 三种模式。

### 2. 所属模块
`src/orchestrator/rerun.py`（新增或补齐 #50 placeholder）、`src/orchestrator/policy/schema.py`、`src/orchestrator/__init__.py`、`tests/test_rerun.py`

### 3. 实现范围
- 定义 `PartialRerunPlan` dataclass：`run_id: str`、`failed_node: str`、`rerun_selection: tuple[str, ...]`、`requires_manual_ack: bool`、`generated_at: datetime`、`rerun_mode: Literal['repair_only', 'asset_only', 'phase_only']`。
- 定义纯输入模型 `RunHistorySnapshot`：至少包含 `run_id: str`、`node_to_phase: Mapping[str, PhaseEnum]`、`node_dependencies: Mapping[str, tuple[str, ...]]`、`failed_nodes: tuple[str, ...]`、`repairable_nodes: Mapping[str, str]`。
- 实现 pure core：`compute_partial_rerun_plan(run_id: str, failed_node: str, run_history: RunHistorySnapshot, policy: GatePolicyProfile) -> PartialRerunPlan`。
- 保持 #50 public facade `plan_partial_rerun(run_id: str, failed_node: str) -> PartialRerunPlan` 的 import/export 稳定；facade 可委托到已配置的 snapshot provider，但本 issue 的算法测试只测 pure core。
- 算法规则：`asset_only` 只选 failed node；`phase_only` 选同 phase 中失败节点及其最小下游闭包；`repair_only` 只选 repair manifest/repair node，不选上游业务资产。
- 对未知 failed node、不可重放节点、policy 不允许 partial rerun 的组合抛明确异常，例如 `PartialRerunNotAllowed`。

### 4. 不在本次范围
- 不调用 Dagster GraphQL/API 提交 rerun；#18 负责触发入口。
- 不查询真实 Dagster instance storage；测试传入 `RunHistorySnapshot`。
- 不处理 Phase 1/2/3 的真实 asset graph，只提供算法模型。
- 不引入 Temporal pause/resume。

### 5. 关键交付物
- `PartialRerunPlan` dataclass 从 `orchestrator.rerun` 导出。
- `RunHistorySnapshot` dataclass 从 `orchestrator.rerun` 导出。
- `PartialRerunNotAllowed(Exception)` 与 `UnknownFailedNode(Exception)`。
- `compute_partial_rerun_plan(...) -> PartialRerunPlan` 纯函数，无文件 IO、网络、Dagster instance 调用。
- `plan_partial_rerun(run_id: str