### PR TITLE
feat(#18): manual rerun 触发入口与 Dagster job 关联

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ dev = [
     "mypy",
 ]
 
+[project.scripts]
+orchestrator-rerun = "orchestrator.cli.rerun:main"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/src/orchestrator/cli/__init__.py
+++ b/src/orchestrator/cli/__init__.py
@@ -1,0 +1,2 @@
+"""Command line entrypoints for orchestrator operations."""
+

--- a/src/orchestrator/cli/rerun.py
+++ b/src/orchestrator/cli/rerun.py
@@ -1,0 +1,94 @@
+"""Manual partial-rerun request CLI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from orchestrator.rerun import PartialRerunPlan, plan_partial_rerun
+
+DEFAULT_REQUEST_DIR = ".orchestrator/rerun_requests"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Generate a manual rerun request for the Dagster sensor to consume."""
+
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        plan = plan_partial_rerun(args.run_id, args.failed_node)
+    except Exception as exc:
+        print(f"failed to plan partial rerun: {exc}", file=sys.stderr)
+        return 2
+
+    request = _request_from_plan(plan)
+    if args.dry_run:
+        print(json.dumps(request, sort_keys=True))
+        return 0
+
+    request_dir = Path(args.request_dir)
+    request_path = request_dir / _request_filename(plan.run_id, plan.failed_node)
+    try:
+        request_dir.mkdir(parents=True, exist_ok=True)
+        request_path.write_text(
+            json.dumps(request, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        print(f"failed to write rerun request: {exc}", file=sys.stderr)
+        return 1
+
+    print(str(request_path))
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="orchestrator-rerun",
+        description="Create a manual partial-rerun request for orchestrator.",
+    )
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--failed-node", required=True)
+    parser.add_argument(
+        "--request-dir",
+        default=DEFAULT_REQUEST_DIR,
+        help=f"directory for rerun request JSON files (default: {DEFAULT_REQUEST_DIR})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the request JSON without writing a request file",
+    )
+    return parser
+
+
+def _request_from_plan(plan: PartialRerunPlan) -> dict[str, Any]:
+    return {
+        "run_id": plan.run_id,
+        "failed_node": plan.failed_node,
+        "rerun_selection": list(plan.rerun_selection),
+        "requires_manual_ack": plan.requires_manual_ack,
+        "rerun_mode": plan.rerun_mode,
+        "generated_at": plan.generated_at.isoformat(),
+    }
+
+
+def _request_filename(run_id: str, failed_node: str) -> str:
+    safe_run_id = _safe_filename_part(run_id)
+    safe_failed_node = _safe_filename_part(failed_node)
+    return f"{safe_run_id}-{safe_failed_node}.json"
+
+
+def _safe_filename_part(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.=-]+", "_", value).strip("._") or "request"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/src/orchestrator/definitions.py
+++ b/src/orchestrator/definitions.py
@@ -19,7 +19,7 @@ from orchestrator.jobs.phase0 import (
 )
 from orchestrator.resources import AssetFactoryProvider, build_resource_bundle
 from orchestrator.schedules import daily_cycle_schedule
-from orchestrator.sensors import data_readiness_sensor
+from orchestrator.sensors import data_readiness_sensor, manual_rerun_sensor
 
 DEFAULT_POLICY_PATH = "config/policy/gate_policy.lite.yaml"
 _RESERVED_RESOURCE_KEYS = ("gate_policy", "dbt", "resource_bundle")
@@ -64,7 +64,7 @@ def build_definitions(
         ],
         jobs=[daily_cycle_job],
         schedules=[daily_cycle_schedule],
-        sensors=[data_readiness_sensor],
+        sensors=[data_readiness_sensor, manual_rerun_sensor],
         resources={
             "gate_policy": GatePolicyResource(policy_path=str(policy_path)),
             "dbt": DbtCliResource(

--- a/src/orchestrator/sensors/__init__.py
+++ b/src/orchestrator/sensors/__init__.py
@@ -1,5 +1,6 @@
 """Dagster sensor exports."""
 
 from orchestrator.sensors.data_readiness import data_readiness_sensor
+from orchestrator.sensors.manual_rerun import manual_rerun_sensor
 
-__all__ = ["data_readiness_sensor"]
+__all__ = ["data_readiness_sensor", "manual_rerun_sensor"]

--- a/src/orchestrator/sensors/manual_rerun.py
+++ b/src/orchestrator/sensors/manual_rerun.py
@@ -18,13 +18,13 @@ _ALLOWED_RERUN_MODES = frozenset({"repair_only", "asset_only", "phase_only"})
 
 
 @sensor(job=daily_cycle_job, name="manual_rerun_sensor")
-def manual_rerun_sensor() -> RunRequest | SkipReason:
+def manual_rerun_sensor() -> RunRequest | list[RunRequest] | SkipReason:
     request_dir = Path(os.environ.get(_REQUEST_DIR_ENV, DEFAULT_REQUEST_DIR))
     return evaluate_manual_rerun_requests(request_dir)
 
 
-def evaluate_manual_rerun_requests(request_dir: Path) -> RunRequest | SkipReason:
-    """Read one request JSON file and return a Dagster run request."""
+def evaluate_manual_rerun_requests(request_dir: Path) -> RunRequest | list[RunRequest] | SkipReason:
+    """Read pending request JSON files and return Dagster run requests."""
 
     if not request_dir.exists():
         return SkipReason(f"manual rerun request dir does not exist: {request_dir}")
@@ -36,6 +36,7 @@ def evaluate_manual_rerun_requests(request_dir: Path) -> RunRequest | SkipReason
         return SkipReason(f"no manual rerun requests found in {request_dir}")
 
     diagnostics: list[str] = []
+    run_requests: list[RunRequest] = []
     for request_path in request_files:
         payload, error = _load_request(request_path)
         if error is not None:
@@ -45,11 +46,16 @@ def evaluate_manual_rerun_requests(request_dir: Path) -> RunRequest | SkipReason
 
         assert payload is not None
         try:
-            return _build_run_request(payload)
+            run_requests.append(_build_run_request(payload))
         except Exception as exc:
             error = f"invalid manual rerun request {request_path.name}: {exc}"
             diagnostics.append(error)
             diagnostics.extend(_quarantine_invalid_request(request_dir, request_path, error))
+
+    if len(run_requests) == 1:
+        return run_requests[0]
+    if run_requests:
+        return run_requests
 
     return SkipReason("; ".join(diagnostics))
 

--- a/src/orchestrator/sensors/manual_rerun.py
+++ b/src/orchestrator/sensors/manual_rerun.py
@@ -1,0 +1,185 @@
+"""Manual partial-rerun request sensor."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from dagster import AssetKey, RunRequest, SkipReason, sensor
+
+from orchestrator.cli.rerun import DEFAULT_REQUEST_DIR
+from orchestrator.jobs.cycle import daily_cycle_job
+
+_REQUEST_DIR_ENV = "ORCHESTRATOR_RERUN_REQUEST_DIR"
+_PROCESSED_DIR_NAME = ".processed"
+_ALLOWED_RERUN_MODES = frozenset({"repair_only", "asset_only", "phase_only"})
+
+
+@sensor(job=daily_cycle_job, name="manual_rerun_sensor")
+def manual_rerun_sensor() -> RunRequest | SkipReason:
+    request_dir = Path(os.environ.get(_REQUEST_DIR_ENV, DEFAULT_REQUEST_DIR))
+    return evaluate_manual_rerun_requests(request_dir)
+
+
+def evaluate_manual_rerun_requests(request_dir: Path) -> RunRequest | SkipReason:
+    """Read one request JSON file and return a Dagster run request."""
+
+    if not request_dir.exists():
+        return SkipReason(f"manual rerun request dir does not exist: {request_dir}")
+    if not request_dir.is_dir():
+        return SkipReason(f"manual rerun request path is not a directory: {request_dir}")
+
+    request_files = tuple(sorted(request_dir.glob("*.json")))
+    if not request_files:
+        return SkipReason(f"no manual rerun requests found in {request_dir}")
+
+    request_path = request_files[0]
+    payload, error = _load_request(request_path)
+    if error is not None:
+        return SkipReason(error)
+
+    assert payload is not None
+    try:
+        run_request = _build_run_request(payload)
+    except Exception as exc:
+        return SkipReason(
+            f"invalid manual rerun request {request_path.name}: {exc}",
+        )
+
+    try:
+        _ack_request(request_dir, request_path)
+    except OSError as exc:
+        return SkipReason(
+            f"failed to mark manual rerun request processed "
+            f"{request_path.name}: {exc}",
+        )
+
+    return run_request
+
+
+def _load_request(request_path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        raw_payload = json.loads(request_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return None, f"invalid manual rerun request JSON {request_path.name}: {exc}"
+    except OSError as exc:
+        return None, f"failed to read manual rerun request {request_path.name}: {exc}"
+
+    if not isinstance(raw_payload, dict):
+        return None, f"invalid manual rerun request {request_path.name}: expected object"
+
+    return _validate_request(raw_payload, request_path.name)
+
+
+def _validate_request(
+    payload: dict[str, Any],
+    request_name: str,
+) -> tuple[dict[str, Any] | None, str | None]:
+    run_id = payload.get("run_id")
+    if not _is_non_empty_str(run_id):
+        return None, f"invalid manual rerun request {request_name}: run_id is required"
+
+    failed_node = payload.get("failed_node")
+    if not _is_non_empty_str(failed_node):
+        return (
+            None,
+            f"invalid manual rerun request {request_name}: failed_node is required",
+        )
+
+    rerun_selection = payload.get("rerun_selection")
+    if (
+        not isinstance(rerun_selection, list)
+        or not rerun_selection
+        or not all(_is_non_empty_str(item) for item in rerun_selection)
+    ):
+        return (
+            None,
+            f"invalid manual rerun request {request_name}: "
+            "rerun_selection must be a non-empty string list",
+        )
+
+    requires_manual_ack = payload.get("requires_manual_ack")
+    if not isinstance(requires_manual_ack, bool):
+        return (
+            None,
+            f"invalid manual rerun request {request_name}: "
+            "requires_manual_ack must be a boolean",
+        )
+
+    rerun_mode = payload.get("rerun_mode")
+    if not _is_non_empty_str(rerun_mode):
+        return (
+            None,
+            f"invalid manual rerun request {request_name}: rerun_mode is required",
+        )
+    if rerun_mode not in _ALLOWED_RERUN_MODES:
+        return (
+            None,
+            f"unknown rerun_mode in manual rerun request {request_name}: "
+            f"{rerun_mode}",
+        )
+
+    generated_at = payload.get("generated_at")
+    if not _is_non_empty_str(generated_at):
+        return (
+            None,
+            f"invalid manual rerun request {request_name}: generated_at is required",
+        )
+
+    return {
+        "run_id": run_id,
+        "failed_node": failed_node,
+        "rerun_selection": list(rerun_selection),
+        "requires_manual_ack": requires_manual_ack,
+        "rerun_mode": rerun_mode,
+        "generated_at": generated_at,
+    }, None
+
+
+def _build_run_request(payload: dict[str, Any]) -> RunRequest:
+    tags = {
+        "rerun_of": payload["run_id"],
+        "failed_node": payload["failed_node"],
+        "rerun_mode": payload["rerun_mode"],
+    }
+    run_key = (
+        "manual-rerun:"
+        f"{payload['run_id']}:"
+        f"{payload['failed_node']}:"
+        f"{payload['generated_at']}"
+    )
+
+    asset_selection = list(payload["rerun_selection"])
+    try:
+        return RunRequest(
+            job_name="daily_cycle_job",
+            run_key=run_key,
+            asset_selection=asset_selection,
+            tags=tags,
+        )
+    except Exception:
+        return RunRequest(
+            job_name="daily_cycle_job",
+            run_key=run_key,
+            asset_selection=[
+                AssetKey.from_user_string(asset_key)
+                for asset_key in asset_selection
+            ],
+            tags=tags,
+        )
+
+
+def _ack_request(request_dir: Path, request_path: Path) -> None:
+    processed_dir = request_dir / _PROCESSED_DIR_NAME
+    processed_dir.mkdir(exist_ok=True)
+    request_path.replace(processed_dir / request_path.name)
+
+
+def _is_non_empty_str(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+__all__ = ["evaluate_manual_rerun_requests", "manual_rerun_sensor"]
+

--- a/src/orchestrator/sensors/manual_rerun.py
+++ b/src/orchestrator/sensors/manual_rerun.py
@@ -13,7 +13,7 @@ from orchestrator.cli.rerun import DEFAULT_REQUEST_DIR
 from orchestrator.jobs.cycle import daily_cycle_job
 
 _REQUEST_DIR_ENV = "ORCHESTRATOR_RERUN_REQUEST_DIR"
-_PROCESSED_DIR_NAME = ".processed"
+_FAILED_DIR_NAME = ".failed"
 _ALLOWED_RERUN_MODES = frozenset({"repair_only", "asset_only", "phase_only"})
 
 
@@ -35,28 +35,23 @@ def evaluate_manual_rerun_requests(request_dir: Path) -> RunRequest | SkipReason
     if not request_files:
         return SkipReason(f"no manual rerun requests found in {request_dir}")
 
-    request_path = request_files[0]
-    payload, error = _load_request(request_path)
-    if error is not None:
-        return SkipReason(error)
+    diagnostics: list[str] = []
+    for request_path in request_files:
+        payload, error = _load_request(request_path)
+        if error is not None:
+            diagnostics.append(error)
+            diagnostics.extend(_quarantine_invalid_request(request_dir, request_path, error))
+            continue
 
-    assert payload is not None
-    try:
-        run_request = _build_run_request(payload)
-    except Exception as exc:
-        return SkipReason(
-            f"invalid manual rerun request {request_path.name}: {exc}",
-        )
+        assert payload is not None
+        try:
+            return _build_run_request(payload)
+        except Exception as exc:
+            error = f"invalid manual rerun request {request_path.name}: {exc}"
+            diagnostics.append(error)
+            diagnostics.extend(_quarantine_invalid_request(request_dir, request_path, error))
 
-    try:
-        _ack_request(request_dir, request_path)
-    except OSError as exc:
-        return SkipReason(
-            f"failed to mark manual rerun request processed "
-            f"{request_path.name}: {exc}",
-        )
-
-    return run_request
+    return SkipReason("; ".join(diagnostics))
 
 
 def _load_request(request_path: Path) -> tuple[dict[str, Any] | None, str | None]:
@@ -171,10 +166,25 @@ def _build_run_request(payload: dict[str, Any]) -> RunRequest:
         )
 
 
-def _ack_request(request_dir: Path, request_path: Path) -> None:
-    processed_dir = request_dir / _PROCESSED_DIR_NAME
-    processed_dir.mkdir(exist_ok=True)
-    request_path.replace(processed_dir / request_path.name)
+def _quarantine_invalid_request(
+    request_dir: Path,
+    request_path: Path,
+    error: str,
+) -> list[str]:
+    failed_dir = request_dir / _FAILED_DIR_NAME
+    try:
+        failed_dir.mkdir(exist_ok=True)
+        request_path.replace(failed_dir / request_path.name)
+        (failed_dir / f"{request_path.name}.error.txt").write_text(
+            error + "\n",
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        return [
+            f"failed to quarantine invalid manual rerun request "
+            f"{request_path.name}: {exc}",
+        ]
+    return []
 
 
 def _is_non_empty_str(value: object) -> bool:
@@ -182,4 +192,3 @@ def _is_non_empty_str(value: object) -> bool:
 
 
 __all__ = ["evaluate_manual_rerun_requests", "manual_rerun_sensor"]
-

--- a/tests/sensors/test_manual_rerun.py
+++ b/tests/sensors/test_manual_rerun.py
@@ -1,0 +1,167 @@
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from orchestrator.cli.rerun import main
+
+
+def test_rerun_cli_dry_run_outputs_plan_json(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(
+        [
+            "--run-id",
+            "r1",
+            "--failed-node",
+            "dbt.phase0.heartbeat",
+            "--dry-run",
+        ],
+    )
+
+    assert exit_code == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["run_id"] == "r1"
+    assert output["failed_node"] == "dbt.phase0.heartbeat"
+    assert output["rerun_selection"] == ["dbt.phase0.heartbeat"]
+    assert output["requires_manual_ack"] is False
+    assert output["rerun_mode"] == "asset_only"
+    assert output["generated_at"]
+
+
+def test_rerun_cli_writes_request_json(tmp_path: Path) -> None:
+    exit_code = main(
+        [
+            "--run-id",
+            "r1",
+            "--failed-node",
+            "dbt.phase0.heartbeat",
+            "--request-dir",
+            str(tmp_path),
+        ],
+    )
+
+    request_path = tmp_path / "r1-dbt.phase0.heartbeat.json"
+    assert exit_code == 0
+    assert request_path.exists()
+    request = json.loads(request_path.read_text(encoding="utf-8"))
+    assert request["run_id"] == "r1"
+    assert request["failed_node"] == "dbt.phase0.heartbeat"
+    assert request["rerun_selection"] == ["dbt.phase0.heartbeat"]
+    assert request["requires_manual_ack"] is False
+    assert request["rerun_mode"] == "asset_only"
+    assert request["generated_at"]
+
+
+@pytest.fixture
+def sensor_exports() -> dict[str, Any]:
+    dagster = pytest.importorskip("dagster", reason="dagster is not installed")
+
+    from orchestrator.sensors.manual_rerun import evaluate_manual_rerun_requests
+
+    return {
+        "RunRequest": dagster.RunRequest,
+        "SkipReason": dagster.SkipReason,
+        "evaluate_manual_rerun_requests": evaluate_manual_rerun_requests,
+    }
+
+
+def test_manual_rerun_sensor_emits_run_request(
+    tmp_path: Path,
+    sensor_exports: dict[str, Any],
+) -> None:
+    evaluate_manual_rerun_requests = sensor_exports["evaluate_manual_rerun_requests"]
+    RunRequest = sensor_exports["RunRequest"]
+    _write_request(tmp_path / "request.json")
+
+    result = evaluate_manual_rerun_requests(tmp_path)
+
+    assert isinstance(result, RunRequest)
+    assert result.job_name == "daily_cycle_job"
+    assert _asset_selection_strings(result.asset_selection) == ["phase0_readiness_ping"]
+    assert result.tags == {
+        "rerun_of": "r1",
+        "failed_node": "phase0_readiness_ping",
+        "rerun_mode": "asset_only",
+    }
+    assert not (tmp_path / "request.json").exists()
+    assert (tmp_path / ".processed" / "request.json").exists()
+
+
+def test_processed_manual_rerun_request_is_not_repeated(
+    tmp_path: Path,
+    sensor_exports: dict[str, Any],
+) -> None:
+    evaluate_manual_rerun_requests = sensor_exports["evaluate_manual_rerun_requests"]
+    SkipReason = sensor_exports["SkipReason"]
+    _write_request(tmp_path / "request.json")
+
+    first_result = evaluate_manual_rerun_requests(tmp_path)
+    second_result = evaluate_manual_rerun_requests(tmp_path)
+
+    assert first_result.__class__.__name__ == "RunRequest"
+    assert isinstance(second_result, SkipReason)
+    assert "no manual rerun requests" in second_result.skip_message
+
+
+def test_manual_rerun_sensor_invalid_json_returns_skip_reason(
+    tmp_path: Path,
+    sensor_exports: dict[str, Any],
+) -> None:
+    evaluate_manual_rerun_requests = sensor_exports["evaluate_manual_rerun_requests"]
+    SkipReason = sensor_exports["SkipReason"]
+    (tmp_path / "request.json").write_text("{not-json", encoding="utf-8")
+
+    result = evaluate_manual_rerun_requests(tmp_path)
+
+    assert isinstance(result, SkipReason)
+    assert "invalid manual rerun request JSON" in result.skip_message
+
+
+def test_manual_rerun_sensor_unknown_rerun_mode_returns_skip_reason(
+    tmp_path: Path,
+    sensor_exports: dict[str, Any],
+) -> None:
+    evaluate_manual_rerun_requests = sensor_exports["evaluate_manual_rerun_requests"]
+    SkipReason = sensor_exports["SkipReason"]
+    _write_request(tmp_path / "request.json", rerun_mode="whole_cycle")
+
+    result = evaluate_manual_rerun_requests(tmp_path)
+
+    assert isinstance(result, SkipReason)
+    assert "unknown rerun_mode" in result.skip_message
+
+
+def _write_request(path: Path, *, rerun_mode: str = "asset_only") -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "run_id": "r1",
+                "failed_node": "phase0_readiness_ping",
+                "rerun_selection": ["phase0_readiness_ping"],
+                "requires_manual_ack": False,
+                "rerun_mode": rerun_mode,
+                "generated_at": "2026-04-16T00:00:00+00:00",
+            },
+        ),
+        encoding="utf-8",
+    )
+
+
+def _asset_selection_strings(asset_selection: object) -> list[str]:
+    output: list[str] = []
+    for asset_key in asset_selection or ():
+        if isinstance(asset_key, str):
+            output.append(asset_key)
+            continue
+        if hasattr(asset_key, "to_user_string"):
+            output.append(asset_key.to_user_string())
+            continue
+        path = getattr(asset_key, "path", None)
+        if isinstance(path, list):
+            output.append("/".join(path))
+            continue
+        output.append(str(asset_key))
+    return output
+

--- a/tests/sensors/test_manual_rerun.py
+++ b/tests/sensors/test_manual_rerun.py
@@ -108,6 +108,38 @@ def test_pending_manual_rerun_request_uses_stable_run_key(
     assert (tmp_path / "request.json").exists()
 
 
+def test_manual_rerun_sensor_emits_all_pending_valid_requests(
+    tmp_path: Path,
+    sensor_exports: dict[str, Any],
+) -> None:
+    evaluate_manual_rerun_requests = sensor_exports["evaluate_manual_rerun_requests"]
+    RunRequest = sensor_exports["RunRequest"]
+    _write_request(
+        tmp_path / "00-first.json",
+        run_id="r1",
+        failed_node="phase0_readiness_ping",
+        generated_at="2026-04-16T00:00:00+00:00",
+    )
+    _write_request(
+        tmp_path / "01-second.json",
+        run_id="r2",
+        failed_node="dbt.phase0.heartbeat",
+        generated_at="2026-04-16T00:01:00+00:00",
+    )
+
+    result = evaluate_manual_rerun_requests(tmp_path)
+
+    assert isinstance(result, list)
+    assert all(isinstance(item, RunRequest) for item in result)
+    assert [item.run_key for item in result] == [
+        "manual-rerun:r1:phase0_readiness_ping:2026-04-16T00:00:00+00:00",
+        "manual-rerun:r2:dbt.phase0.heartbeat:2026-04-16T00:01:00+00:00",
+    ]
+    assert [item.tags["rerun_of"] for item in result] == ["r1", "r2"]
+    assert (tmp_path / "00-first.json").exists()
+    assert (tmp_path / "01-second.json").exists()
+
+
 def test_manual_rerun_sensor_invalid_json_returns_skip_reason(
     tmp_path: Path,
     sensor_exports: dict[str, Any],
@@ -162,16 +194,23 @@ def test_manual_rerun_sensor_invalid_request_does_not_starve_valid_later_request
     assert (tmp_path / "01-valid.json").exists()
 
 
-def _write_request(path: Path, *, rerun_mode: str = "asset_only") -> None:
+def _write_request(
+    path: Path,
+    *,
+    run_id: str = "r1",
+    failed_node: str = "phase0_readiness_ping",
+    rerun_mode: str = "asset_only",
+    generated_at: str = "2026-04-16T00:00:00+00:00",
+) -> None:
     path.write_text(
         json.dumps(
             {
-                "run_id": "r1",
-                "failed_node": "phase0_readiness_ping",
-                "rerun_selection": ["phase0_readiness_ping"],
+                "run_id": run_id,
+                "failed_node": failed_node,
+                "rerun_selection": [failed_node],
                 "requires_manual_ack": False,
                 "rerun_mode": rerun_mode,
-                "generated_at": "2026-04-16T00:00:00+00:00",
+                "generated_at": generated_at,
             },
         ),
         encoding="utf-8",

--- a/tests/sensors/test_manual_rerun.py
+++ b/tests/sensors/test_manual_rerun.py
@@ -85,24 +85,27 @@ def test_manual_rerun_sensor_emits_run_request(
         "failed_node": "phase0_readiness_ping",
         "rerun_mode": "asset_only",
     }
-    assert not (tmp_path / "request.json").exists()
-    assert (tmp_path / ".processed" / "request.json").exists()
+    assert result.run_key == (
+        "manual-rerun:r1:phase0_readiness_ping:2026-04-16T00:00:00+00:00"
+    )
+    assert (tmp_path / "request.json").exists()
+    assert not (tmp_path / ".processed" / "request.json").exists()
 
 
-def test_processed_manual_rerun_request_is_not_repeated(
+def test_pending_manual_rerun_request_uses_stable_run_key(
     tmp_path: Path,
     sensor_exports: dict[str, Any],
 ) -> None:
     evaluate_manual_rerun_requests = sensor_exports["evaluate_manual_rerun_requests"]
-    SkipReason = sensor_exports["SkipReason"]
     _write_request(tmp_path / "request.json")
 
     first_result = evaluate_manual_rerun_requests(tmp_path)
     second_result = evaluate_manual_rerun_requests(tmp_path)
 
     assert first_result.__class__.__name__ == "RunRequest"
-    assert isinstance(second_result, SkipReason)
-    assert "no manual rerun requests" in second_result.skip_message
+    assert second_result.__class__.__name__ == "RunRequest"
+    assert first_result.run_key == second_result.run_key
+    assert (tmp_path / "request.json").exists()
 
 
 def test_manual_rerun_sensor_invalid_json_returns_skip_reason(
@@ -117,6 +120,10 @@ def test_manual_rerun_sensor_invalid_json_returns_skip_reason(
 
     assert isinstance(result, SkipReason)
     assert "invalid manual rerun request JSON" in result.skip_message
+    assert not (tmp_path / "request.json").exists()
+    assert (tmp_path / ".failed" / "request.json").exists()
+    error = (tmp_path / ".failed" / "request.json.error.txt").read_text(encoding="utf-8")
+    assert "invalid manual rerun request JSON" in error
 
 
 def test_manual_rerun_sensor_unknown_rerun_mode_returns_skip_reason(
@@ -131,6 +138,28 @@ def test_manual_rerun_sensor_unknown_rerun_mode_returns_skip_reason(
 
     assert isinstance(result, SkipReason)
     assert "unknown rerun_mode" in result.skip_message
+    assert not (tmp_path / "request.json").exists()
+    assert (tmp_path / ".failed" / "request.json").exists()
+
+
+def test_manual_rerun_sensor_invalid_request_does_not_starve_valid_later_request(
+    tmp_path: Path,
+    sensor_exports: dict[str, Any],
+) -> None:
+    evaluate_manual_rerun_requests = sensor_exports["evaluate_manual_rerun_requests"]
+    RunRequest = sensor_exports["RunRequest"]
+    (tmp_path / "00-invalid.json").write_text("{not-json", encoding="utf-8")
+    _write_request(tmp_path / "01-valid.json")
+
+    result = evaluate_manual_rerun_requests(tmp_path)
+
+    assert isinstance(result, RunRequest)
+    assert result.run_key == (
+        "manual-rerun:r1:phase0_readiness_ping:2026-04-16T00:00:00+00:00"
+    )
+    assert not (tmp_path / "00-invalid.json").exists()
+    assert (tmp_path / ".failed" / "00-invalid.json").exists()
+    assert (tmp_path / "01-valid.json").exists()
 
 
 def _write_request(path: Path, *, rerun_mode: str = "asset_only") -> None:
@@ -164,4 +193,3 @@ def _asset_selection_strings(asset_selection: object) -> list[str]:
             continue
         output.append(str(asset_key))
     return output
-

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -49,7 +49,11 @@ def test_build_definitions_collects_p1a_surface(
 
     assert len(defs.jobs) == 1
     assert len(defs.schedules) == 1
-    assert len(defs.sensors) == 1
+    assert len(defs.sensors) == 2
+    assert {sensor.name for sensor in defs.sensors} == {
+        "data_readiness_sensor",
+        "manual_rerun_sensor",
+    }
     assert AssetKey(["fake_phase0_asset"]) in _asset_keys(defs)
     assert "fake_phase0_check" in _check_names(defs)
     assert "gate_policy" in defs.resources


### PR DESCRIPTION
Closes #18

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `src/orchestrator/checks/asset_checks.py`, `src/orchestrator/checks/classifier.py`, `src/orchestrator/definitions.py`, `src/orchestrator/jobs/phase0.py`, `src/orchestrator/rerun.py`, `tests/integration/conftest.py`


---
### 1. 背景与目标
根据 §12.1、§12.2 与 §21 阶段 1，Phase 0 失败后需要支持人工触发的局部 rerun，而不是只能整条 daily cycle 重跑。当前代码只有 `daily_cycle_job`、`daily_cycle_schedule` 和一个 readiness sensor stub，没有 manual rerun 入口；#17 会提供 `PartialRerunPlan` 与 planner。目标是增加一个轻量 CLI + Dagster sensor 关联：CLI 生成 rerun request，sensor 消费 request 并对 `daily_cycle_job` 发出带 `asset_selection`/tags 的 `RunRequest`。

### 2. 所属模块
`src/orchestrator/cli/rerun.py`（新增）、`src/orchestrator/sensors/manual_rerun.py`（新增）、`src/orchestrator/sensors/__init__.py`、`src/orchestrator/definitions.py`、`pyproject.toml`、`tests/sensors/test_manual_rerun.py`

### 3. 实现范围
- 新增 CLI entrypoint：`orchestrator-rerun --run-id <run_id> --failed-node <node> --request-dir <dir> [--dry-run]`，内部调用 `plan_partial_rerun(run_id, failed_node)`。
- CLI `--dry-run` 输出 `PartialRerunPlan` JSON 到 stdout；非 dry-run 写入 request JSON 文件，例如 `.orchestrator/rerun_requests/<run_id>-<failed_node>.json`。
- 新增 `manual_rerun_sensor`：读取 request dir 中的 JSON，校验字段，返回 `RunRequest(job_name='daily_cycle_job', run_key=..., asset_selection=list(plan.rerun_selection), tags={'rerun_of': run_id, 'failed_node': failed_node, 'rerun_mode': plan.rerun_mode})`。
- sensor 成功消费 request 后采用可测试的 ack 策略：移动到 `.processed` 或写入 status 字段，避免同一 request 无限重复触发。
- 在 `src/orchestrator/definitions.py` 把 `manual_rerun_sensor` 加入 `Definitions.sensors`，保留 `data_readiness_sensor`。
- 所有文件 IO 限定在 request dir；不调用 GitHub、Dagster GraphQL 或外部服务。

### 4. 不在本次范围
- 不实现 Web UI 或 Dagster UI 自定义按钮。
- 不提交真实 Dagster run；sensor 只返回 `RunRequest`。
- 不实现权限校验、审批流或 Slack ack。
- 不改变 #17 的 planner 规则。

### 5. 关键交付物
- `src/orchestrator/cli/rerun.py::main(argv: Sequence[str] | None = None) -> int`。
- `[project.scripts] orchestrator-rerun = 'orchestrator.cli.rerun:main'`。
- `manual_rerun_sensor` 从 `orchestrator.sensors` 导出，sensor name 固定为 `manual_rerun_sensor`。
- request JSON schema 至少包含 `run_id`、`failed_node`、`rerun_selection`、`requires_manual_ack`、`rerun_mode`、`generated_at`。
- `RunRequest` tags 包含 `rerun_of`、`failed_node`、`rerun_mode`，便于 Dagst