### PR TITLE
feat(#62): [milestone-1 review] P0: Data readiness sensor depends on resources it does not declare or guarantee

### DIFF
--- a/src/orchestrator/definitions.py
+++ b/src/orchestrator/definitions.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from pathlib import Path
 
 from dagster import AssetKey, ConfigurableResource, Definitions
 from dagster_dbt import DbtCliResource
 
 from orchestrator.checks import (
+    DataReadinessSignal,
     GatePolicyResource,
     llm_health_check,
     phase0_ping_check,
@@ -25,7 +26,12 @@ from orchestrator.jobs.phase0 import (
 )
 from orchestrator.resources import AssetFactoryProvider, build_resource_bundle
 from orchestrator.schedules import daily_cycle_schedule
-from orchestrator.sensors import data_readiness_sensor, manual_rerun_sensor
+from orchestrator.sensors.data_readiness import (
+    DATA_READINESS_PROVIDER_RESOURCE_KEY,
+    DATA_READINESS_RESOURCE_KEY,
+    data_readiness_sensor,
+)
+from orchestrator.sensors.manual_rerun import manual_rerun_sensor
 
 DEFAULT_POLICY_PATH = "config/policy/gate_policy.lite.yaml"
 _RESERVED_RESOURCE_KEYS = ("gate_policy", "dbt", "resource_bundle")
@@ -50,6 +56,23 @@ class _FailClosedLLMHealthProbeResource(ConfigurableResource):
 
     def create_resource(self, context: object) -> _MissingLLMHealthProbe:
         return _MissingLLMHealthProbe()
+
+
+class _MissingDataReadinessProvider:
+    def get_data_readiness_signal(self) -> DataReadinessSignal:
+        return DataReadinessSignal(
+            ready=False,
+            cycle_id="missing-data-readiness",
+            reason="data_readiness resource is not configured",
+            failed_node=DATA_READINESS_RESOURCE_KEY,
+        )
+
+
+class _FailClosedDataReadinessResource(ConfigurableResource):
+    """Default provider that lets the readiness gate fail through policy."""
+
+    def create_resource(self, context: object) -> _MissingDataReadinessProvider:
+        return _MissingDataReadinessProvider()
 
 
 def build_definitions(
@@ -84,6 +107,7 @@ def build_definitions(
         _LLM_HEALTH_PROBE_RESOURCE_KEY,
         _FailClosedLLMHealthProbeResource(),
     )
+    data_readiness_resource = _data_readiness_resource(resource_bundle.resources)
 
     return Definitions(
         assets=[
@@ -105,6 +129,7 @@ def build_definitions(
                 profiles_dir=str(DBT_PROFILES_DIR),
             ),
             _LLM_HEALTH_PROBE_RESOURCE_KEY: llm_health_probe_resource,
+            DATA_READINESS_RESOURCE_KEY: data_readiness_resource,
             "resource_bundle": resource_bundle,
             **resource_bundle.resources,
         },
@@ -139,6 +164,18 @@ def _validate_phase0_provider_assets(provider_assets: Iterable[object]) -> None:
         raise ValueError(
             "phase0 provider assets must include candidate_freeze",
         )
+
+
+def _data_readiness_resource(resources: Mapping[str, object]) -> object:
+    for resource_key in (
+        DATA_READINESS_RESOURCE_KEY,
+        DATA_READINESS_PROVIDER_RESOURCE_KEY,
+    ):
+        resource = resources.get(resource_key)
+        if resource is not None:
+            return resource
+
+    return _FailClosedDataReadinessResource()
 
 
 defs = build_definitions()

--- a/src/orchestrator/sensors/data_readiness.py
+++ b/src/orchestrator/sensors/data_readiness.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any
 
 from dagster import RunRequest, SensorEvaluationContext, SkipReason, sensor
@@ -18,15 +17,20 @@ from orchestrator.policy import (
     FailureClass,
     GatePolicyProfile,
     PhaseEnum,
-    load_gate_policy,
 )
 from orchestrator.jobs.cycle import daily_cycle_job
 
 
-_DEFAULT_POLICY_PATH = (
-    Path(__file__).resolve().parents[3] / "config" / "policy" / "gate_policy.lite.yaml"
+DATA_READINESS_RESOURCE_KEY = "data_readiness"
+DATA_READINESS_PROVIDER_RESOURCE_KEY = "data_readiness_provider"
+GATE_POLICY_RESOURCE_KEY = "gate_policy"
+DATA_READINESS_SENSOR_REQUIRED_RESOURCE_KEYS = frozenset(
+    {DATA_READINESS_RESOURCE_KEY, GATE_POLICY_RESOURCE_KEY},
 )
-_READINESS_RESOURCE_KEYS = ("data_readiness", "data_readiness_provider")
+_READINESS_RESOURCE_KEYS = (
+    DATA_READINESS_RESOURCE_KEY,
+    DATA_READINESS_PROVIDER_RESOURCE_KEY,
+)
 _READINESS_METHOD_NAMES = (
     "get_data_readiness_signal",
     "get_readiness_signal",
@@ -43,7 +47,11 @@ class _DataReadinessGateEvent:
     reason: str | None = None
 
 
-@sensor(job=daily_cycle_job, name="data_readiness_sensor")
+@sensor(
+    job=daily_cycle_job,
+    name="data_readiness_sensor",
+    required_resource_keys=DATA_READINESS_SENSOR_REQUIRED_RESOURCE_KEYS,
+)
 def data_readiness_sensor(
     context: SensorEvaluationContext,
 ) -> RunRequest | SkipReason:
@@ -146,7 +154,7 @@ def _validate_signal(signal: DataReadinessSignal) -> None:
 
 
 def _gate_policy_from_context(context: SensorEvaluationContext) -> GatePolicyProfile:
-    resource = _first_available_resource(context, ("gate_policy",))
+    resource = _first_available_resource(context, (GATE_POLICY_RESOURCE_KEY,))
     if isinstance(resource, GatePolicyProfile):
         return resource
 
@@ -154,7 +162,13 @@ def _gate_policy_from_context(context: SensorEvaluationContext) -> GatePolicyPro
     if isinstance(policy, GatePolicyProfile):
         return policy
 
-    return load_gate_policy(_DEFAULT_POLICY_PATH)
+    if resource is None:
+        raise RuntimeError("gate_policy resource is required")
+
+    raise TypeError(
+        "gate_policy resource must be a GatePolicyProfile or expose "
+        "a GatePolicyProfile policy",
+    )
 
 
 def _first_available_resource(
@@ -179,4 +193,10 @@ def _first_available_resource(
     return None
 
 
-__all__ = ["data_readiness_sensor"]
+__all__ = [
+    "DATA_READINESS_PROVIDER_RESOURCE_KEY",
+    "DATA_READINESS_RESOURCE_KEY",
+    "DATA_READINESS_SENSOR_REQUIRED_RESOURCE_KEYS",
+    "GATE_POLICY_RESOURCE_KEY",
+    "data_readiness_sensor",
+]

--- a/tests/sensors/test_data_readiness.py
+++ b/tests/sensors/test_data_readiness.py
@@ -199,6 +199,17 @@ def test_data_readiness_sensor_name(sensor_exports: dict[str, Any]) -> None:
     assert data_readiness_sensor.name == "data_readiness_sensor"
 
 
+def test_data_readiness_sensor_declares_required_resources(
+    sensor_exports: dict[str, Any],
+) -> None:
+    data_readiness_sensor = sensor_exports["data_readiness_sensor"]
+
+    assert data_readiness_sensor.required_resource_keys == {
+        "data_readiness",
+        "gate_policy",
+    }
+
+
 def test_schedule_and_sensor_can_be_collected_together(
     sensor_exports: dict[str, Any],
 ) -> None:

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -4,6 +4,8 @@ from typing import Any, cast
 
 import pytest
 
+from orchestrator.checks import DataReadinessSignal
+
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _DBT_MANIFEST_PATH = _REPO_ROOT / "dbt_stub" / "target" / "manifest.json"
 
@@ -61,6 +63,7 @@ def test_build_definitions_collects_p1a_surface(
     assert "fake_phase0_check" in _check_names(defs)
     assert "gate_policy" in defs.resources
     assert "resource_bundle" in defs.resources
+    assert "data_readiness" in defs.resources
     assert "fake_data_platform_resource" in defs.resources
     assert "llm_health_probe" in defs.resources
     assert "orchestration_context_stub" not in defs.resources
@@ -74,6 +77,60 @@ def test_build_definitions_collects_p1a_surface(
     assert bundle.source_modules == (__name__,)
     assert bundle.config_ref == "config/policy/gate_policy.lite.yaml"
     assert bundle.read_only is True
+
+
+def test_build_definitions_backs_data_readiness_sensor_resources(
+    definitions_exports: dict[str, Any],
+) -> None:
+    build_definitions = definitions_exports["build_definitions"]
+
+    defs = build_definitions(policy_path="config/policy/gate_policy.lite.yaml")
+    sensor = _sensor_by_name(defs, "data_readiness_sensor")
+
+    assert sensor.required_resource_keys == {"data_readiness", "gate_policy"}
+    assert sensor.required_resource_keys <= set(defs.resources)
+
+
+def test_data_readiness_sensor_evaluates_with_definition_resources(
+    definitions_exports: dict[str, Any],
+) -> None:
+    dagster = definitions_exports["dagster"]
+    build_definitions = definitions_exports["build_definitions"]
+    provider = _fake_readiness_provider(
+        dagster,
+        resource_key="data_readiness_provider",
+    )
+
+    defs = build_definitions(
+        module_factories=[provider],
+        policy_path="config/policy/gate_policy.lite.yaml",
+    )
+    sensor = _sensor_by_name(defs, "data_readiness_sensor")
+
+    assert "data_readiness" in defs.resources
+    assert "data_readiness_provider" in defs.resources
+
+    result = _evaluate_sensor_tick(dagster, sensor, defs)
+
+    run_requests = list(result.run_requests or ())
+    assert len(run_requests) == 1
+    assert run_requests[0].run_key == "cycle-20260416"
+    assert run_requests[0].tags["phase"] == "phase0"
+
+
+def test_data_readiness_sensor_defaults_fail_closed_without_provider(
+    definitions_exports: dict[str, Any],
+) -> None:
+    dagster = definitions_exports["dagster"]
+    build_definitions = definitions_exports["build_definitions"]
+
+    defs = build_definitions(policy_path="config/policy/gate_policy.lite.yaml")
+    sensor = _sensor_by_name(defs, "data_readiness_sensor")
+
+    result = _evaluate_sensor_tick(dagster, sensor, defs)
+
+    assert list(result.run_requests or ()) == []
+    assert "data_readiness resource is not configured" in result.skip_message
 
 
 def test_build_definitions_signature_matches_contract(
@@ -270,12 +327,57 @@ def _fake_provider(dagster: Any) -> object:
     return FakeDataPlatformProvider()
 
 
+def _fake_readiness_provider(
+    dagster: Any,
+    resource_key: str = "data_readiness",
+) -> object:
+    class FakeReadinessProvider:
+        def get_data_readiness_signal(self) -> DataReadinessSignal:
+            return DataReadinessSignal(
+                ready=True,
+                cycle_id="cycle-20260416",
+            )
+
+    class FakeReadinessResource(dagster.ConfigurableResource):
+        def create_resource(self, context: object) -> FakeReadinessProvider:
+            return FakeReadinessProvider()
+
+    class FakeReadinessProviderFactory:
+        def get_assets(self) -> tuple[object, ...]:
+            return ()
+
+        def get_checks(self) -> tuple[object, ...]:
+            return ()
+
+        def get_resources(self) -> dict[str, object]:
+            return {
+                resource_key: cast(object, FakeReadinessResource()),
+            }
+
+    return FakeReadinessProviderFactory()
+
+
 def _asset_keys(defs: Any) -> set[object]:
     return {
         asset_key
         for asset_def in defs.assets or ()
         for asset_key in getattr(asset_def, "keys", ())
     }
+
+
+def _sensor_by_name(defs: Any, name: str) -> Any:
+    for sensor in defs.sensors or ():
+        if sensor.name == name:
+            return sensor
+    pytest.fail(f"missing sensor {name}")
+
+
+def _evaluate_sensor_tick(dagster: Any, sensor: Any, defs: Any) -> Any:
+    context = dagster.build_sensor_context(definitions=defs)
+    if callable(getattr(context, "__enter__", None)):
+        with context as active_context:
+            return sensor.evaluate_tick(active_context)
+    return sensor.evaluate_tick(context)
 
 
 def _check_names(defs: Any) -> set[str]:


### PR DESCRIPTION
Closes #62

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/orchestrator/checks/dbt_events.py`, `src/orchestrator/sensors/manual_rerun.py`, `tests/integration/conftest.py`


---
## 背景与目标
Milestone review for milestone-1 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
data_readiness_sensor reads context.resources.data_readiness or data_readiness_provider and gate_policy, but the sensor definition does not declare required resource keys and build_definitions does not ensure that a readiness provider exists. Manual unit tests pass because they call evaluation_fn with an explicit context, but real sensor evaluation through Dagster can fail before the Phase 0 fail_run matrix is applied.

## 实现范围
- 修改文件: `src/orchestrator/sensors/data_readiness.py`
- Declare required sensor resources or route readiness through resource_bundle with an explicit contract. Update build_definitions to validate the readiness resource for the milestone profile, and add a Definitions-level sensor evaluation test using the assembled resources.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
python3 -m pytest
```
