### PR TITLE
feat(#61): [milestone-1 review] P0: dbt test failure handling is only an adapter, not a Dagster integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.12"
 dependencies = [
     "dagster",
     "dagster-dbt",
+    "pendulum>=3.2",
     "pydantic",
     "pyyaml",
 ]

--- a/src/orchestrator/checks/dbt_events.py
+++ b/src/orchestrator/checks/dbt_events.py
@@ -2,17 +2,37 @@
 
 from __future__ import annotations
 
+import json
+import os
+import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator
 
 from orchestrator.checks.classifier import classify_gate_result
+from orchestrator.checks.decision_handler import dispatch_gate_decision_alert
 from orchestrator.checks.models import GateDecision
-from orchestrator.policy import FailureClass, GatePolicyProfile, PhaseEnum
+from orchestrator.cli.rerun import DEFAULT_REQUEST_DIR
+from orchestrator.policy import FailureClass, GateAction, GatePolicyProfile, PhaseEnum
 from orchestrator.rerun import (
     PartialRerunPlan,
     RunHistorySnapshot,
     compute_partial_rerun_plan,
 )
+
+_RERUN_REQUEST_DIR_ENV = "ORCHESTRATOR_RERUN_REQUEST_DIR"
+_FAILED_DBT_TEST_STATUSES = frozenset({"fail", "error"})
+_DBT_ASSET_RESOURCE_TYPES = frozenset({"model", "seed", "snapshot", "source"})
+
+
+@dataclass(frozen=True, slots=True)
+class DbtFailureHandlingResult:
+    """Side effects produced for a classified dbt test failure."""
+
+    decision: GateDecision
+    partial_rerun_plan: PartialRerunPlan | None
+    rerun_request_path: Path | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -20,6 +40,117 @@ class _DbtGateEvent:
     failure_class: FailureClass
     dbt_node_name: str | None = None
     asset_key: str | None = None
+
+
+def stream_dbt_build_events(
+    *,
+    context: object,
+    dbt_invocation: object,
+    policy: GatePolicyProfile,
+    manifest_path: str | Path | None = None,
+    request_dir: str | Path | None = None,
+) -> Iterator[object]:
+    """Stream dbt events and handle failed dbt tests through the gate pipeline."""
+
+    failure_event: object | None = None
+    try:
+        for event in _stream_dbt_invocation(dbt_invocation):
+            if failure_event is None:
+                failure_event = _dbt_test_failure_from_stream_event(event)
+            yield event
+    except Exception:
+        failure_event = failure_event or _dbt_test_failure_from_artifacts(
+            dbt_invocation,
+            manifest_path=manifest_path,
+        )
+        if failure_event is not None:
+            handle_dbt_test_failure(
+                context=context,
+                event=failure_event,
+                policy=policy,
+                request_dir=request_dir,
+            )
+        raise
+
+    failure_event = failure_event or _dbt_test_failure_from_artifacts(
+        dbt_invocation,
+        manifest_path=manifest_path,
+    )
+    if failure_event is not None:
+        handle_dbt_test_failure(
+            context=context,
+            event=failure_event,
+            policy=policy,
+            request_dir=request_dir,
+        )
+
+
+def handle_dbt_test_failure(
+    *,
+    context: object,
+    event: object,
+    policy: GatePolicyProfile,
+    request_dir: str | Path | None = None,
+) -> DbtFailureHandlingResult:
+    """Classify a dbt test failure and produce alert/rerun side effects."""
+
+    decision = classify_dbt_test_failure(event, policy)
+    failed_node = _required_event_asset_key(event)
+    partial_rerun_plan: PartialRerunPlan | None = None
+    rerun_request_path: Path | None = None
+
+    if decision.action is GateAction.PARTIAL_RERUN:
+        partial_rerun_plan = plan_dbt_test_partial_rerun(
+            _run_id_from_context(context),
+            failed_node,
+            event,
+            policy,
+        )
+        rerun_request_path = write_dbt_partial_rerun_request(
+            partial_rerun_plan,
+            request_dir=request_dir,
+        )
+
+    summary = decision.reason or _dbt_failure_summary(event, failed_node)
+    dispatch_gate_decision_alert(
+        decision,
+        cycle_id=_cycle_id_from_context(context),
+        failed_node=failed_node,
+        summary=summary,
+        channels=policy.alert_channels,
+    )
+    _emit_gate_decision_observation(
+        context=context,
+        decision=decision,
+        failed_node=failed_node,
+        event=event,
+        partial_rerun_plan=partial_rerun_plan,
+        rerun_request_path=rerun_request_path,
+    )
+
+    return DbtFailureHandlingResult(
+        decision=decision,
+        partial_rerun_plan=partial_rerun_plan,
+        rerun_request_path=rerun_request_path,
+    )
+
+
+def write_dbt_partial_rerun_request(
+    plan: PartialRerunPlan,
+    *,
+    request_dir: str | Path | None = None,
+) -> Path:
+    """Write a manual-rerun request for the manual rerun sensor."""
+
+    target_dir = _rerun_request_dir(request_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    request_path = target_dir / _request_filename(plan.run_id, plan.failed_node)
+    request_path.write_text(
+        json.dumps(_request_from_plan(plan), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    return request_path
 
 
 def classify_dbt_test_failure(
@@ -57,6 +188,425 @@ def plan_dbt_test_partial_rerun(
     )
 
     return compute_partial_rerun_plan(run_id, failed_node, run_history, policy)
+
+
+def _stream_dbt_invocation(dbt_invocation: object) -> Iterator[object]:
+    stream = getattr(dbt_invocation, "stream", None)
+    if not callable(stream):
+        raise TypeError("dbt_invocation must expose stream()")
+
+    yield from stream()
+
+
+def _dbt_test_failure_from_stream_event(event: object) -> object | None:
+    if not _is_failed_asset_check_event(event):
+        return None
+
+    return event if _extract_asset_key(event) is not None else None
+
+
+def _dbt_test_failure_from_artifacts(
+    dbt_invocation: object,
+    *,
+    manifest_path: str | Path | None,
+) -> object | None:
+    run_results = _dbt_artifact(dbt_invocation, "run_results.json")
+    if not isinstance(run_results, Mapping):
+        return None
+
+    manifest = _dbt_artifact(
+        dbt_invocation,
+        "manifest.json",
+        fallback_path=manifest_path,
+    )
+    if not isinstance(manifest, Mapping):
+        return None
+
+    results = run_results.get("results")
+    if not isinstance(results, Sequence) or isinstance(results, (bytes, str)):
+        return None
+
+    for result in results:
+        if not _is_failed_dbt_test_result(result, manifest):
+            continue
+
+        event = _gate_event_from_dbt_result(result, manifest)
+        if event is not None:
+            return event
+
+    return None
+
+
+def _dbt_artifact(
+    dbt_invocation: object,
+    artifact_name: str,
+    *,
+    fallback_path: str | Path | None = None,
+) -> object | None:
+    get_artifact = getattr(dbt_invocation, "get_artifact", None)
+    if callable(get_artifact):
+        try:
+            return get_artifact(artifact_name)
+        except Exception:
+            pass
+
+    if artifact_name == "manifest.json" and fallback_path is not None:
+        try:
+            return json.loads(Path(fallback_path).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+
+    return None
+
+
+def _is_failed_asset_check_event(event: object) -> bool:
+    passed = _asset_check_passed_value(event)
+    if passed is not False:
+        return False
+
+    if _extract_dbt_node_name(event) is not None:
+        return True
+
+    metadata = _event_metadata(event)
+    return any(key in metadata for key in ("dbt_node_info", "node_info", "unique_id"))
+
+
+def _asset_check_passed_value(event: object) -> bool | None:
+    for value in _candidate_values(event, ("passed",)):
+        if isinstance(value, bool):
+            return value
+
+    event_specific_data = _mapping_or_attr(event, "event_specific_data")
+    if event_specific_data is not None:
+        for nested_name in ("asset_check_evaluation", "evaluation"):
+            evaluation = _mapping_or_attr(event_specific_data, nested_name)
+            if evaluation is None:
+                continue
+            passed = _mapping_or_attr(evaluation, "passed")
+            if isinstance(passed, bool):
+                return passed
+
+    return None
+
+
+def _is_failed_dbt_test_result(result: object, manifest: Mapping[str, object]) -> bool:
+    if not isinstance(result, Mapping):
+        return False
+
+    status = result.get("status")
+    if status not in _FAILED_DBT_TEST_STATUSES:
+        return False
+
+    unique_id = _dbt_result_unique_id(result)
+    if unique_id is None:
+        return False
+
+    node = _manifest_node(manifest, unique_id)
+    if node is not None:
+        return node.get("resource_type") == "test"
+
+    return unique_id.startswith("test.")
+
+
+def _gate_event_from_dbt_result(
+    result: Mapping[str, object],
+    manifest: Mapping[str, object],
+) -> Mapping[str, object] | None:
+    unique_id = _dbt_result_unique_id(result)
+    if unique_id is None:
+        return None
+
+    asset_key = _dbt_asset_key_for_failed_test(unique_id, manifest)
+    if asset_key is None:
+        return None
+
+    node_name = _dbt_test_node_name(unique_id, result, manifest)
+    return {
+        "asset_key": asset_key,
+        "metadata": {
+            "node_info": {
+                "node_name": node_name,
+                "unique_id": unique_id,
+            },
+            "dbt_status": result.get("status"),
+            "dbt_message": result.get("message"),
+        },
+    }
+
+
+def _dbt_result_unique_id(result: Mapping[str, object]) -> str | None:
+    unique_id = result.get("unique_id")
+    if isinstance(unique_id, str) and unique_id:
+        return unique_id
+
+    node = result.get("node")
+    if isinstance(node, Mapping):
+        node_unique_id = node.get("unique_id")
+        if isinstance(node_unique_id, str) and node_unique_id:
+            return node_unique_id
+
+    return None
+
+
+def _dbt_test_node_name(
+    unique_id: str,
+    result: Mapping[str, object],
+    manifest: Mapping[str, object],
+) -> str:
+    for value in (result.get("node_name"), result.get("name")):
+        if isinstance(value, str) and value:
+            return value
+
+    node = _manifest_node(manifest, unique_id)
+    if node is not None:
+        name = node.get("name")
+        if isinstance(name, str) and name:
+            return name
+
+    return unique_id
+
+
+def _dbt_asset_key_for_failed_test(
+    unique_id: str,
+    manifest: Mapping[str, object],
+) -> str | None:
+    test_node = _manifest_node(manifest, unique_id)
+    for dependency_unique_id in _dbt_test_dependencies(test_node):
+        dependency_node = _manifest_node(manifest, dependency_unique_id)
+        if dependency_node is None:
+            continue
+        if dependency_node.get("resource_type") not in _DBT_ASSET_RESOURCE_TYPES:
+            continue
+
+        asset_key = _dbt_asset_key_for_node(dependency_node)
+        if asset_key is not None:
+            return asset_key
+
+    return None
+
+
+def _dbt_test_dependencies(test_node: Mapping[str, object] | None) -> tuple[str, ...]:
+    if test_node is None:
+        return ()
+
+    depends_on = test_node.get("depends_on")
+    if not isinstance(depends_on, Mapping):
+        return ()
+
+    nodes = depends_on.get("nodes")
+    if not isinstance(nodes, Sequence) or isinstance(nodes, (bytes, str)):
+        return ()
+
+    return tuple(node for node in nodes if isinstance(node, str) and node)
+
+
+def _dbt_asset_key_for_node(node: Mapping[str, object]) -> str | None:
+    dagster_meta = _dagster_meta_for_node(node)
+    for key in ("asset_key", "asset_key_path"):
+        if key not in dagster_meta:
+            continue
+        try:
+            return _stable_asset_key_string(dagster_meta[key])
+        except (TypeError, ValueError):
+            continue
+
+    resource_type = node.get("resource_type")
+    if resource_type == "source":
+        source_name = node.get("source_name")
+        name = node.get("name")
+        if (
+            isinstance(source_name, str)
+            and source_name
+            and isinstance(name, str)
+            and name
+        ):
+            return f"{source_name}/{name}"
+        return None
+
+    name = node.get("name")
+    if isinstance(name, str) and name:
+        return name
+
+    return None
+
+
+def _dagster_meta_for_node(node: Mapping[str, object]) -> Mapping[str, object]:
+    for parent_key in ("meta", "config"):
+        parent = node.get(parent_key)
+        if not isinstance(parent, Mapping):
+            continue
+
+        meta = parent.get("meta") if parent_key == "config" else parent
+        if not isinstance(meta, Mapping):
+            continue
+
+        dagster_meta = meta.get("dagster")
+        if isinstance(dagster_meta, Mapping):
+            return dagster_meta
+
+    return {}
+
+
+def _manifest_node(
+    manifest: Mapping[str, object],
+    unique_id: str,
+) -> Mapping[str, object] | None:
+    for key in ("nodes", "sources"):
+        section = manifest.get(key)
+        if not isinstance(section, Mapping):
+            continue
+
+        node = section.get(unique_id)
+        if isinstance(node, Mapping):
+            return node
+
+    return None
+
+
+def _required_event_asset_key(event: object) -> str:
+    asset_key = _extract_asset_key(event)
+    if asset_key is None:
+        raise ValueError("dbt failure event asset_key metadata is required")
+
+    return asset_key
+
+
+def _run_id_from_context(context: object) -> str:
+    run_id = _mapping_or_attr(context, "run_id")
+    if isinstance(run_id, str) and run_id:
+        return run_id
+
+    run = _mapping_or_attr(context, "run")
+    run_id = _mapping_or_attr(run, "run_id") if run is not None else None
+    if isinstance(run_id, str) and run_id:
+        return run_id
+
+    raise ValueError("Dagster context run_id is required for dbt partial rerun")
+
+
+def _cycle_id_from_context(context: object) -> str:
+    tags = _context_tags(context)
+    cycle_id = tags.get("cycle_id")
+    if isinstance(cycle_id, str) and cycle_id:
+        return cycle_id
+
+    return _run_id_from_context(context)
+
+
+def _context_tags(context: object) -> Mapping[str, object]:
+    tags = _mapping_or_attr(context, "run_tags")
+    if isinstance(tags, Mapping):
+        return tags
+
+    run = _mapping_or_attr(context, "run")
+    tags = _mapping_or_attr(run, "tags") if run is not None else None
+    if isinstance(tags, Mapping):
+        return tags
+
+    return {}
+
+
+def _dbt_failure_summary(event: object, failed_node: str) -> str:
+    metadata = _event_metadata(event)
+    message = metadata.get("dbt_message")
+    if isinstance(message, str) and message:
+        return message
+
+    node_name = _extract_dbt_node_name(event)
+    if node_name:
+        return f"dbt test failed for {node_name}"
+
+    return f"dbt test failed for asset {failed_node}"
+
+
+def _emit_gate_decision_observation(
+    *,
+    context: object,
+    decision: GateDecision,
+    failed_node: str,
+    event: object,
+    partial_rerun_plan: PartialRerunPlan | None,
+    rerun_request_path: Path | None,
+) -> None:
+    log_event = getattr(context, "log_event", None)
+    if not callable(log_event):
+        return
+
+    try:
+        from dagster import AssetKey, AssetObservation
+    except ModuleNotFoundError:
+        return
+
+    metadata = _gate_decision_metadata(
+        decision=decision,
+        event=event,
+        partial_rerun_plan=partial_rerun_plan,
+        rerun_request_path=rerun_request_path,
+    )
+    log_event(
+        AssetObservation(
+            asset_key=AssetKey.from_user_string(failed_node),
+            description="dbt test failure gate decision",
+            metadata=metadata,
+        ),
+    )
+
+
+def _gate_decision_metadata(
+    *,
+    decision: GateDecision,
+    event: object,
+    partial_rerun_plan: PartialRerunPlan | None,
+    rerun_request_path: Path | None,
+) -> dict[str, object]:
+    metadata: dict[str, object] = {
+        "phase": decision.phase.value,
+        "action": decision.action.value,
+        "failure_class": (
+            decision.failure_class.value if decision.failure_class is not None else ""
+        ),
+        "reason": decision.reason or "",
+        "dbt_node_name": _extract_dbt_node_name(event) or "",
+    }
+    if partial_rerun_plan is not None:
+        metadata["rerun_mode"] = partial_rerun_plan.rerun_mode
+        metadata["rerun_selection"] = json.dumps(
+            list(partial_rerun_plan.rerun_selection),
+        )
+        metadata["requires_manual_ack"] = partial_rerun_plan.requires_manual_ack
+    if rerun_request_path is not None:
+        metadata["rerun_request_path"] = str(rerun_request_path)
+
+    return metadata
+
+
+def _request_from_plan(plan: PartialRerunPlan) -> dict[str, Any]:
+    return {
+        "run_id": plan.run_id,
+        "failed_node": plan.failed_node,
+        "rerun_selection": list(plan.rerun_selection),
+        "requires_manual_ack": plan.requires_manual_ack,
+        "rerun_mode": plan.rerun_mode,
+        "generated_at": plan.generated_at.isoformat(),
+    }
+
+
+def _request_filename(run_id: str, failed_node: str) -> str:
+    return (
+        f"{_safe_filename_part(run_id)}-"
+        f"{_safe_filename_part(failed_node)}.json"
+    )
+
+
+def _safe_filename_part(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.=-]+", "_", value).strip("._") or "request"
+
+
+def _rerun_request_dir(request_dir: str | Path | None) -> Path:
+    if request_dir is not None:
+        return Path(request_dir)
+
+    return Path(os.environ.get(_RERUN_REQUEST_DIR_ENV, DEFAULT_REQUEST_DIR))
 
 
 def _validated_failed_node_from_event(
@@ -135,6 +685,14 @@ def _event_metadata(event: object) -> Mapping[str, object]:
         if isinstance(nested_metadata, Mapping):
             return nested_metadata
 
+        for nested_name in ("asset_check_evaluation", "evaluation"):
+            evaluation = _mapping_or_attr(event_specific_data, nested_name)
+            if evaluation is None:
+                continue
+            nested_metadata = _mapping_or_attr(evaluation, "metadata")
+            if isinstance(nested_metadata, Mapping):
+                return nested_metadata
+
     return {}
 
 
@@ -209,6 +767,10 @@ def _asset_key_path(asset_key: object) -> tuple[str, ...]:
 
 
 __all__ = [
+    "DbtFailureHandlingResult",
     "classify_dbt_test_failure",
+    "handle_dbt_test_failure",
     "plan_dbt_test_partial_rerun",
+    "stream_dbt_build_events",
+    "write_dbt_partial_rerun_request",
 ]

--- a/src/orchestrator/checks/dbt_events.py
+++ b/src/orchestrator/checks/dbt_events.py
@@ -53,34 +53,55 @@ def stream_dbt_build_events(
 ) -> Iterator[object]:
     """Stream dbt events and handle failed dbt tests through the gate pipeline."""
 
-    failure_event: object | None = None
+    failure_events: list[object] = []
     try:
         for event in _stream_dbt_invocation(dbt_invocation):
-            if failure_event is None:
-                failure_event = _dbt_test_failure_from_stream_event(event)
+            failure_event = _dbt_test_failure_from_stream_event(event)
+            if failure_event is not None:
+                _append_unique_dbt_failure_event(failure_events, failure_event)
             yield event
     except Exception:
-        failure_event = failure_event or _dbt_test_failure_from_artifacts(
-            dbt_invocation,
-            manifest_path=manifest_path,
+        _append_unique_dbt_failure_events(
+            failure_events,
+            _dbt_test_failures_from_artifacts(
+                dbt_invocation,
+                manifest_path=manifest_path,
+            ),
         )
-        if failure_event is not None:
-            handle_dbt_test_failure(
-                context=context,
-                event=failure_event,
-                policy=policy,
-                request_dir=request_dir,
-            )
+        _handle_dbt_test_failures(
+            context=context,
+            events=failure_events,
+            policy=policy,
+            request_dir=request_dir,
+        )
         raise
 
-    failure_event = failure_event or _dbt_test_failure_from_artifacts(
-        dbt_invocation,
-        manifest_path=manifest_path,
+    _append_unique_dbt_failure_events(
+        failure_events,
+        _dbt_test_failures_from_artifacts(
+            dbt_invocation,
+            manifest_path=manifest_path,
+        ),
     )
-    if failure_event is not None:
+    _handle_dbt_test_failures(
+        context=context,
+        events=failure_events,
+        policy=policy,
+        request_dir=request_dir,
+    )
+
+
+def _handle_dbt_test_failures(
+    *,
+    context: object,
+    events: Sequence[object],
+    policy: GatePolicyProfile,
+    request_dir: str | Path | None,
+) -> None:
+    for event in events:
         handle_dbt_test_failure(
             context=context,
-            event=failure_event,
+            event=event,
             policy=policy,
             request_dir=request_dir,
         )
@@ -229,9 +250,21 @@ def _dbt_test_failure_from_artifacts(
     *,
     manifest_path: str | Path | None,
 ) -> object | None:
+    failure_events = _dbt_test_failures_from_artifacts(
+        dbt_invocation,
+        manifest_path=manifest_path,
+    )
+    return failure_events[0] if failure_events else None
+
+
+def _dbt_test_failures_from_artifacts(
+    dbt_invocation: object,
+    *,
+    manifest_path: str | Path | None,
+) -> tuple[object, ...]:
     run_results = _dbt_artifact(dbt_invocation, "run_results.json")
     if not isinstance(run_results, Mapping):
-        return None
+        return ()
 
     manifest = _dbt_artifact(
         dbt_invocation,
@@ -239,21 +272,50 @@ def _dbt_test_failure_from_artifacts(
         fallback_path=manifest_path,
     )
     if not isinstance(manifest, Mapping):
-        return None
+        return ()
 
     results = run_results.get("results")
     if not isinstance(results, Sequence) or isinstance(results, (bytes, str)):
-        return None
+        return ()
 
+    failure_events: list[object] = []
     for result in results:
         if not _is_failed_dbt_test_result(result, manifest):
             continue
 
         event = _gate_event_from_dbt_result(result, manifest)
         if event is not None:
-            return event
+            _append_unique_dbt_failure_event(failure_events, event)
 
-    return None
+    return tuple(failure_events)
+
+
+def _append_unique_dbt_failure_events(
+    target: list[object],
+    events: Sequence[object],
+) -> None:
+    for event in events:
+        _append_unique_dbt_failure_event(target, event)
+
+
+def _append_unique_dbt_failure_event(target: list[object], event: object) -> None:
+    identity = _dbt_failure_identity(event)
+    if any(_dbt_failure_identity(existing) == identity for existing in target):
+        return
+
+    target.append(event)
+
+
+def _dbt_failure_identity(event: object) -> tuple[str, str]:
+    asset_key = _extract_asset_key(event)
+    if asset_key is not None:
+        return ("asset", asset_key)
+
+    node_name = _extract_dbt_node_name(event)
+    if node_name is not None:
+        return ("node", node_name)
+
+    return ("event", str(id(event)))
 
 
 def _dbt_artifact(

--- a/src/orchestrator/checks/dbt_events.py
+++ b/src/orchestrator/checks/dbt_events.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import tempfile
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -145,10 +146,28 @@ def write_dbt_partial_rerun_request(
     target_dir = _rerun_request_dir(request_dir)
     target_dir.mkdir(parents=True, exist_ok=True)
     request_path = target_dir / _request_filename(plan.run_id, plan.failed_node)
-    request_path.write_text(
-        json.dumps(_request_from_plan(plan), indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+    payload = json.dumps(_request_from_plan(plan), indent=2, sort_keys=True) + "\n"
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=target_dir,
+            prefix=f".{request_path.stem}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temp_file:
+            temp_path = Path(temp_file.name)
+            temp_file.write(payload)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+
+        os.replace(temp_path, request_path)
+        _fsync_directory(target_dir)
+    except Exception:
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
+        raise
 
     return request_path
 
@@ -607,6 +626,20 @@ def _rerun_request_dir(request_dir: str | Path | None) -> Path:
         return Path(request_dir)
 
     return Path(os.environ.get(_RERUN_REQUEST_DIR_ENV, DEFAULT_REQUEST_DIR))
+
+
+def _fsync_directory(path: Path) -> None:
+    try:
+        fd = os.open(path, os.O_RDONLY)
+    except OSError:
+        return
+
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
 
 
 def _validated_failed_node_from_event(

--- a/src/orchestrator/jobs/phase0.py
+++ b/src/orchestrator/jobs/phase0.py
@@ -9,6 +9,8 @@ from typing import Iterator
 from dagster import AssetExecutionContext, asset
 from dagster_dbt import DbtCliResource, dbt_assets
 
+from orchestrator.checks.dbt_events import stream_dbt_build_events
+from orchestrator.checks.resources import GatePolicyResource
 from orchestrator.jobs.phase0_constants import (
     PHASE0_CANDIDATE_FREEZE_ASSET_KEY,
     PHASE0_GROUP_NAME,
@@ -46,8 +48,9 @@ def phase0_readiness_ping() -> str:
 def dbt_phase0_assets(
     context: AssetExecutionContext,
     dbt: DbtCliResource,
+    gate_policy: GatePolicyResource,
 ) -> Iterator[object]:
-    yield from dbt.cli(
+    dbt_invocation = dbt.cli(
         [
             "build",
             "--project-dir",
@@ -56,7 +59,13 @@ def dbt_phase0_assets(
             str(DBT_PROFILES_DIR),
         ],
         context=context,
-    ).stream()
+    )
+    yield from stream_dbt_build_events(
+        context=context,
+        dbt_invocation=dbt_invocation,
+        policy=gate_policy.policy,
+        manifest_path=DBT_MANIFEST_PATH,
+    )
 
 
 __all__ = [

--- a/tests/checks/test_dbt_events.py
+++ b/tests/checks/test_dbt_events.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import logging
 from inspect import signature
 from pathlib import Path
 from typing import Any
@@ -8,7 +10,9 @@ import pytest
 
 from orchestrator.checks.dbt_events import (
     classify_dbt_test_failure,
+    handle_dbt_test_failure,
     plan_dbt_test_partial_rerun,
+    stream_dbt_build_events,
 )
 from orchestrator.policy import FailureClass, GateAction, PhaseEnum, load_gate_policy
 from orchestrator.rerun import PartialRerunNotAllowed
@@ -30,6 +34,41 @@ class MissingMetadataEvent:
     pass
 
 
+class FakeDagsterContext:
+    run_id = "run-dbt"
+    run_tags = {"cycle_id": "cycle-dbt"}
+
+    def __init__(self) -> None:
+        self.logged_events: list[object] = []
+
+    def log_event(self, event: object) -> None:
+        self.logged_events.append(event)
+
+
+class FailingDbtInvocation:
+    def stream(self) -> Any:
+        yield {"event": "dbt build started"}
+        raise RuntimeError("dbt build failed")
+
+    def get_artifact(self, artifact_name: str) -> object:
+        if artifact_name == "run_results.json":
+            return {
+                "results": [
+                    {
+                        "status": "fail",
+                        "unique_id": (
+                            "test.orchestrator_stub."
+                            "not_null_heartbeat_heartbeat"
+                        ),
+                        "message": "Got 1 result, configured to fail if != 0",
+                    },
+                ],
+            }
+        if artifact_name == "manifest.json":
+            return _manifest_for_heartbeat_test()
+        raise KeyError(artifact_name)
+
+
 @pytest.fixture
 def gate_policy() -> Any:
     return load_gate_policy(LITE_POLICY_PATH)
@@ -46,6 +85,71 @@ def test_dbt_adapter_signatures_match_issue_contract() -> None:
         "event",
         "policy",
     ]
+
+
+def test_handle_dbt_test_failure_dispatches_alert_and_writes_request(
+    caplog: pytest.LogCaptureFixture,
+    gate_policy: Any,
+    tmp_path: Path,
+) -> None:
+    event = _heartbeat_failure_event()
+    context = FakeDagsterContext()
+
+    with caplog.at_level(logging.WARNING):
+        result = handle_dbt_test_failure(
+            context=context,
+            event=event,
+            policy=gate_policy,
+            request_dir=tmp_path,
+        )
+
+    payload = _alert_payloads(caplog)[-1]
+    request_payload = json.loads(result.rerun_request_path.read_text())
+
+    assert result.decision.action is GateAction.PARTIAL_RERUN
+    assert result.partial_rerun_plan is not None
+    assert result.partial_rerun_plan.rerun_selection == ("heartbeat",)
+    assert request_payload["run_id"] == "run-dbt"
+    assert request_payload["failed_node"] == "heartbeat"
+    assert request_payload["rerun_selection"] == ["heartbeat"]
+    assert request_payload["requires_manual_ack"] is False
+    assert request_payload["rerun_mode"] == "asset_only"
+    assert payload["cycle_id"] == "cycle-dbt"
+    assert payload["phase"] == "phase0"
+    assert payload["failed_node"] == "heartbeat"
+    assert payload["action"] == "partial_rerun"
+    assert payload["failure_class"] == "task_level"
+
+
+def test_stream_dbt_build_events_handles_failed_test_artifact(
+    caplog: pytest.LogCaptureFixture,
+    gate_policy: Any,
+    tmp_path: Path,
+) -> None:
+    stream = stream_dbt_build_events(
+        context=FakeDagsterContext(),
+        dbt_invocation=FailingDbtInvocation(),
+        policy=gate_policy,
+        request_dir=tmp_path,
+    )
+
+    assert next(stream) == {"event": "dbt build started"}
+    with caplog.at_level(logging.WARNING), pytest.raises(
+        RuntimeError,
+        match="dbt build failed",
+    ):
+        next(stream)
+
+    payload = _alert_payloads(caplog)[-1]
+    request_files = list(tmp_path.glob("*.json"))
+    request_payload = json.loads(request_files[0].read_text())
+
+    assert payload["cycle_id"] == "cycle-dbt"
+    assert payload["failed_node"] == "heartbeat"
+    assert payload["action"] == "partial_rerun"
+    assert payload["failure_class"] == "task_level"
+    assert request_payload["failed_node"] == "heartbeat"
+    assert request_payload["rerun_selection"] == ["heartbeat"]
 
 
 def test_classify_dbt_test_failure_from_node_name(gate_policy: Any) -> None:
@@ -188,3 +292,46 @@ def _with_phase0_task_partial_allowed(
             ],
         },
     )
+
+
+def _heartbeat_failure_event() -> dict[str, object]:
+    return {
+        "asset_key": "heartbeat",
+        "metadata": {
+            "node_info": {
+                "node_name": "not_null_heartbeat_heartbeat",
+                "unique_id": "test.orchestrator_stub.not_null_heartbeat_heartbeat",
+            },
+            "dbt_message": "Got 1 result, configured to fail if != 0",
+        },
+    }
+
+
+def _manifest_for_heartbeat_test() -> dict[str, object]:
+    test_unique_id = "test.orchestrator_stub.not_null_heartbeat_heartbeat"
+    model_unique_id = "model.orchestrator_stub.heartbeat"
+
+    return {
+        "nodes": {
+            test_unique_id: {
+                "resource_type": "test",
+                "name": "not_null_heartbeat_heartbeat",
+                "unique_id": test_unique_id,
+                "depends_on": {"nodes": [model_unique_id]},
+            },
+            model_unique_id: {
+                "resource_type": "model",
+                "name": "heartbeat",
+                "unique_id": model_unique_id,
+            },
+        },
+    }
+
+
+def _alert_payloads(caplog: pytest.LogCaptureFixture) -> list[dict[str, object]]:
+    payloads: list[dict[str, object]] = []
+    for record in caplog.records:
+        if record.name != "orchestrator.alerting.dispatcher":
+            continue
+        payloads.append(json.loads(record.message))
+    return payloads

--- a/tests/checks/test_dbt_events.py
+++ b/tests/checks/test_dbt_events.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+from datetime import datetime, timezone
 from inspect import signature
 from pathlib import Path
 from typing import Any
@@ -13,9 +15,10 @@ from orchestrator.checks.dbt_events import (
     handle_dbt_test_failure,
     plan_dbt_test_partial_rerun,
     stream_dbt_build_events,
+    write_dbt_partial_rerun_request,
 )
 from orchestrator.policy import FailureClass, GateAction, PhaseEnum, load_gate_policy
-from orchestrator.rerun import PartialRerunNotAllowed
+from orchestrator.rerun import PartialRerunNotAllowed, PartialRerunPlan
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -150,6 +153,50 @@ def test_stream_dbt_build_events_handles_failed_test_artifact(
     assert payload["failure_class"] == "task_level"
     assert request_payload["failed_node"] == "heartbeat"
     assert request_payload["rerun_selection"] == ["heartbeat"]
+
+
+def test_write_dbt_partial_rerun_request_is_atomically_published(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import orchestrator.checks.dbt_events as dbt_events
+
+    real_replace = os.replace
+    sensor_visible_files_before_publish: list[Path] = []
+
+    def replace_spy(src: str | os.PathLike[str], dst: str | os.PathLike[str]) -> None:
+        temp_path = Path(src)
+        final_path = Path(dst)
+
+        assert temp_path.parent == tmp_path
+        assert temp_path.suffix == ".tmp"
+        assert final_path.suffix == ".json"
+
+        sensor_visible_files_before_publish.extend(tmp_path.glob("*.json"))
+        real_replace(src, dst)
+
+    monkeypatch.setattr(dbt_events.os, "replace", replace_spy)
+
+    request_path = write_dbt_partial_rerun_request(
+        PartialRerunPlan(
+            run_id="run-dbt",
+            failed_node="heartbeat",
+            rerun_selection=("heartbeat",),
+            requires_manual_ack=False,
+            generated_at=datetime(2026, 4, 16, tzinfo=timezone.utc),
+            rerun_mode="asset_only",
+        ),
+        request_dir=tmp_path,
+    )
+
+    assert request_path == tmp_path / "run-dbt-heartbeat.json"
+    assert not list(tmp_path.glob("*.tmp"))
+    assert not (tmp_path / ".failed").exists()
+    assert sensor_visible_files_before_publish == []
+
+    payload = json.loads(request_path.read_text(encoding="utf-8"))
+    assert payload["run_id"] == "run-dbt"
+    assert payload["failed_node"] == "heartbeat"
 
 
 def test_classify_dbt_test_failure_from_node_name(gate_policy: Any) -> None:

--- a/tests/checks/test_dbt_events.py
+++ b/tests/checks/test_dbt_events.py
@@ -72,6 +72,38 @@ class FailingDbtInvocation:
         raise KeyError(artifact_name)
 
 
+class MultiFailingDbtInvocation:
+    def stream(self) -> Any:
+        yield {"event": "dbt build started"}
+        raise RuntimeError("dbt build failed")
+
+    def get_artifact(self, artifact_name: str) -> object:
+        if artifact_name == "run_results.json":
+            return {
+                "results": [
+                    {
+                        "status": "fail",
+                        "unique_id": (
+                            "test.orchestrator_stub."
+                            "not_null_heartbeat_heartbeat"
+                        ),
+                        "message": "heartbeat is null",
+                    },
+                    {
+                        "status": "error",
+                        "unique_id": (
+                            "test.orchestrator_stub."
+                            "not_null_second_model_second_model"
+                        ),
+                        "message": "second_model test errored",
+                    },
+                ],
+            }
+        if artifact_name == "manifest.json":
+            return _manifest_for_two_failed_assets()
+        raise KeyError(artifact_name)
+
+
 @pytest.fixture
 def gate_policy() -> Any:
     return load_gate_policy(LITE_POLICY_PATH)
@@ -153,6 +185,44 @@ def test_stream_dbt_build_events_handles_failed_test_artifact(
     assert payload["failure_class"] == "task_level"
     assert request_payload["failed_node"] == "heartbeat"
     assert request_payload["rerun_selection"] == ["heartbeat"]
+
+
+def test_stream_dbt_build_events_handles_each_failed_asset_from_artifacts(
+    caplog: pytest.LogCaptureFixture,
+    gate_policy: Any,
+    tmp_path: Path,
+) -> None:
+    stream = stream_dbt_build_events(
+        context=FakeDagsterContext(),
+        dbt_invocation=MultiFailingDbtInvocation(),
+        policy=gate_policy,
+        request_dir=tmp_path,
+    )
+
+    assert next(stream) == {"event": "dbt build started"}
+    with caplog.at_level(logging.WARNING), pytest.raises(
+        RuntimeError,
+        match="dbt build failed",
+    ):
+        next(stream)
+
+    alert_failed_nodes = {
+        payload["failed_node"]
+        for payload in _alert_payloads(caplog)
+        if payload["action"] == "partial_rerun"
+    }
+    request_payloads = {
+        payload["failed_node"]: payload
+        for payload in (
+            json.loads(path.read_text(encoding="utf-8"))
+            for path in tmp_path.glob("*.json")
+        )
+    }
+
+    assert alert_failed_nodes == {"heartbeat", "second_model"}
+    assert set(request_payloads) == {"heartbeat", "second_model"}
+    assert request_payloads["heartbeat"]["rerun_selection"] == ["heartbeat"]
+    assert request_payloads["second_model"]["rerun_selection"] == ["second_model"]
 
 
 def test_write_dbt_partial_rerun_request_is_atomically_published(
@@ -370,6 +440,42 @@ def _manifest_for_heartbeat_test() -> dict[str, object]:
                 "resource_type": "model",
                 "name": "heartbeat",
                 "unique_id": model_unique_id,
+            },
+        },
+    }
+
+
+def _manifest_for_two_failed_assets() -> dict[str, object]:
+    heartbeat_test_unique_id = "test.orchestrator_stub.not_null_heartbeat_heartbeat"
+    heartbeat_model_unique_id = "model.orchestrator_stub.heartbeat"
+    second_test_unique_id = (
+        "test.orchestrator_stub.not_null_second_model_second_model"
+    )
+    second_model_unique_id = "model.orchestrator_stub.second_model"
+
+    return {
+        "nodes": {
+            heartbeat_test_unique_id: {
+                "resource_type": "test",
+                "name": "not_null_heartbeat_heartbeat",
+                "unique_id": heartbeat_test_unique_id,
+                "depends_on": {"nodes": [heartbeat_model_unique_id]},
+            },
+            heartbeat_model_unique_id: {
+                "resource_type": "model",
+                "name": "heartbeat",
+                "unique_id": heartbeat_model_unique_id,
+            },
+            second_test_unique_id: {
+                "resource_type": "test",
+                "name": "not_null_second_model_second_model",
+                "unique_id": second_test_unique_id,
+                "depends_on": {"nodes": [second_model_unique_id]},
+            },
+            second_model_unique_id: {
+                "resource_type": "model",
+                "name": "second_model",
+                "unique_id": second_model_unique_id,
             },
         },
     }

--- a/tests/integration/test_phase0_failure_matrix.py
+++ b/tests/integration/test_phase0_failure_matrix.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import json
 import logging
+import shutil
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -176,6 +179,82 @@ def test_dbt_test_failure_matrix_plans_only_failed_dbt_asset_group(
     assert "candidate_freeze" not in plan.rerun_selection
 
 
+def test_dbt_test_failure_from_dagster_run_emits_gate_outputs(
+    dagster_module: object,
+    dagster_dbt_module: object,
+    dagster_instance: object,
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    dagster = dagster_module
+    dagster_dbt = dagster_dbt_module
+    failing_project = _prepare_failing_dbt_project(tmp_path, tmp_dbt_project)
+    rerun_request_dir = tmp_path / "rerun_requests"
+    monkeypatch.setenv("ORCHESTRATOR_DBT_PROJECT_DIR", str(failing_project))
+    monkeypatch.setenv("ORCHESTRATOR_RERUN_REQUEST_DIR", str(rerun_request_dir))
+    _clear_phase0_imports()
+
+    try:
+        from orchestrator.checks.resources import GatePolicyResource
+        from orchestrator.jobs.phase0 import (
+            DBT_PROFILES_DIR,
+            DBT_PROJECT_DIR,
+            dbt_phase0_assets,
+        )
+
+        heartbeat_key = _heartbeat_asset_key(dbt_phase0_assets)
+        job = dagster.define_asset_job(
+            "dbt_failure_gate_job",
+            selection=dagster.AssetSelection.assets(heartbeat_key),
+        )
+        defs = dagster.Definitions(
+            assets=[dbt_phase0_assets],
+            jobs=[job],
+            resources={
+                "gate_policy": GatePolicyResource(policy_path=stub_policy_path),
+                "dbt": dagster_dbt.DbtCliResource(
+                    project_dir=str(DBT_PROJECT_DIR),
+                    profiles_dir=str(DBT_PROFILES_DIR),
+                ),
+            },
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = defs.get_job_def("dbt_failure_gate_job").execute_in_process(
+                instance=dagster_instance,
+                raise_on_error=False,
+            )
+    finally:
+        _clear_phase0_imports()
+
+    alert = _alert_payloads(caplog)[-1]
+    request_files = sorted(rerun_request_dir.glob("*.json"))
+    request_payload = json.loads(request_files[0].read_text(encoding="utf-8"))
+    observation = _gate_decision_observations(result)[-1]
+    heartbeat_node = heartbeat_key.to_user_string()
+
+    assert result.success is False
+    assert alert["cycle_id"] == _run_id_from_result(result)
+    assert alert["phase"] == "phase0"
+    assert alert["failed_node"] == heartbeat_node
+    assert alert["action"] == "partial_rerun"
+    assert alert["failure_class"] == "task_level"
+    assert request_payload["run_id"] == _run_id_from_result(result)
+    assert request_payload["failed_node"] == heartbeat_node
+    assert request_payload["rerun_selection"] == [heartbeat_node]
+    assert request_payload["requires_manual_ack"] is False
+    assert request_payload["rerun_mode"] == "asset_only"
+    assert metadata_value(observation, "phase") == "phase0"
+    assert metadata_value(observation, "action") == "partial_rerun"
+    assert metadata_value(observation, "failure_class") == "task_level"
+    assert json.loads(metadata_value(observation, "rerun_selection")) == [
+        heartbeat_node,
+    ]
+
+
 def test_manual_rerun_request_sensor_minimal_happy_path(
     dagster_module: object,
     tmp_path: Path,
@@ -256,3 +335,83 @@ def _heartbeat_asset_key(dbt_phase0_assets: object) -> object:
         if path and path[-1] == "heartbeat":
             return asset_key
     pytest.fail("dbt heartbeat model asset key was not registered")
+
+
+def _prepare_failing_dbt_project(tmp_path: Path, source_project: Path) -> Path:
+    project_dir = tmp_path / "failing_dbt_stub"
+    shutil.copytree(source_project, project_dir)
+    (project_dir / "models" / "phase0" / "heartbeat.sql").write_text(
+        "select cast(null as integer) as heartbeat\n",
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            "dbt",
+            "compile",
+            "--profiles-dir",
+            ".",
+            "--project-dir",
+            ".",
+        ],
+        cwd=project_dir,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+        timeout=45,
+    )
+    if completed.returncode != 0:
+        pytest.fail(f"dbt compile failed for failing fixture:\n{completed.stdout}")
+
+    return project_dir
+
+
+def _gate_decision_observations(result: object) -> list[object]:
+    observations: list[object] = []
+    for event in tuple(getattr(result, "all_events", ())):
+        if not (
+            getattr(event, "is_asset_observation", False)
+            or getattr(event, "event_type_value", None) == "ASSET_OBSERVATION"
+        ):
+            continue
+
+        event_specific_data = getattr(event, "event_specific_data", None)
+        observation = getattr(event_specific_data, "asset_observation", None)
+        if observation is None:
+            observation = getattr(event_specific_data, "observation", None)
+        if observation is None:
+            observation = getattr(event, "asset_observation", None)
+        if observation is None:
+            continue
+        try:
+            action = metadata_value(observation, "action")
+        except KeyError:
+            continue
+        if action == "partial_rerun":
+            observations.append(observation)
+
+    return observations
+
+
+def _run_id_from_result(result: object) -> str:
+    run_id = getattr(result, "run_id", None)
+    if isinstance(run_id, str) and run_id:
+        return run_id
+
+    dagster_run = getattr(result, "dagster_run", None)
+    run_id = getattr(dagster_run, "run_id", None)
+    if isinstance(run_id, str) and run_id:
+        return run_id
+
+    pytest.fail("Dagster execute_in_process result did not expose run_id")
+
+
+def _clear_phase0_imports() -> None:
+    for module_name in list(sys.modules):
+        if module_name == "orchestrator.definitions":
+            sys.modules.pop(module_name, None)
+        elif module_name == "orchestrator.jobs":
+            sys.modules.pop(module_name, None)
+        elif module_name.startswith("orchestrator.jobs."):
+            sys.modules.pop(module_name, None)


### PR DESCRIPTION
Closes #61

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/orchestrator/checks/dbt_events.py`, `src/orchestrator/sensors/manual_rerun.py`, `tests/integration/conftest.py`


---
## 背景与目标
Milestone review for milestone-1 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
classify_dbt_test_failure and plan_dbt_test_partial_rerun model the desired policy result, but dbt_phase0_assets still only streams dbt build events. No hook, sensor, event-log consumer, or asset check connects an actual dbt test failure to GateDecision classification, alert dispatch, or rerun request creation. The integration test calls the adapter directly rather than inducing a failing dbt test inside Dagster.

## 实现范围
- 修改文件: `src/orchestrator/checks/dbt_events.py`
- Wire dbt failure events into the same gate pipeline used by readiness and llm_health_check. Add a failing dbt integration fixture that verifies the emitted GateDecision, alert payload, and partial rerun plan or request from an actual Dagster run.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
python3 -m pytest
```
