### PR TITLE
feat(#15): llm_health_check AssetCheck（硬停语义）

### DIFF
--- a/src/orchestrator/checks/__init__.py
+++ b/src/orchestrator/checks/__init__.py
@@ -6,7 +6,12 @@ from orchestrator.checks.dbt_events import (
     classify_dbt_test_failure,
     plan_dbt_test_partial_rerun,
 )
-from orchestrator.checks.models import DataReadinessSignal, GateDecision
+from orchestrator.checks.models import (
+    DataReadinessSignal,
+    GateDecision,
+    LLMHealthProbe,
+    LLMHealthResult,
+)
 from orchestrator.policy import FailureClass, GateAction, PhaseEnum
 
 
@@ -19,6 +24,10 @@ def __getattr__(name: str) -> object:
         from orchestrator.checks.asset_checks import phase0_ping_check
 
         return phase0_ping_check
+    if name == "llm_health_check":
+        from orchestrator.checks.asset_checks import llm_health_check
+
+        return llm_health_check
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -28,11 +37,14 @@ __all__ = [
     "DataReadinessSignal",
     "GateDecision",
     "GatePolicyResource",
+    "LLMHealthProbe",
+    "LLMHealthResult",
     "PhaseEnum",
     "UnknownGateFailure",
     "classify_gate_result",
     "classify_dbt_test_failure",
     "dispatch_gate_decision_alert",
+    "llm_health_check",
     "phase0_ping_check",
     "plan_dbt_test_partial_rerun",
 ]

--- a/src/orchestrator/checks/asset_checks.py
+++ b/src/orchestrator/checks/asset_checks.py
@@ -2,11 +2,33 @@
 
 from __future__ import annotations
 
-from dagster import AssetCheckResult, asset_check
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from dagster import AssetCheckResult, ResourceParam, asset_check
 
 from orchestrator.checks.classifier import classify_gate_result
+from orchestrator.checks.decision_handler import dispatch_gate_decision_alert
+from orchestrator.checks.models import GateDecision, LLMHealthProbe
 from orchestrator.checks.resources import GatePolicyResource
-from orchestrator.policy import GateAction, PhaseEnum
+from orchestrator.policy import FailureClass, GateAction, PhaseEnum
+
+_LLM_HEALTH_CHECK_NAME = "llm_health_check"
+
+
+@dataclass(frozen=True, slots=True)
+class _LLMHealthGateEvent:
+    failure_class: FailureClass
+    provider: str | None
+    summary: str
+    failed_node: str = _LLM_HEALTH_CHECK_NAME
+
+
+@dataclass(frozen=True, slots=True)
+class _NormalizedLLMHealthResult:
+    healthy: bool
+    summary: str
+    provider: str | None = None
 
 
 @asset_check(asset="phase0_readiness_ping")
@@ -17,4 +39,99 @@ def phase0_ping_check(gate_policy: GatePolicyResource) -> AssetCheckResult:
     return AssetCheckResult(passed=decision.action is GateAction.CONTINUE)
 
 
-__all__ = ["phase0_ping_check"]
+@asset_check(
+    asset="phase0_readiness_ping",
+    name=_LLM_HEALTH_CHECK_NAME,
+    blocking=True,
+)
+def llm_health_check(
+    gate_policy: GatePolicyResource,
+    llm_health_probe: ResourceParam[LLMHealthProbe],
+) -> AssetCheckResult:
+    """Block Phase 0 when the reasoner-runtime LLM probe is unhealthy."""
+
+    health = _read_llm_health(llm_health_probe)
+    if health.healthy:
+        return AssetCheckResult(
+            passed=True,
+            metadata=_llm_health_metadata(health=health),
+        )
+
+    decision = classify_gate_result(
+        PhaseEnum.PHASE0,
+        _LLMHealthGateEvent(
+            failure_class=FailureClass.INFRA,
+            provider=health.provider,
+            summary=health.summary,
+        ),
+        gate_policy.policy,
+    )
+    metadata = _llm_health_metadata(health=health, decision=decision)
+
+    if decision.action is not GateAction.CONTINUE:
+        dispatch_gate_decision_alert(
+            decision,
+            cycle_id=_LLM_HEALTH_CHECK_NAME,
+            failed_node=_LLM_HEALTH_CHECK_NAME,
+            summary=decision.reason or health.summary,
+            channels=gate_policy.policy.alert_channels,
+        )
+
+    return AssetCheckResult(
+        passed=decision.action is GateAction.CONTINUE,
+        metadata=metadata,
+    )
+
+
+def _read_llm_health(
+    llm_health_probe: LLMHealthProbe,
+) -> _NormalizedLLMHealthResult:
+    check_health = getattr(llm_health_probe, "check_health", None)
+    if not callable(check_health):
+        raise TypeError("llm_health_probe resource must expose check_health()")
+
+    return _coerce_llm_health_result(check_health())
+
+
+def _coerce_llm_health_result(value: object) -> _NormalizedLLMHealthResult:
+    if isinstance(value, Mapping):
+        healthy = value.get("healthy")
+        summary = value.get("summary")
+        provider = value.get("provider")
+    else:
+        healthy = getattr(value, "healthy", None)
+        summary = getattr(value, "summary", None)
+        provider = getattr(value, "provider", None)
+
+    if not isinstance(healthy, bool):
+        raise TypeError("llm health result healthy must be bool")
+    if not isinstance(summary, str) or not summary:
+        raise TypeError("llm health result summary must be a non-empty string")
+    if provider is not None and not isinstance(provider, str):
+        raise TypeError("llm health result provider must be a string or None")
+
+    return _NormalizedLLMHealthResult(
+        healthy=healthy,
+        summary=summary,
+        provider=provider,
+    )
+
+
+def _llm_health_metadata(
+    *,
+    health: _NormalizedLLMHealthResult,
+    decision: GateDecision | None = None,
+) -> dict[str, str]:
+    metadata = {
+        "provider": health.provider or "",
+        "summary": health.summary,
+    }
+    if decision is not None:
+        metadata["failure_class"] = (
+            decision.failure_class.value if decision.failure_class else ""
+        )
+        metadata["action"] = decision.action.value
+    return metadata
+
+
+__all__ = ["llm_health_check", "phase0_ping_check"]

--- a/src/orchestrator/checks/models.py
+++ b/src/orchestrator/checks/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Protocol
 
 from orchestrator.policy import FailureClass, GateAction, PhaseEnum
 
@@ -27,4 +28,25 @@ class DataReadinessSignal:
     failed_node: str = "data_readiness"
 
 
-__all__ = ["DataReadinessSignal", "GateDecision"]
+class LLMHealthResult(Protocol):
+    """Health result shape exposed by reasoner-runtime providers."""
+
+    healthy: bool
+    summary: str
+    provider: str | None
+
+
+class LLMHealthProbe(Protocol):
+    """Minimal reasoner-runtime health probe consumed by the orchestrator."""
+
+    def check_health(self) -> LLMHealthResult:
+        """Return the current LLM provider health."""
+        ...
+
+
+__all__ = [
+    "DataReadinessSignal",
+    "GateDecision",
+    "LLMHealthProbe",
+    "LLMHealthResult",
+]

--- a/src/orchestrator/definitions.py
+++ b/src/orchestrator/definitions.py
@@ -9,7 +9,11 @@ from pathlib import Path
 from dagster import AssetKey, Definitions
 from dagster_dbt import DbtCliResource
 
-from orchestrator.checks import GatePolicyResource, phase0_ping_check
+from orchestrator.checks import (
+    GatePolicyResource,
+    llm_health_check,
+    phase0_ping_check,
+)
 from orchestrator.jobs.cycle import daily_cycle_job
 from orchestrator.jobs.phase0 import (
     DBT_PROFILES_DIR,
@@ -63,6 +67,7 @@ def build_definitions(
         ],
         asset_checks=[
             phase0_ping_check,
+            llm_health_check,
             *provider_checks,
         ],
         jobs=[daily_cycle_job],
@@ -82,19 +87,32 @@ def build_definitions(
 
 def _validate_phase0_provider_assets(provider_assets: Iterable[object]) -> None:
     candidate_freeze_key = AssetKey([PHASE0_CANDIDATE_FREEZE_ASSET_KEY])
+    has_phase0_provider_asset = False
+    has_candidate_freeze = False
 
     for asset_def in provider_assets:
-        if candidate_freeze_key not in getattr(asset_def, "keys", ()):
+        keys = tuple(getattr(asset_def, "keys", ()))
+        group_names = getattr(asset_def, "group_names_by_key", {})
+        if any(
+            group_names.get(asset_key) == PHASE0_GROUP_NAME for asset_key in keys
+        ):
+            has_phase0_provider_asset = True
+
+        if candidate_freeze_key not in keys:
             continue
 
-        group_name = getattr(asset_def, "group_names_by_key", {}).get(
-            candidate_freeze_key,
-        )
+        has_candidate_freeze = True
+        group_name = group_names.get(candidate_freeze_key)
         if group_name != PHASE0_GROUP_NAME:
             raise ValueError(
                 "candidate_freeze asset must declare "
                 f"group_name={PHASE0_GROUP_NAME!r}; got {group_name!r}",
             )
+
+    if has_phase0_provider_asset and not has_candidate_freeze:
+        raise ValueError(
+            "phase0 provider assets must include candidate_freeze",
+        )
 
 
 defs = build_definitions()

--- a/tests/checks/test_llm_health_check.py
+++ b/tests/checks/test_llm_health_check.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from orchestrator.policy import load_gate_policy
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_LITE_POLICY_PATH = _REPO_ROOT / "config" / "policy" / "gate_policy.lite.yaml"
+_DIRECT_PROVIDER_IO = re.compile(r"litellm|requests[.]|httpx|urlopen")
+
+
+@dataclass(frozen=True, slots=True)
+class _FakeHealthResult:
+    healthy: bool
+    summary: str
+    provider: str | None
+
+
+class _FakeHealthProbe:
+    def __init__(self, result: _FakeHealthResult) -> None:
+        self._result = result
+
+    def check_health(self) -> _FakeHealthResult:
+        return self._result
+
+
+@pytest.fixture
+def gate_policy_resource() -> object:
+    return SimpleNamespace(policy=load_gate_policy(_LITE_POLICY_PATH))
+
+
+def test_llm_health_check_passes_when_probe_is_healthy(
+    caplog: pytest.LogCaptureFixture,
+    gate_policy_resource: object,
+) -> None:
+    pytest.importorskip("dagster", reason="dagster is not installed")
+
+    from orchestrator.checks.asset_checks import llm_health_check
+
+    with caplog.at_level(logging.WARNING):
+        result = llm_health_check(
+            gate_policy=gate_policy_resource,
+            llm_health_probe=_FakeHealthProbe(
+                _FakeHealthResult(
+                    healthy=True,
+                    summary="provider ready",
+                    provider="fake-llm",
+                ),
+            ),
+        )
+
+    assert result.passed is True
+    assert result.metadata == {
+        "provider": "fake-llm",
+        "summary": "provider ready",
+    }
+    assert caplog.records == []
+
+
+def test_llm_health_check_fails_phase0_infra_with_fail_run_action(
+    gate_policy_resource: object,
+) -> None:
+    pytest.importorskip("dagster", reason="dagster is not installed")
+
+    from orchestrator.checks.asset_checks import llm_health_check
+
+    result = llm_health_check(
+        gate_policy=gate_policy_resource,
+        llm_health_probe=_FakeHealthProbe(
+            _FakeHealthResult(
+                healthy=False,
+                summary="probe failed",
+                provider="fake-llm",
+            ),
+        ),
+    )
+
+    assert result.passed is False
+    assert result.metadata["failure_class"] == "infra"
+    assert result.metadata["action"] == "fail_run"
+    assert result.metadata["provider"] == "fake-llm"
+    assert result.metadata["summary"] == "probe failed"
+
+
+def test_llm_health_check_dispatches_fail_run_alert(
+    caplog: pytest.LogCaptureFixture,
+    gate_policy_resource: object,
+) -> None:
+    pytest.importorskip("dagster", reason="dagster is not installed")
+
+    from orchestrator.checks.asset_checks import llm_health_check
+
+    with caplog.at_level(logging.WARNING):
+        llm_health_check(
+            gate_policy=gate_policy_resource,
+            llm_health_probe=_FakeHealthProbe(
+                _FakeHealthResult(
+                    healthy=False,
+                    summary="probe failed",
+                    provider="fake-llm",
+                ),
+            ),
+        )
+
+    payload = json.loads(caplog.records[-1].message)
+
+    assert payload["phase"] == "phase0"
+    assert payload["failed_node"] == "llm_health_check"
+    assert payload["action"] == "fail_run"
+    assert payload["summary"] == "LLM health check failed; stop before Phase 1."
+
+
+def test_llm_health_check_is_dagster_asset_check_definition() -> None:
+    dagster = pytest.importorskip("dagster", reason="dagster is not installed")
+
+    from orchestrator.checks import llm_health_check
+
+    definitions = dagster.Definitions(asset_checks=[llm_health_check])
+
+    assert "llm_health_check" in _check_names(definitions)
+
+
+def test_orchestrator_checks_do_not_import_provider_io_clients() -> None:
+    scanned_paths = [
+        *(_REPO_ROOT / "src" / "orchestrator" / "checks").rglob("*.py"),
+        *(_REPO_ROOT / "src" / "orchestrator" / "resources").rglob("*.py"),
+    ]
+    matches: list[str] = []
+
+    for path in scanned_paths:
+        text = path.read_text(encoding="utf-8")
+        if _DIRECT_PROVIDER_IO.search(text):
+            matches.append(str(path.relative_to(_REPO_ROOT)))
+
+    assert matches == []
+
+
+def _check_names(defs: Any) -> set[str]:
+    names: set[str] = set()
+    for check_def in defs.asset_checks or ():
+        names.update(
+            check_key.name
+            for check_key in getattr(check_def, "check_keys", ())
+        )
+        names.update(spec.name for spec in getattr(check_def, "specs", ()))
+        if name := getattr(check_def, "name", None):
+            names.add(name)
+    return names

--- a/tests/integration/test_data_platform_provider_wiring.py
+++ b/tests/integration/test_data_platform_provider_wiring.py
@@ -45,10 +45,14 @@ def test_data_platform_provider_contributes_phase0_surface(
     assert dbt_phase0_keys <= selected_keys
     assert "fake_data_platform_phase0_check" in _check_names(defs)
     assert "fake_data_platform_resource" in defs.resources
+    assert "llm_health_probe" in defs.resources
 
     bundle = defs.resources["resource_bundle"]
     assert isinstance(bundle, ResourceBundle)
-    assert bundle.resource_keys == ("fake_data_platform_resource",)
+    assert bundle.resource_keys == (
+        "fake_data_platform_resource",
+        "llm_health_probe",
+    )
     assert bundle.source_modules == (__name__,)
     assert bundle.config_ref == stub_policy_path
     assert bundle.read_only is True
@@ -102,6 +106,19 @@ def _fake_data_platform_provider(
         def create_resource(self, context: object) -> dict[str, str]:
             return {"source": "fake-provider"}
 
+    class FakeLLMHealthResult:
+        healthy = True
+        summary = "provider ready"
+        provider = "fake-llm"
+
+    class FakeLLMHealthProbe:
+        def check_health(self) -> FakeLLMHealthResult:
+            return FakeLLMHealthResult()
+
+    class FakeLLMHealthProbeResource(dagster.ConfigurableResource):
+        def create_resource(self, context: object) -> FakeLLMHealthProbe:
+            return FakeLLMHealthProbe()
+
     @dagster.asset(
         name="candidate_freeze",
         group_name=candidate_group,
@@ -135,7 +152,11 @@ def _fake_data_platform_provider(
                 "fake_data_platform_resource": cast(
                     object,
                     FakeDataPlatformResource(),
-                )
+                ),
+                "llm_health_probe": cast(
+                    object,
+                    FakeLLMHealthProbeResource(),
+                ),
             }
 
     return (

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -55,15 +55,22 @@ def test_build_definitions_collects_p1a_surface(
         "manual_rerun_sensor",
     }
     assert AssetKey(["fake_phase0_asset"]) in _asset_keys(defs)
+    assert AssetKey(["candidate_freeze"]) in _asset_keys(defs)
+    assert "phase0_ping_check" in _check_names(defs)
+    assert "llm_health_check" in _check_names(defs)
     assert "fake_phase0_check" in _check_names(defs)
     assert "gate_policy" in defs.resources
     assert "resource_bundle" in defs.resources
     assert "fake_data_platform_resource" in defs.resources
+    assert "llm_health_probe" in defs.resources
     assert "orchestration_context_stub" not in defs.resources
 
     bundle = defs.resources["resource_bundle"]
     assert isinstance(bundle, ResourceBundle)
-    assert bundle.resource_keys == ("fake_data_platform_resource",)
+    assert bundle.resource_keys == (
+        "fake_data_platform_resource",
+        "llm_health_probe",
+    )
     assert bundle.source_modules == (__name__,)
     assert bundle.config_ref == "config/policy/gate_policy.lite.yaml"
     assert bundle.read_only is True
@@ -165,13 +172,57 @@ def test_duplicate_provider_resource_key_raises_value_error(
         )
 
 
+def test_phase0_provider_missing_candidate_freeze_is_rejected(
+    definitions_exports: dict[str, Any],
+) -> None:
+    build_definitions = definitions_exports["build_definitions"]
+    dagster = definitions_exports["dagster"]
+
+    @dagster.asset(name="fake_phase0_asset", group_name="phase0")
+    def fake_phase0_asset() -> str:
+        return "ok"
+
+    class MissingCandidateProvider:
+        def get_assets(self) -> tuple[object, ...]:
+            return (fake_phase0_asset,)
+
+        def get_checks(self) -> tuple[object, ...]:
+            return ()
+
+        def get_resources(self) -> dict[str, object]:
+            return {}
+
+    with pytest.raises(
+        ValueError,
+        match="phase0 provider assets must include candidate_freeze",
+    ):
+        build_definitions(module_factories=[MissingCandidateProvider()])
+
+
 def _fake_provider(dagster: Any) -> object:
     class FakeDataPlatformResource(dagster.ConfigurableResource):
         def create_resource(self, context: object) -> dict[str, str]:
             return {"status": "ok"}
 
+    class FakeLLMHealthResult:
+        healthy = True
+        summary = "provider ready"
+        provider = "fake-llm"
+
+    class FakeLLMHealthProbe:
+        def check_health(self) -> FakeLLMHealthResult:
+            return FakeLLMHealthResult()
+
+    class FakeLLMHealthProbeResource(dagster.ConfigurableResource):
+        def create_resource(self, context: object) -> FakeLLMHealthProbe:
+            return FakeLLMHealthProbe()
+
     @dagster.asset(name="fake_phase0_asset", group_name="phase0")
     def fake_phase0_asset() -> str:
+        return "ok"
+
+    @dagster.asset(name="candidate_freeze", group_name="phase0")
+    def candidate_freeze() -> str:
         return "ok"
 
     @dagster.asset_check(asset=fake_phase0_asset, name="fake_phase0_check")
@@ -180,7 +231,7 @@ def _fake_provider(dagster: Any) -> object:
 
     class FakeDataPlatformProvider:
         def get_assets(self) -> tuple[object, ...]:
-            return (fake_phase0_asset,)
+            return (fake_phase0_asset, candidate_freeze)
 
         def get_checks(self) -> tuple[object, ...]:
             return (fake_phase0_check,)
@@ -190,7 +241,11 @@ def _fake_provider(dagster: Any) -> object:
                 "fake_data_platform_resource": cast(
                     object,
                     FakeDataPlatformResource(),
-                )
+                ),
+                "llm_health_probe": cast(
+                    object,
+                    FakeLLMHealthProbeResource(),
+                ),
             }
 
     return FakeDataPlatformProvider()


### PR DESCRIPTION
Closes #15

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `src/orchestrator/checks/asset_checks.py`, `src/orchestrator/checks/classifier.py`, `src/orchestrator/checks/dbt_events.py`, `src/orchestrator/definitions.py`, `src/orchestrator/sensors/data_readiness.py`, `src/orchestrator/sensors/manual_rerun.py`, `tests/integration/conftest.py`


---
### 1. 背景与目标
根据 §12.3 第二行，`llm_health_check` 失败必须在 Phase 0 硬停，不能进入 Phase 1。当前 `src/orchestrator/checks/asset_checks.py` 只有 `phase0_ping_check`，它调用 classifier 的 pass 路径并总是返回通过；`config/policy/gate_policy.lite.yaml` 已有 `phase0/infra/fail_run` 行，描述为 LLM health check failed。目标是接入 `reasoner-runtime` 公开 health probe resource，新增 blocking AssetCheck，把失败 event 归类为 `GateAction.FAIL_RUN`，并复用 #13 的 gate-decision alert helper。

### 2. 所属模块
`src/orchestrator/checks/asset_checks.py`、`src/orchestrator/checks/models.py`、`src/orchestrator/checks/decision_handler.py`、`src/orchestrator/definitions.py`、`tests/checks/test_llm_health_check.py`、`tests/integration/test_phase0_failure_matrix.py`

### 3. 实现范围
- 在 `asset_checks.py` 新增 `@asset_check(asset='phase0_readiness_ping', name='llm_health_check', blocking=True)` 的 `llm_health_check(...) -> AssetCheckResult`。
- 通过注入 resource key `llm_health_probe` 调用 reasoner-runtime 公开 health probe；测试中使用 fake probe，生产中由 #12 的 module factory/resource 提供。
- 定义/复用轻量 health result 协议：`healthy: bool`、`summary: str`、`provider: str | None`，orchestrator 不直接 import LiteLLM 或发 HTTP 请求。
- 失败时构造 #50 的 gate event，调用 `classify_gate_result(PhaseEnum.PHASE0, event, gate_policy.policy)`，event 对应 `FailureClass.INFRA`。
- `GateAction.FAIL_RUN` 时返回 `AssetCheckResult(passed=False, metadata={...})`，并调用 #13 的 `dispatch_gate_decision_alert(...)`。
- 更新 `src/orchestrator/checks/__init__.py` 与 `src/orchestrator/definitions.py`，确保 `llm_health_check` 被默认 `Definitions.asset_checks` 收集。

### 4. 不在本次范围
- 不实现 reasoner-runtime provider 策略、重试、模型选择或 LiteLLM 客户端。
- 不实现 Phase 1 job；本 issue 只保证 blocking check 语义可被后续 phase 依赖消费。
- 不处理 Phase 2 单股票 LLM 失败；那是 `phase2/task_level/mark_inconclusive`。
- 不新增 Webhook/Slack 告警通道。

### 5. 关键交付物
- `llm_health_check` 是 Dagster `AssetChecksDefinition`，名称固定为 `llm_health_check`，asset 固定挂在 `phase0_readiness_ping`。
- `llm_health_probe` resource 协议在测试中以 fake object 覆盖，至少支持 `check_health() -> object` 或等价公开方法。
- 失败路径调用 `classify_gate_result(PhaseEnum.PHASE0, event,