### PR TITLE
feat(#16): dbt test fail → partial rerun 路径

### DIFF
--- a/src/orchestrator/checks/__init__.py
+++ b/src/orchestrator/checks/__init__.py
@@ -1,6 +1,10 @@
 """Gate check classifier and Dagster check exports."""
 
 from orchestrator.checks.classifier import UnknownGateFailure, classify_gate_result
+from orchestrator.checks.dbt_events import (
+    classify_dbt_test_failure,
+    plan_dbt_test_partial_rerun,
+)
 from orchestrator.checks.models import GateDecision
 from orchestrator.policy import FailureClass, GateAction, PhaseEnum
 
@@ -25,5 +29,7 @@ __all__ = [
     "PhaseEnum",
     "UnknownGateFailure",
     "classify_gate_result",
+    "classify_dbt_test_failure",
     "phase0_ping_check",
+    "plan_dbt_test_partial_rerun",
 ]

--- a/src/orchestrator/checks/dbt_events.py
+++ b/src/orchestrator/checks/dbt_events.py
@@ -1,0 +1,192 @@
+"""Adapters for dbt test failure events emitted through Dagster."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+from orchestrator.checks.classifier import classify_gate_result
+from orchestrator.checks.models import GateDecision
+from orchestrator.policy import FailureClass, GatePolicyProfile, PhaseEnum
+from orchestrator.rerun import (
+    PartialRerunPlan,
+    RunHistorySnapshot,
+    compute_partial_rerun_plan,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _DbtGateEvent:
+    failure_class: FailureClass
+    dbt_node_name: str | None = None
+    asset_key: str | None = None
+
+
+def classify_dbt_test_failure(
+    event: object,
+    policy: GatePolicyProfile,
+) -> GateDecision:
+    """Classify a dbt test failure as the Phase 0 task-level gate outcome."""
+
+    gate_event = _dbt_test_failure_gate_event(event)
+
+    return classify_gate_result(PhaseEnum.PHASE0, gate_event, policy)
+
+
+def plan_dbt_test_partial_rerun(
+    run_id: str,
+    failed_asset_key: str,
+    event: object,
+    policy: GatePolicyProfile,
+) -> PartialRerunPlan:
+    """Plan the minimal rerun selection for a failed Phase 0 dbt asset."""
+
+    _dbt_test_failure_gate_event(event)
+    failed_node = _stable_asset_key_string(failed_asset_key)
+    run_history = RunHistorySnapshot(
+        run_id=run_id,
+        node_to_phase={failed_node: PhaseEnum.PHASE0},
+        node_dependencies={failed_node: ()},
+        failed_nodes=(failed_node,),
+        repairable_nodes={},
+        node_failure_classes={failed_node: FailureClass.TASK_LEVEL},
+    )
+
+    return compute_partial_rerun_plan(run_id, failed_node, run_history, policy)
+
+
+def _dbt_test_failure_gate_event(event: object) -> _DbtGateEvent:
+    if event is None:
+        raise TypeError("dbt test failure event is required")
+
+    return _DbtGateEvent(
+        failure_class=FailureClass.TASK_LEVEL,
+        dbt_node_name=_extract_dbt_node_name(event),
+        asset_key=_extract_asset_key(event),
+    )
+
+
+def _extract_dbt_node_name(event: object) -> str | None:
+    for value in _candidate_values(event, ("dbt_node_name", "node_name", "unique_id")):
+        if isinstance(value, str) and value:
+            return value
+
+    metadata = _event_metadata(event)
+    for key in ("dbt_node_info", "node_info"):
+        node_info = metadata.get(key)
+        if isinstance(node_info, Mapping):
+            for field in ("node_name", "unique_id", "name"):
+                value = node_info.get(field)
+                if isinstance(value, str) and value:
+                    return value
+
+    return None
+
+
+def _extract_asset_key(event: object) -> str | None:
+    for value in _candidate_values(event, ("asset_key", "asset_key_path")):
+        try:
+            return _stable_asset_key_string(value)
+        except (TypeError, ValueError):
+            continue
+
+    metadata = _event_metadata(event)
+    for key in ("asset_key", "asset_key_path"):
+        if key not in metadata:
+            continue
+        try:
+            return _stable_asset_key_string(metadata[key])
+        except (TypeError, ValueError):
+            continue
+
+    return None
+
+
+def _event_metadata(event: object) -> Mapping[str, object]:
+    metadata = _mapping_or_attr(event, "metadata")
+    if isinstance(metadata, Mapping):
+        return metadata
+
+    event_specific_data = _mapping_or_attr(event, "event_specific_data")
+    if event_specific_data is not None:
+        nested_metadata = _mapping_or_attr(event_specific_data, "metadata")
+        if isinstance(nested_metadata, Mapping):
+            return nested_metadata
+
+    return {}
+
+
+def _candidate_values(event: object, names: Sequence[str]) -> tuple[object, ...]:
+    values: list[object] = []
+    for name in names:
+        value = _mapping_or_attr(event, name)
+        if value is not None:
+            values.append(value)
+
+    dagster_event = _mapping_or_attr(event, "dagster_event")
+    if dagster_event is not None:
+        for name in names:
+            value = _mapping_or_attr(dagster_event, name)
+            if value is not None:
+                values.append(value)
+
+    return tuple(values)
+
+
+def _mapping_or_attr(value: object, name: str) -> object | None:
+    if isinstance(value, Mapping):
+        return value.get(name)
+    return getattr(value, name, None)
+
+
+def _stable_asset_key_string(asset_key: object) -> str:
+    if isinstance(asset_key, str):
+        if not asset_key:
+            raise ValueError("failed_asset_key is required")
+        return asset_key
+
+    to_user_string = getattr(asset_key, "to_user_string", None)
+    if callable(to_user_string):
+        value = to_user_string()
+        if isinstance(value, str) and value:
+            return value
+
+    path = _asset_key_path(asset_key)
+    if path:
+        return "/".join(path)
+
+    to_string = getattr(asset_key, "to_string", None)
+    if callable(to_string):
+        value = to_string()
+        if isinstance(value, str) and value:
+            return value
+
+    raise TypeError("asset key must be a string or expose a stable string form")
+
+
+def _asset_key_path(asset_key: object) -> tuple[str, ...]:
+    if isinstance(asset_key, Mapping):
+        value = asset_key.get("path")
+    else:
+        value = getattr(asset_key, "path", None)
+
+    if isinstance(value, str):
+        return (value,) if value else ()
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, str)):
+        path = tuple(str(part) for part in value if str(part))
+        if path:
+            return path
+    if isinstance(asset_key, Sequence) and not isinstance(
+        asset_key,
+        (bytes, bytearray, str),
+    ):
+        path = tuple(str(part) for part in asset_key if str(part))
+        if path:
+            return path
+    return ()
+
+
+__all__ = [
+    "classify_dbt_test_failure",
+    "plan_dbt_test_partial_rerun",
+]

--- a/src/orchestrator/jobs/phase0.py
+++ b/src/orchestrator/jobs/phase0.py
@@ -25,12 +25,24 @@ DBT_PROFILES_DIR = DBT_PROJECT_DIR
 DBT_MANIFEST_PATH = DBT_PROJECT_DIR / "target" / "manifest.json"
 
 
+def _require_dbt_manifest(manifest_path: Path) -> Path:
+    if not manifest_path.exists():
+        msg = (
+            "dbt manifest is missing at "
+            f"{manifest_path}. Run `dbt compile --project-dir "
+            f"{DBT_PROJECT_DIR} --profiles-dir {DBT_PROFILES_DIR}` or prepare "
+            "the dbt fixture before importing orchestrator.definitions."
+        )
+        raise FileNotFoundError(msg)
+    return manifest_path
+
+
 @asset(group_name=PHASE0_GROUP_NAME)
 def phase0_readiness_ping() -> str:
     return "ok"
 
 
-@dbt_assets(manifest=DBT_MANIFEST_PATH)
+@dbt_assets(manifest=_require_dbt_manifest(DBT_MANIFEST_PATH))
 def dbt_phase0_assets(
     context: AssetExecutionContext,
     dbt: DbtCliResource,

--- a/src/orchestrator/rerun.py
+++ b/src/orchestrator/rerun.py
@@ -141,10 +141,6 @@ def _policy_entry_for_failed_node(
     if len(phase_entries) == 1:
         return phase_entries[0]
 
-    partial_entries = [entry for entry in phase_entries if entry.allow_partial_rerun]
-    if len(partial_entries) == 1:
-        return partial_entries[0]
-
     msg = (
         "failed node requires an explicit failure_class for policy lookup: "
         f"run_id={run_history.run_id} failed_node={failed_node} phase={phase.value}"

--- a/tests/checks/test_dbt_events.py
+++ b/tests/checks/test_dbt_events.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from inspect import signature
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from orchestrator.checks.dbt_events import (
+    classify_dbt_test_failure,
+    plan_dbt_test_partial_rerun,
+)
+from orchestrator.policy import FailureClass, GateAction, PhaseEnum, load_gate_policy
+from orchestrator.rerun import PartialRerunNotAllowed
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LITE_POLICY_PATH = REPO_ROOT / "config" / "policy" / "gate_policy.lite.yaml"
+
+
+class FakeAssetKey:
+    def __init__(self, path: tuple[str, ...]) -> None:
+        self.path = path
+
+    def to_user_string(self) -> str:
+        return "/".join(self.path)
+
+
+class MissingMetadataEvent:
+    pass
+
+
+@pytest.fixture
+def gate_policy() -> Any:
+    return load_gate_policy(LITE_POLICY_PATH)
+
+
+def test_dbt_adapter_signatures_match_issue_contract() -> None:
+    assert list(signature(classify_dbt_test_failure).parameters) == [
+        "event",
+        "policy",
+    ]
+    assert list(signature(plan_dbt_test_partial_rerun).parameters) == [
+        "run_id",
+        "failed_asset_key",
+        "event",
+        "policy",
+    ]
+
+
+def test_classify_dbt_test_failure_from_node_name(gate_policy: Any) -> None:
+    event = {
+        "metadata": {
+            "node_info": {
+                "node_name": "not_null_heartbeat_heartbeat",
+            }
+        }
+    }
+
+    decision = classify_dbt_test_failure(event, gate_policy)
+
+    assert decision.phase is PhaseEnum.PHASE0
+    assert decision.failure_class is FailureClass.TASK_LEVEL
+    assert decision.action is GateAction.PARTIAL_RERUN
+    assert (
+        decision.reason
+        == "dbt test failed; rerun the repaired asset group after the fix."
+    )
+
+
+def test_plan_dbt_test_partial_rerun_uses_failed_asset_key_only(
+    gate_policy: Any,
+) -> None:
+    event = {
+        "asset_key": FakeAssetKey(("dbt_phase0_assets",)),
+        "metadata": {
+            "node_info": {
+                "node_name": "not_null_heartbeat_heartbeat",
+            }
+        },
+    }
+
+    plan = plan_dbt_test_partial_rerun(
+        "run-dbt",
+        FakeAssetKey(("dbt_phase0_assets",)),
+        event,
+        gate_policy,
+    )
+
+    assert plan.run_id == "run-dbt"
+    assert plan.failed_node == "dbt_phase0_assets"
+    assert plan.rerun_selection == ("dbt_phase0_assets",)
+    assert plan.requires_manual_ack is False
+    assert plan.rerun_mode == "asset_only"
+    assert "phase0_readiness_ping" not in plan.rerun_selection
+    assert "candidate_freeze" not in plan.rerun_selection
+
+
+def test_dbt_test_failure_with_missing_metadata_still_maps_to_task_level(
+    gate_policy: Any,
+) -> None:
+    decision = classify_dbt_test_failure(MissingMetadataEvent(), gate_policy)
+    plan = plan_dbt_test_partial_rerun(
+        "run-missing-metadata",
+        "heartbeat",
+        MissingMetadataEvent(),
+        gate_policy,
+    )
+
+    assert decision.phase is PhaseEnum.PHASE0
+    assert decision.failure_class is FailureClass.TASK_LEVEL
+    assert decision.action is GateAction.PARTIAL_RERUN
+    assert plan.rerun_selection == ("heartbeat",)
+
+
+def test_dbt_partial_rerun_denied_policy_raises(gate_policy: Any) -> None:
+    policy = _with_phase0_task_partial_allowed(gate_policy, allow_partial_rerun=False)
+
+    with pytest.raises(PartialRerunNotAllowed, match="partial rerun is not allowed"):
+        plan_dbt_test_partial_rerun(
+            "run-denied",
+            "dbt_phase0_assets",
+            {"asset_key": "dbt_phase0_assets"},
+            policy,
+        )
+
+
+def test_classify_dbt_test_failure_requires_event(gate_policy: Any) -> None:
+    with pytest.raises(TypeError, match="dbt test failure event is required"):
+        classify_dbt_test_failure(None, gate_policy)
+
+
+def _with_phase0_task_partial_allowed(
+    policy: Any,
+    *,
+    allow_partial_rerun: bool,
+) -> Any:
+    return policy.model_copy(
+        update={
+            "phase_matrix": [
+                entry.model_copy(
+                    update={"allow_partial_rerun": allow_partial_rerun},
+                )
+                if (
+                    entry.phase is PhaseEnum.PHASE0
+                    and entry.failure_class is FailureClass.TASK_LEVEL
+                )
+                else entry
+                for entry in policy.phase_matrix
+            ],
+        },
+    )

--- a/tests/integration/test_phase0_failure_matrix.py
+++ b/tests/integration/test_phase0_failure_matrix.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from orchestrator.checks.dbt_events import plan_dbt_test_partial_rerun
+from orchestrator.policy import load_gate_policy
+
+
+def test_dbt_failure_matrix_plans_failed_asset_without_phase0_neighbors(
+    stub_policy_path: str,
+) -> None:
+    policy = load_gate_policy(stub_policy_path)
+
+    plan = plan_dbt_test_partial_rerun(
+        "run-phase0-dbt",
+        "dbt_phase0_assets",
+        {"metadata": {"node_info": {"node_name": "not_null_heartbeat"}}},
+        policy,
+    )
+
+    assert plan.rerun_selection == ("dbt_phase0_assets",)
+    assert plan.requires_manual_ack is False
+    assert "phase0_readiness_ping" not in plan.rerun_selection
+    assert "candidate_freeze" not in plan.rerun_selection

--- a/tests/jobs/test_phase0.py
+++ b/tests/jobs/test_phase0.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -72,3 +73,27 @@ def test_phase0_readiness_ping_key_is_addressable(
 
     assert phase0_readiness_ping.key == asset_key
     assert asset_key in phase0_readiness_ping.keys
+
+
+def test_missing_dbt_manifest_fails_with_prepare_hint(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    pytest.importorskip("dagster", reason="dagster is not installed")
+    pytest.importorskip("dagster_dbt", reason="dagster-dbt is not installed")
+    monkeypatch.setenv("ORCHESTRATOR_DBT_PROJECT_DIR", str(tmp_path))
+    _clear_phase0_imports()
+
+    try:
+        with pytest.raises(FileNotFoundError, match="dbt compile|prepare"):
+            __import__("orchestrator.jobs.phase0", fromlist=["phase0"])
+    finally:
+        _clear_phase0_imports()
+
+
+def _clear_phase0_imports() -> None:
+    for module_name in list(sys.modules):
+        if module_name == "orchestrator.jobs":
+            sys.modules.pop(module_name, None)
+        elif module_name.startswith("orchestrator.jobs."):
+            sys.modules.pop(module_name, None)

--- a/tests/test_rerun.py
+++ b/tests/test_rerun.py
@@ -1,10 +1,17 @@
 from dataclasses import FrozenInstanceError, fields
 from datetime import datetime, timezone
 from inspect import getsource, signature
+from pathlib import Path
 
 import pytest
 
-from orchestrator.policy import FailureClass, GateAction, GatePolicyProfile, PhaseEnum
+from orchestrator.policy import (
+    FailureClass,
+    GateAction,
+    GatePolicyProfile,
+    PhaseEnum,
+    load_gate_policy,
+)
 from orchestrator.policy.schema import PhaseMatrixEntry
 from orchestrator.rerun import (
     PartialRerunNotAllowed,
@@ -14,6 +21,10 @@ from orchestrator.rerun import (
     compute_partial_rerun_plan,
     plan_partial_rerun,
 )
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LITE_POLICY_PATH = REPO_ROOT / "config" / "policy" / "gate_policy.lite.yaml"
 
 
 def _policy(*entries: PhaseMatrixEntry) -> GatePolicyProfile:
@@ -227,6 +238,63 @@ def test_unknown_failed_node_mentions_run_id_and_node() -> None:
     assert "missing_node" in message
 
 
+def test_run_history_run_id_mismatch_raises() -> None:
+    run_history = RunHistorySnapshot(
+        run_id="snapshot-run",
+        node_to_phase={"phase2_score_AAPL": PhaseEnum.PHASE2},
+        node_dependencies={"phase2_score_AAPL": ()},
+        failed_nodes=("phase2_score_AAPL",),
+        repairable_nodes={},
+        node_failure_classes={"phase2_score_AAPL": FailureClass.TASK_LEVEL},
+    )
+    policy = _policy(
+        _entry(
+            PhaseEnum.PHASE2,
+            FailureClass.TASK_LEVEL,
+            GateAction.PARTIAL_RERUN,
+            allow_partial_rerun=True,
+        )
+    )
+
+    with pytest.raises(
+        PartialRerunNotAllowed,
+        match="requested=requested-run snapshot=snapshot-run",
+    ):
+        compute_partial_rerun_plan(
+            "requested-run",
+            "phase2_score_AAPL",
+            run_history,
+            policy,
+        )
+
+
+def test_node_exists_but_is_not_marked_failed_raises() -> None:
+    run_history = RunHistorySnapshot(
+        run_id="run-not-failed",
+        node_to_phase={"phase2_score_AAPL": PhaseEnum.PHASE2},
+        node_dependencies={"phase2_score_AAPL": ()},
+        failed_nodes=(),
+        repairable_nodes={},
+        node_failure_classes={"phase2_score_AAPL": FailureClass.TASK_LEVEL},
+    )
+    policy = _policy(
+        _entry(
+            PhaseEnum.PHASE2,
+            FailureClass.TASK_LEVEL,
+            GateAction.PARTIAL_RERUN,
+            allow_partial_rerun=True,
+        )
+    )
+
+    with pytest.raises(PartialRerunNotAllowed, match="is not marked failed"):
+        compute_partial_rerun_plan(
+            "run-not-failed",
+            "phase2_score_AAPL",
+            run_history,
+            policy,
+        )
+
+
 def test_policy_not_allowing_partial_rerun_raises() -> None:
     run_history = RunHistorySnapshot(
         run_id="run-denied",
@@ -249,6 +317,94 @@ def test_policy_not_allowing_partial_rerun_raises() -> None:
         compute_partial_rerun_plan(
             "run-denied",
             "phase0_market_data",
+            run_history,
+            policy,
+        )
+
+
+def test_mixed_phase_policy_requires_failure_class() -> None:
+    run_history = RunHistorySnapshot(
+        run_id="run-mixed-policy",
+        node_to_phase={"dbt_phase0_assets": PhaseEnum.PHASE0},
+        node_dependencies={"dbt_phase0_assets": ()},
+        failed_nodes=("dbt_phase0_assets",),
+        repairable_nodes={},
+        node_failure_classes=None,
+    )
+    policy = load_gate_policy(LITE_POLICY_PATH)
+
+    with pytest.raises(
+        PartialRerunNotAllowed,
+        match="requires an explicit failure_class",
+    ):
+        compute_partial_rerun_plan(
+            "run-mixed-policy",
+            "dbt_phase0_assets",
+            run_history,
+            policy,
+        )
+
+
+def test_single_entry_phase_policy_can_infer_missing_failure_class() -> None:
+    run_history = RunHistorySnapshot(
+        run_id="run-single-policy",
+        node_to_phase={"phase2_score_AAPL": PhaseEnum.PHASE2},
+        node_dependencies={"phase2_score_AAPL": ()},
+        failed_nodes=("phase2_score_AAPL",),
+        repairable_nodes={},
+        node_failure_classes=None,
+    )
+    policy = _policy(
+        _entry(
+            PhaseEnum.PHASE2,
+            FailureClass.TASK_LEVEL,
+            GateAction.PARTIAL_RERUN,
+            allow_partial_rerun=True,
+        )
+    )
+
+    plan = compute_partial_rerun_plan(
+        "run-single-policy",
+        "phase2_score_AAPL",
+        run_history,
+        policy,
+    )
+
+    assert plan.rerun_selection == ("phase2_score_AAPL",)
+    assert plan.requires_manual_ack is False
+
+
+def test_ambiguous_multi_entry_phase_policy_requires_failure_class() -> None:
+    run_history = RunHistorySnapshot(
+        run_id="run-ambiguous-policy",
+        node_to_phase={"phase2_score_AAPL": PhaseEnum.PHASE2},
+        node_dependencies={"phase2_score_AAPL": ()},
+        failed_nodes=("phase2_score_AAPL",),
+        repairable_nodes={},
+        node_failure_classes=None,
+    )
+    policy = _policy(
+        _entry(
+            PhaseEnum.PHASE2,
+            FailureClass.TASK_LEVEL,
+            GateAction.PARTIAL_RERUN,
+            allow_partial_rerun=True,
+        ),
+        _entry(
+            PhaseEnum.PHASE2,
+            FailureClass.DATA_QUALITY,
+            GateAction.FAIL_RUN,
+            allow_partial_rerun=False,
+        ),
+    )
+
+    with pytest.raises(
+        PartialRerunNotAllowed,
+        match="requires an explicit failure_class",
+    ):
+        compute_partial_rerun_plan(
+            "run-ambiguous-policy",
+            "phase2_score_AAPL",
             run_history,
             policy,
         )


### PR DESCRIPTION
Closes #16

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `src/orchestrator/checks/asset_checks.py`, `src/orchestrator/checks/classifier.py`, `src/orchestrator/definitions.py`, `src/orchestrator/rerun.py`, `src/orchestrator/sensors/manual_rerun.py`, `tests/integration/conftest.py`


---
### 1. 背景与目标
根据 §12.3 第三行，Phase 0 dbt test fail 应归类为 `partial_rerun`，只重跑修复后的失败 asset group。当前 `src/orchestrator/jobs/phase0.py` 的 `dbt_phase0_assets` 已经通过 `dagster-dbt` 执行 `dbt build`，`config/policy/gate_policy.lite.yaml` 也已有 `phase0/task_level/partial_rerun` 行，但还没有把 dbt test failure event 转成 `GateDecision` 和 `PartialRerunPlan`。目标是补齐 dbt failure adapter 与 partial-rerun plan 生成路径，不改变 dbt model 的业务实现。

### 2. 所属模块
`src/orchestrator/checks/dbt_events.py`（新增）、`src/orchestrator/rerun.py`、`src/orchestrator/jobs/phase0.py`、`tests/checks/test_dbt_events.py`、`tests/test_rerun.py`、`tests/integration/test_phase0_failure_matrix.py`

### 3. 实现范围
- 新增 `src/orchestrator/checks/dbt_events.py`：把 Dagster/dbt test fail 事件标准化为 #50 的 gate event，失败类固定映射为 `FailureClass.TASK_LEVEL`，phase 固定为 `PhaseEnum.PHASE0`。
- 新增函数 `classify_dbt_test_failure(event: object, policy: GatePolicyProfile) -> GateDecision`，内部调用 `classify_gate_result(PhaseEnum.PHASE0, gate_event, policy)`。
- 新增函数 `plan_dbt_test_partial_rerun(run_id: str, failed_asset_key: str, event: object, policy: GatePolicyProfile) -> PartialRerunPlan`，内部调用 #17 的 pure planner，rerun mode 使用 `asset_only` 或 policy 中允许的最小 asset group selection。
- 失败节点 selection 使用 Dagster AssetKey 的稳定字符串格式；测试覆盖 `dbt_phase0_assets` 和 fake `candidate_freeze` 不被误选。
- 对 dbt manifest 缺失保持清晰 preflight：不得在 import `orchestrator.definitions` 时静默 skip；沿用 #50 或现有 fixture 的 manifest prepare/compile 机制。
- 不直接解析 dbt manifest JSON 做业务判断；只读取事件提供的 node/asset key 元数据。

### 4. 不在本次范围
- 不实现 dbt model、schema test 或数据修复逻辑。
- 不自动提交 Dagster rerun；manual trigger 由 #18 负责。
- 不处理 Phase 2/3 的 failure matrix。
- 不实现全链重跑或跨 phase dependency closure。

### 5. 关键交付物
- `classify_dbt_test_failure(event: object, policy: GatePolicyProfile) -> GateDecision`。
- `plan_dbt_test_partial_rerun(run_id: str, failed_asset_key: str, event: object, policy: GatePolicyProfile) -> PartialRerunPlan`。
- `GateDecision.action is GateAction.PARTIAL_RERUN` 对应 `phase0/task_level` policy 行。
- `PartialRerunPlan.rerun_selec