### PR TITLE
feat(#14): candidate freeze asset 与 Phase 0 asset group 扩展

### DIFF
--- a/docs/RUNBOOK_P1A.md
+++ b/docs/RUNBOOK_P1A.md
@@ -30,6 +30,7 @@
 
 - `dbt_stub/` 只用于 P1a 骨架；接入 `data-platform` 后替换为其公开 dbt project 入口。
 - `phase0_readiness_ping` 是 API 占位 asset；接入真实 readiness API 时保持 orchestrator 只装配，不复制业务逻辑。
+- `candidate_freeze` 属于 Phase 0 asset group，但业务实现由 `data-platform` 的 `AssetFactoryProvider.get_assets()` 提供；orchestrator 只校验 asset key 与 `phase0` group 并纳入 `daily_cycle_job` 选择。
 - `phase0_ping_check` 只做 Gate policy wiring；真实检查函数应由上游 `PureCheckProvider` 暴露。
 - `GatePolicyResource` 当前读取 `config/policy/gate_policy.lite.yaml`；环境装配交给 `assembly` 后只替换 policy 路径。
 

--- a/src/orchestrator/definitions.py
+++ b/src/orchestrator/definitions.py
@@ -6,7 +6,7 @@ import os
 from collections.abc import Iterable
 from pathlib import Path
 
-from dagster import Definitions
+from dagster import AssetKey, Definitions
 from dagster_dbt import DbtCliResource
 
 from orchestrator.checks import GatePolicyResource, phase0_ping_check
@@ -14,6 +14,8 @@ from orchestrator.jobs.cycle import daily_cycle_job
 from orchestrator.jobs.phase0 import (
     DBT_PROFILES_DIR,
     DBT_PROJECT_DIR,
+    PHASE0_CANDIDATE_FREEZE_ASSET_KEY,
+    PHASE0_GROUP_NAME,
     dbt_phase0_assets,
     phase0_readiness_ping,
 )
@@ -46,6 +48,7 @@ def build_definitions(
         for module_factory in module_factory_list
         for asset in module_factory.get_assets()
     ]
+    _validate_phase0_provider_assets(provider_assets)
     provider_checks = [
         check
         for module_factory in module_factory_list
@@ -75,6 +78,23 @@ def build_definitions(
             **resource_bundle.resources,
         },
     )
+
+
+def _validate_phase0_provider_assets(provider_assets: Iterable[object]) -> None:
+    candidate_freeze_key = AssetKey([PHASE0_CANDIDATE_FREEZE_ASSET_KEY])
+
+    for asset_def in provider_assets:
+        if candidate_freeze_key not in getattr(asset_def, "keys", ()):
+            continue
+
+        group_name = getattr(asset_def, "group_names_by_key", {}).get(
+            candidate_freeze_key,
+        )
+        if group_name != PHASE0_GROUP_NAME:
+            raise ValueError(
+                "candidate_freeze asset must declare "
+                f"group_name={PHASE0_GROUP_NAME!r}; got {group_name!r}",
+            )
 
 
 defs = build_definitions()

--- a/src/orchestrator/jobs/__init__.py
+++ b/src/orchestrator/jobs/__init__.py
@@ -1,9 +1,20 @@
 """Dagster job and asset group exports."""
 
 from orchestrator.jobs.cycle import build_daily_cycle_jobs, daily_cycle_job
-from orchestrator.jobs.phase0 import dbt_phase0_assets, phase0_readiness_ping
+from orchestrator.jobs.phase0 import (
+    PHASE0_CANDIDATE_FREEZE_ASSET_KEY,
+    PHASE0_GROUP_NAME,
+    PHASE0_READINESS_ASSET_KEY,
+    PHASE0_REQUIRED_ASSET_KEYS,
+    dbt_phase0_assets,
+    phase0_readiness_ping,
+)
 
 __all__ = [
+    "PHASE0_CANDIDATE_FREEZE_ASSET_KEY",
+    "PHASE0_GROUP_NAME",
+    "PHASE0_READINESS_ASSET_KEY",
+    "PHASE0_REQUIRED_ASSET_KEYS",
     "build_daily_cycle_jobs",
     "daily_cycle_job",
     "dbt_phase0_assets",

--- a/src/orchestrator/jobs/cycle.py
+++ b/src/orchestrator/jobs/cycle.py
@@ -5,10 +5,12 @@ from typing import Any
 
 from dagster import AssetSelection, define_asset_job
 
+from orchestrator.jobs.phase0_constants import PHASE0_GROUP_NAME
+
 
 daily_cycle_job = define_asset_job(
     name="daily_cycle_job",
-    selection=AssetSelection.groups("phase0"),
+    selection=AssetSelection.groups(PHASE0_GROUP_NAME),
 )
 
 

--- a/src/orchestrator/jobs/phase0.py
+++ b/src/orchestrator/jobs/phase0.py
@@ -9,6 +9,13 @@ from typing import Iterator
 from dagster import AssetExecutionContext, asset
 from dagster_dbt import DbtCliResource, dbt_assets
 
+from orchestrator.jobs.phase0_constants import (
+    PHASE0_CANDIDATE_FREEZE_ASSET_KEY,
+    PHASE0_GROUP_NAME,
+    PHASE0_READINESS_ASSET_KEY,
+    PHASE0_REQUIRED_ASSET_KEYS,
+)
+
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _DBT_PROJECT_DIR_ENV = os.environ.get("ORCHESTRATOR_DBT_PROJECT_DIR")
 DBT_PROJECT_DIR = (
@@ -18,7 +25,7 @@ DBT_PROFILES_DIR = DBT_PROJECT_DIR
 DBT_MANIFEST_PATH = DBT_PROJECT_DIR / "target" / "manifest.json"
 
 
-@asset(group_name="phase0")
+@asset(group_name=PHASE0_GROUP_NAME)
 def phase0_readiness_ping() -> str:
     return "ok"
 
@@ -38,3 +45,16 @@ def dbt_phase0_assets(
         ],
         context=context,
     ).stream()
+
+
+__all__ = [
+    "DBT_MANIFEST_PATH",
+    "DBT_PROFILES_DIR",
+    "DBT_PROJECT_DIR",
+    "PHASE0_CANDIDATE_FREEZE_ASSET_KEY",
+    "PHASE0_GROUP_NAME",
+    "PHASE0_READINESS_ASSET_KEY",
+    "PHASE0_REQUIRED_ASSET_KEYS",
+    "dbt_phase0_assets",
+    "phase0_readiness_ping",
+]

--- a/src/orchestrator/jobs/phase0_constants.py
+++ b/src/orchestrator/jobs/phase0_constants.py
@@ -1,0 +1,16 @@
+"""Phase 0 asset group constants."""
+
+PHASE0_GROUP_NAME: str = "phase0"
+PHASE0_READINESS_ASSET_KEY: str = "phase0_readiness_ping"
+PHASE0_CANDIDATE_FREEZE_ASSET_KEY: str = "candidate_freeze"
+PHASE0_REQUIRED_ASSET_KEYS: tuple[str, ...] = (
+    PHASE0_READINESS_ASSET_KEY,
+    PHASE0_CANDIDATE_FREEZE_ASSET_KEY,
+)
+
+__all__ = [
+    "PHASE0_CANDIDATE_FREEZE_ASSET_KEY",
+    "PHASE0_GROUP_NAME",
+    "PHASE0_READINESS_ASSET_KEY",
+    "PHASE0_REQUIRED_ASSET_KEYS",
+]

--- a/tests/integration/test_data_platform_provider_wiring.py
+++ b/tests/integration/test_data_platform_provider_wiring.py
@@ -15,6 +15,12 @@ def test_data_platform_provider_contributes_phase0_surface(
     pytest.importorskip("dagster_dbt", reason="dagster-dbt is not installed")
 
     from orchestrator.definitions import build_definitions
+    from orchestrator.jobs.cycle import daily_cycle_job
+    from orchestrator.jobs.phase0 import (
+        PHASE0_GROUP_NAME,
+        dbt_phase0_assets,
+        phase0_readiness_ping,
+    )
     from orchestrator.resources import ResourceBundle
 
     provider, fake_asset, _fake_check = _fake_data_platform_provider(dagster)
@@ -25,7 +31,18 @@ def test_data_platform_provider_contributes_phase0_surface(
 
     dagster.Definitions.validate_loadable(defs)
 
-    assert dagster.AssetKey(["fake_data_platform_phase0_asset"]) in _asset_keys(defs)
+    candidate_freeze_key = dagster.AssetKey(["candidate_freeze"])
+    selected_keys = daily_cycle_job.selection.resolve(
+        [phase0_readiness_ping, dbt_phase0_assets, fake_asset],
+    )
+    dbt_phase0_keys = set(dbt_phase0_assets.keys)
+
+    assert candidate_freeze_key in _asset_keys(defs)
+    assert fake_asset.group_names_by_key[candidate_freeze_key] == PHASE0_GROUP_NAME
+    assert dagster.AssetKey(["phase0_readiness_ping"]) in selected_keys
+    assert candidate_freeze_key in selected_keys
+    assert dbt_phase0_keys
+    assert dbt_phase0_keys <= selected_keys
     assert "fake_data_platform_phase0_check" in _check_names(defs)
     assert "fake_data_platform_resource" in defs.resources
 
@@ -50,27 +67,57 @@ def test_data_platform_provider_contributes_phase0_surface(
     assert result.success is True
 
 
-def _fake_data_platform_provider(dagster: Any) -> tuple[object, object, object]:
+def test_candidate_freeze_group_mismatch_is_rejected(
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+) -> None:
+    dagster = pytest.importorskip("dagster", reason="dagster is not installed")
+    pytest.importorskip("dagster_dbt", reason="dagster-dbt is not installed")
+
+    from orchestrator.definitions import build_definitions
+
+    provider, _fake_asset, _fake_check = _fake_data_platform_provider(
+        dagster,
+        candidate_group="not_phase0",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "candidate_freeze asset must declare "
+            "group_name='phase0'; got 'not_phase0'"
+        ),
+    ):
+        build_definitions(
+            module_factories=[provider],
+            policy_path=stub_policy_path,
+        )
+
+
+def _fake_data_platform_provider(
+    dagster: Any,
+    candidate_group: str = "phase0",
+) -> tuple[object, object, object]:
     class FakeDataPlatformResource(dagster.ConfigurableResource):
         def create_resource(self, context: object) -> dict[str, str]:
             return {"source": "fake-provider"}
 
     @dagster.asset(
-        name="fake_data_platform_phase0_asset",
-        group_name="phase0",
+        name="candidate_freeze",
+        group_name=candidate_group,
         required_resource_keys={
             "fake_data_platform_resource",
             "resource_bundle",
         },
     )
-    def fake_data_platform_phase0_asset(context: object) -> str:
+    def candidate_freeze(context: object) -> str:
         fake_resource = context.resources.fake_data_platform_resource
         bundle = context.resources.resource_bundle
         assert bundle.read_only is True
         return fake_resource["source"]
 
     @dagster.asset_check(
-        asset=fake_data_platform_phase0_asset,
+        asset=candidate_freeze,
         name="fake_data_platform_phase0_check",
     )
     def fake_data_platform_phase0_check() -> object:
@@ -78,7 +125,7 @@ def _fake_data_platform_provider(dagster: Any) -> tuple[object, object, object]:
 
     class FakeDataPlatformProvider:
         def get_assets(self) -> tuple[object, ...]:
-            return (fake_data_platform_phase0_asset,)
+            return (candidate_freeze,)
 
         def get_checks(self) -> tuple[object, ...]:
             return (fake_data_platform_phase0_check,)
@@ -93,7 +140,7 @@ def _fake_data_platform_provider(dagster: Any) -> tuple[object, object, object]:
 
     return (
         FakeDataPlatformProvider(),
-        fake_data_platform_phase0_asset,
+        candidate_freeze,
         fake_data_platform_phase0_check,
     )
 

--- a/tests/jobs/test_phase0.py
+++ b/tests/jobs/test_phase0.py
@@ -19,15 +19,30 @@ def asset_key_type() -> Any:
 
 
 @pytest.fixture
-def phase0_readiness_ping_asset() -> Any:
+def phase0_module() -> Any:
     pytest.importorskip("dagster", reason="dagster is not installed")
     pytest.importorskip("dagster_dbt", reason="dagster-dbt is not installed")
     if not _DBT_MANIFEST_PATH.exists():
         pytest.skip("dbt manifest is not compiled; run make dbt-compile")
 
-    from orchestrator.jobs import phase0_readiness_ping
+    from orchestrator.jobs import phase0
+
+    return phase0
+
+
+@pytest.fixture
+def phase0_readiness_ping_asset(phase0_module: Any) -> Any:
+    phase0_readiness_ping = phase0_module.phase0_readiness_ping
 
     return phase0_readiness_ping
+
+
+def test_phase0_group_constants(phase0_module: Any) -> None:
+    assert phase0_module.PHASE0_GROUP_NAME == "phase0"
+    assert phase0_module.PHASE0_REQUIRED_ASSET_KEYS == (
+        "phase0_readiness_ping",
+        "candidate_freeze",
+    )
 
 
 def test_phase0_readiness_ping_asset_exists(


### PR DESCRIPTION
Closes #14

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `src/orchestrator/checks/asset_checks.py`, `src/orchestrator/checks/classifier.py`, `src/orchestrator/jobs/phase0.py`, `src/orchestrator/rerun.py`, `src/orchestrator/sensors/manual_rerun.py`, `tests/integration/conftest.py`


---
### 1. 背景与目标
根据 §8.1 与 §21 阶段 1，Phase 0 不只包含 P1a 的 `phase0_readiness_ping` 和 dbt heartbeat，还需要把 candidate freeze 作为数据准备资产纳入同一个 Phase 0 asset group。当前 `src/orchestrator/jobs/phase0.py` 只定义了 `phase0_readiness_ping` 与 `dbt_phase0_assets`，`daily_cycle_job` 通过 `AssetSelection.groups('phase0')` 选择 Phase 0。目标是消费 #12 接入的 data-platform 公开 factory，把 candidate freeze asset 纳入 Phase 0 selection，同时保持 orchestrator 不实现候选池 freeze 业务逻辑。

### 2. 所属模块
`src/orchestrator/jobs/phase0.py`、`src/orchestrator/jobs/cycle.py`、`src/orchestrator/definitions.py`、`tests/jobs/test_phase0.py`、`tests/integration/test_data_platform_provider_wiring.py`

### 3. 实现范围
- 在 `src/orchestrator/jobs/phase0.py` 增加 Phase 0 命名常量，例如 `PHASE0_GROUP_NAME = 'phase0'`、`PHASE0_REQUIRED_ASSET_KEYS = ('phase0_readiness_ping', 'candidate_freeze')`。
- 通过 #12 的 `AssetFactoryProvider.get_assets()` 消费 data-platform 提供的 candidate freeze asset；orchestrator 只验证 asset key/group，不写 freeze 计算。
- 更新 `build_definitions(module_factories, policy_path)` 的 provider asset 收集逻辑，确保 candidate freeze asset 与 `phase0_readiness_ping`、`dbt_phase0_assets` 一起进入 `Definitions.assets`。
- 保持 `daily_cycle_job = define_asset_job(name='daily_cycle_job', selection=AssetSelection.groups('phase0'))` 的组选择语义；如 #50 已引入 `build_daily_cycle_jobs(phase_config)`，在对应 phase config 中列入 candidate freeze。
- 新增/更新测试：fake data-platform provider 暴露 `@asset(name='candidate_freeze', group_name='phase0')`，断言 `daily_cycle_job.selection.resolve(...)` 包含该 AssetKey。
- 更新 `docs/RUNBOOK_P1A.md` 或新增 Phase 0 runbook 小节，说明 candidate freeze 由 data-platform 提供，orchestrator 只做 wiring。

### 4. 不在本次范围
- 不实现 candidate freeze 的 SQL、API 调用、股票池筛选或落库逻辑。
- 不处理 dbt test failure 到 partial rerun 的决策；由 #16 负责。
- 不引入 Phase 1/2/3 asset。
- 不要求本仓库安装真实 `data-platform` 包；测试用 fake provider 验证协议。

### 5. 关键交付物
- `PHASE0_GROUP_NAME: str = 'phase0'` 从 `orchestrator.jobs.phase0` 导出。
- `PHASE0_REQUIRED_ASSET_KEYS: tuple[str, ...]` 至少包含 `phase0_readiness_ping` 与 `candidate_freeze`。
- fake provider candidate freez