### PR TITLE
feat(#20): Phase 1 graph-engine asset 接入

### DIFF
--- a/src/orchestrator/definitions.py
+++ b/src/orchestrator/definitions.py
@@ -23,6 +23,7 @@ from orchestrator.jobs.phase0 import (
     DBT_PROJECT_DIR,
     PHASE0_CANDIDATE_FREEZE_ASSET_KEY,
     PHASE0_GROUP_NAME,
+    PHASE0_READINESS_ASSET_KEY,
     dbt_phase0_assets,
     phase0_readiness_ping,
 )
@@ -285,6 +286,12 @@ def _validate_phase1_provider_assets(provider_assets: Iterable[object]) -> None:
         AssetKey([PHASE1_GRAPH_PROMOTION_ASSET_KEY]),
         AssetKey([PHASE1_GRAPH_SNAPSHOT_ASSET_KEY]),
     )
+    required_phase0_dependency_keys = frozenset(
+        {
+            AssetKey([PHASE0_READINESS_ASSET_KEY]),
+            AssetKey([PHASE0_CANDIDATE_FREEZE_ASSET_KEY]),
+        },
+    )
     required_asset_key_names = {
         asset_key: asset_key.path[-1] for asset_key in required_asset_keys
     }
@@ -302,12 +309,30 @@ def _validate_phase1_provider_assets(provider_assets: Iterable[object]) -> None:
                     f"{asset_key_name} asset must declare "
                     f"group_name={PHASE1_GROUP_NAME!r}; got {group_name!r}",
                 )
+            if asset_key == AssetKey([PHASE1_GRAPH_PROMOTION_ASSET_KEY]):
+                dependency_keys = _asset_dependency_keys(asset_def, asset_key)
+                missing_dependency_keys = required_phase0_dependency_keys.difference(
+                    dependency_keys,
+                )
+                if missing_dependency_keys:
+                    dependency_names = ", ".join(
+                        sorted(
+                            key.to_user_string()
+                            for key in missing_dependency_keys
+                        ),
+                    )
+                    raise ValueError(
+                        "phase1 graph_promotion asset must depend on a Phase 0 "
+                        "gate asset before it can be included in daily_cycle_job. "
+                        f"Missing: {dependency_names}.",
+                    )
 
 
 def _requires_milestone_surface() -> bool:
-    return _is_milestone_surface_profile() or _is_env_truthy(
-        _REQUIRE_MILESTONE_SURFACE_ENV,
-    )
+    forced = os.environ.get(_REQUIRE_MILESTONE_SURFACE_ENV)
+    if forced is not None:
+        return forced.strip().lower() in _TRUTHY_ENV_VALUES
+    return _is_milestone_surface_profile()
 
 
 def _requires_phase1_surface() -> bool:
@@ -389,6 +414,27 @@ def _validate_phase1_surface(provider_assets: Iterable[object]) -> None:
             "assets that satisfy the graph promotion/snapshot contract. "
             f"Missing: {missing_items}.",
         )
+
+
+def _asset_dependency_keys(
+    asset_def: object,
+    asset_key: AssetKey,
+) -> frozenset[AssetKey]:
+    dependency_keys: set[AssetKey] = set()
+    for attribute_name in (
+        "asset_deps",
+        "dependency_keys_by_key",
+        "deps_by_key",
+    ):
+        dependency_mapping = getattr(asset_def, attribute_name, None)
+        if isinstance(dependency_mapping, Mapping):
+            dependency_keys.update(dependency_mapping.get(asset_key, ()))
+
+    raw_dependency_keys = getattr(asset_def, "dependency_keys", ())
+    if raw_dependency_keys:
+        dependency_keys.update(raw_dependency_keys)
+
+    return frozenset(dependency_keys)
 
 
 def _data_readiness_resource(resources: Mapping[str, object]) -> object:

--- a/src/orchestrator/definitions.py
+++ b/src/orchestrator/definitions.py
@@ -26,6 +26,11 @@ from orchestrator.jobs.phase0 import (
     dbt_phase0_assets,
     phase0_readiness_ping,
 )
+from orchestrator.jobs.phase1 import (
+    PHASE1_GRAPH_PROMOTION_ASSET_KEY,
+    PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
+    PHASE1_GROUP_NAME,
+)
 from orchestrator.resources import AssetFactoryProvider, build_resource_bundle
 from orchestrator.schedules import daily_cycle_schedule
 from orchestrator.sensors.data_readiness import (
@@ -46,9 +51,33 @@ _MILESTONE_SURFACE_PROFILES = frozenset(
     {
         "milestone",
         "milestone-1",
+        "milestone-2",
+        "milestone-3",
+        "milestone-4",
         "p1b",
         "p1c",
+        "p2",
+        "p3",
+        "p5",
+        "p5+",
         "phase0",
+        "phase1",
+        "phase2",
+        "phase3",
+    }
+)
+_PHASE1_SURFACE_PROFILES = frozenset(
+    {
+        "milestone-2",
+        "milestone-3",
+        "milestone-4",
+        "p2",
+        "p3",
+        "p5",
+        "p5+",
+        "phase1",
+        "phase2",
+        "phase3",
     }
 )
 _TRUTHY_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
@@ -113,8 +142,11 @@ def build_definitions(
         for asset in module_factory.get_assets()
     ]
     _validate_phase0_provider_assets(provider_assets)
+    _validate_phase1_provider_assets(provider_assets)
     if _requires_milestone_surface():
         _validate_milestone_surface(provider_assets, resource_bundle.resources)
+    if _requires_phase1_surface():
+        _validate_phase1_surface(provider_assets)
     provider_checks = [
         check
         for module_factory in module_factory_list
@@ -248,17 +280,54 @@ def _validate_phase0_provider_assets(provider_assets: Iterable[object]) -> None:
         )
 
 
-def _requires_milestone_surface() -> bool:
-    forced = os.environ.get(_REQUIRE_MILESTONE_SURFACE_ENV)
-    if forced is not None:
-        return forced.strip().lower() in _TRUTHY_ENV_VALUES
+def _validate_phase1_provider_assets(provider_assets: Iterable[object]) -> None:
+    required_asset_keys = (
+        AssetKey([PHASE1_GRAPH_PROMOTION_ASSET_KEY]),
+        AssetKey([PHASE1_GRAPH_SNAPSHOT_ASSET_KEY]),
+    )
+    required_asset_key_names = {
+        asset_key: asset_key.path[-1] for asset_key in required_asset_keys
+    }
 
+    for asset_def in provider_assets:
+        keys = tuple(getattr(asset_def, "keys", ()))
+        group_names = getattr(asset_def, "group_names_by_key", {})
+        for asset_key in required_asset_keys:
+            if asset_key not in keys:
+                continue
+            group_name = group_names.get(asset_key)
+            if group_name != PHASE1_GROUP_NAME:
+                asset_key_name = required_asset_key_names[asset_key]
+                raise ValueError(
+                    f"{asset_key_name} asset must declare "
+                    f"group_name={PHASE1_GROUP_NAME!r}; got {group_name!r}",
+                )
+
+
+def _requires_milestone_surface() -> bool:
+    return _is_milestone_surface_profile() or _is_env_truthy(
+        _REQUIRE_MILESTONE_SURFACE_ENV,
+    )
+
+
+def _requires_phase1_surface() -> bool:
+    return _normalized_definitions_profile() in _PHASE1_SURFACE_PROFILES
+
+
+def _is_milestone_surface_profile() -> bool:
+    return _normalized_definitions_profile() in _MILESTONE_SURFACE_PROFILES
+
+
+def _normalized_definitions_profile() -> str:
     profile = os.environ.get(_DEFINITIONS_PROFILE_ENV) or os.environ.get(
         _PROFILE_ENV,
         "",
     )
-    normalized_profile = profile.strip().lower().replace("_", "-")
-    return normalized_profile in _MILESTONE_SURFACE_PROFILES
+    return profile.strip().lower().replace("_", "-")
+
+
+def _is_env_truthy(env_key: str) -> bool:
+    return os.environ.get(env_key, "").strip().lower() in _TRUTHY_ENV_VALUES
 
 
 def _validate_milestone_surface(
@@ -291,6 +360,33 @@ def _validate_milestone_surface(
             "reasoner-runtime module factories. Configure "
             f"{_MODULE_FACTORIES_ENV} with 'module:attribute' import paths, or "
             "pass module_factories explicitly to build_definitions(). "
+            f"Missing: {missing_items}.",
+        )
+
+
+def _validate_phase1_surface(provider_assets: Iterable[object]) -> None:
+    required_asset_keys = {
+        AssetKey([PHASE1_GRAPH_PROMOTION_ASSET_KEY]): "graph_promotion asset",
+        AssetKey([PHASE1_GRAPH_SNAPSHOT_ASSET_KEY]): "graph_snapshot asset",
+    }
+    phase1_asset_keys = {
+        asset_key
+        for asset_def in provider_assets
+        for asset_key in getattr(asset_def, "keys", ())
+        if getattr(asset_def, "group_names_by_key", {}).get(asset_key)
+        == PHASE1_GROUP_NAME
+    }
+    missing = [
+        contract_name
+        for asset_key, contract_name in required_asset_keys.items()
+        if asset_key not in phase1_asset_keys
+    ]
+
+    if missing:
+        missing_items = ", ".join(missing)
+        raise ValueError(
+            "phase1 milestone Definitions assembly requires graph provider "
+            "assets that satisfy the graph promotion/snapshot contract. "
             f"Missing: {missing_items}.",
         )
 

--- a/src/orchestrator/definitions.py
+++ b/src/orchestrator/definitions.py
@@ -282,10 +282,9 @@ def _validate_phase0_provider_assets(provider_assets: Iterable[object]) -> None:
 
 
 def _validate_phase1_provider_assets(provider_assets: Iterable[object]) -> None:
-    required_asset_keys = (
-        AssetKey([PHASE1_GRAPH_PROMOTION_ASSET_KEY]),
-        AssetKey([PHASE1_GRAPH_SNAPSHOT_ASSET_KEY]),
-    )
+    graph_promotion_key = AssetKey([PHASE1_GRAPH_PROMOTION_ASSET_KEY])
+    graph_snapshot_key = AssetKey([PHASE1_GRAPH_SNAPSHOT_ASSET_KEY])
+    required_asset_keys = (graph_promotion_key, graph_snapshot_key)
     required_phase0_dependency_keys = frozenset(
         {
             AssetKey([PHASE0_READINESS_ASSET_KEY]),
@@ -295,10 +294,14 @@ def _validate_phase1_provider_assets(provider_assets: Iterable[object]) -> None:
     required_asset_key_names = {
         asset_key: asset_key.path[-1] for asset_key in required_asset_keys
     }
+    phase1_asset_defs: dict[AssetKey, object] = {}
 
     for asset_def in provider_assets:
         keys = tuple(getattr(asset_def, "keys", ()))
         group_names = getattr(asset_def, "group_names_by_key", {})
+        for asset_key in keys:
+            if group_names.get(asset_key) == PHASE1_GROUP_NAME:
+                phase1_asset_defs[asset_key] = asset_def
         for asset_key in required_asset_keys:
             if asset_key not in keys:
                 continue
@@ -309,29 +312,42 @@ def _validate_phase1_provider_assets(provider_assets: Iterable[object]) -> None:
                     f"{asset_key_name} asset must declare "
                     f"group_name={PHASE1_GROUP_NAME!r}; got {group_name!r}",
                 )
-            if asset_key == AssetKey([PHASE1_GRAPH_PROMOTION_ASSET_KEY]):
-                dependency_keys = _asset_dependency_keys(asset_def, asset_key)
-                missing_dependency_keys = required_phase0_dependency_keys.difference(
-                    dependency_keys,
-                )
-                if missing_dependency_keys:
-                    dependency_names = ", ".join(
-                        sorted(
-                            key.to_user_string()
-                            for key in missing_dependency_keys
-                        ),
-                    )
-                    raise ValueError(
-                        "phase1 graph_promotion asset must depend on a Phase 0 "
-                        "gate asset before it can be included in daily_cycle_job. "
-                        f"Missing: {dependency_names}.",
-                    )
+
+    phase1_asset_keys = frozenset(phase1_asset_defs)
+    for asset_key in phase1_asset_defs:
+        if _has_required_dependency_ancestry(
+            asset_key,
+            phase1_asset_defs,
+            required_phase0_dependency_keys,
+            phase1_asset_keys,
+            seen=frozenset(),
+        ):
+            continue
+
+        if asset_key == graph_snapshot_key:
+            raise ValueError(
+                "phase1 graph_snapshot asset must depend on graph_promotion "
+                "or directly on Phase 0 gate assets before it can be included "
+                "in daily_cycle_job. Missing Phase 0 ancestry: "
+                f"{_asset_key_names(required_phase0_dependency_keys)}.",
+            )
+        if asset_key == graph_promotion_key:
+            raise ValueError(
+                "phase1 graph_promotion asset must depend on Phase 0 gate "
+                "assets before it can be included in daily_cycle_job. Missing: "
+                f"{_asset_key_names(required_phase0_dependency_keys)}.",
+            )
+        raise ValueError(
+            "phase1 provider asset must depend on Phase 0 gate assets directly "
+            "or through another phase1 asset before it can be included in "
+            f"daily_cycle_job. Asset: {asset_key.to_user_string()}.",
+        )
 
 
 def _requires_milestone_surface() -> bool:
     forced = os.environ.get(_REQUIRE_MILESTONE_SURFACE_ENV)
     if forced is not None:
-        return forced.strip().lower() in _TRUTHY_ENV_VALUES
+        return _is_env_truthy(_REQUIRE_MILESTONE_SURFACE_ENV)
     return _is_milestone_surface_profile()
 
 
@@ -435,6 +451,39 @@ def _asset_dependency_keys(
         dependency_keys.update(raw_dependency_keys)
 
     return frozenset(dependency_keys)
+
+
+def _has_required_dependency_ancestry(
+    asset_key: AssetKey,
+    phase1_asset_defs: Mapping[AssetKey, object],
+    required_dependency_keys: frozenset[AssetKey],
+    phase1_asset_keys: frozenset[AssetKey],
+    *,
+    seen: frozenset[AssetKey],
+) -> bool:
+    if asset_key in seen:
+        return False
+
+    asset_def = phase1_asset_defs[asset_key]
+    dependency_keys = _asset_dependency_keys(asset_def, asset_key)
+    if required_dependency_keys.issubset(dependency_keys):
+        return True
+
+    next_seen = seen | frozenset({asset_key})
+    return any(
+        _has_required_dependency_ancestry(
+            dependency_key,
+            phase1_asset_defs,
+            required_dependency_keys,
+            phase1_asset_keys,
+            seen=next_seen,
+        )
+        for dependency_key in dependency_keys.intersection(phase1_asset_keys)
+    )
+
+
+def _asset_key_names(asset_keys: Iterable[AssetKey]) -> str:
+    return ", ".join(sorted(asset_key.to_user_string() for asset_key in asset_keys))
 
 
 def _data_readiness_resource(resources: Mapping[str, object]) -> object:

--- a/src/orchestrator/jobs/__init__.py
+++ b/src/orchestrator/jobs/__init__.py
@@ -9,12 +9,20 @@ from orchestrator.jobs.phase0 import (
     dbt_phase0_assets,
     phase0_readiness_ping,
 )
+from orchestrator.jobs.phase1 import (
+    PHASE1_GRAPH_PROMOTION_ASSET_KEY,
+    PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
+    PHASE1_GROUP_NAME,
+)
 
 __all__ = [
     "PHASE0_CANDIDATE_FREEZE_ASSET_KEY",
     "PHASE0_GROUP_NAME",
     "PHASE0_READINESS_ASSET_KEY",
     "PHASE0_REQUIRED_ASSET_KEYS",
+    "PHASE1_GRAPH_PROMOTION_ASSET_KEY",
+    "PHASE1_GRAPH_SNAPSHOT_ASSET_KEY",
+    "PHASE1_GROUP_NAME",
     "build_daily_cycle_jobs",
     "daily_cycle_job",
     "dbt_phase0_assets",

--- a/src/orchestrator/jobs/cycle.py
+++ b/src/orchestrator/jobs/cycle.py
@@ -6,18 +6,19 @@ from typing import Any
 from dagster import AssetSelection, define_asset_job
 
 from orchestrator.jobs.phase0_constants import PHASE0_GROUP_NAME
+from orchestrator.jobs.phase1 import PHASE1_GROUP_NAME
 
 
 daily_cycle_job = define_asset_job(
     name="daily_cycle_job",
-    selection=AssetSelection.groups(PHASE0_GROUP_NAME),
+    selection=AssetSelection.groups(PHASE0_GROUP_NAME, PHASE1_GROUP_NAME),
 )
 
 
 def build_daily_cycle_jobs(
     phase_config: Mapping[str, Any] | None,
 ) -> tuple[object, ...]:
-    """Build P1a daily cycle jobs from the phase configuration facade."""
+    """Build daily cycle jobs from the phase configuration facade."""
 
     return (daily_cycle_job,)
 

--- a/src/orchestrator/jobs/phase1.py
+++ b/src/orchestrator/jobs/phase1.py
@@ -1,0 +1,11 @@
+"""Phase 1 graph asset group contract constants."""
+
+PHASE1_GROUP_NAME: str = "phase1"
+PHASE1_GRAPH_PROMOTION_ASSET_KEY: str = "graph_promotion"
+PHASE1_GRAPH_SNAPSHOT_ASSET_KEY: str = "graph_snapshot"
+
+__all__ = [
+    "PHASE1_GRAPH_PROMOTION_ASSET_KEY",
+    "PHASE1_GRAPH_SNAPSHOT_ASSET_KEY",
+    "PHASE1_GROUP_NAME",
+]

--- a/tests/integration/test_phase1_graph_provider_wiring.py
+++ b/tests/integration/test_phase1_graph_provider_wiring.py
@@ -24,11 +24,12 @@ def test_phase1_graph_provider_contributes_daily_cycle_selection(
         PHASE1_GROUP_NAME,
     )
 
+    phase0_provider = _fake_phase0_surface_provider(dagster)
     provider, graph_promotion, graph_snapshot, _graph_check = (
         _fake_graph_provider(dagster)
     )
     defs = build_definitions(
-        module_factories=[provider],
+        module_factories=[phase0_provider, provider],
         policy_path=stub_policy_path,
     )
 
@@ -40,6 +41,7 @@ def test_phase1_graph_provider_contributes_daily_cycle_selection(
         [
             phase0_readiness_ping,
             dbt_phase0_assets,
+            *phase0_provider.get_assets(),
             graph_promotion,
             graph_snapshot,
         ],
@@ -56,7 +58,12 @@ def test_phase1_graph_provider_contributes_daily_cycle_selection(
     assert "fake_graph_snapshot_check" in _check_names(defs)
 
     result = dagster.materialize(
-        [graph_promotion, graph_snapshot],
+        [
+            phase0_readiness_ping,
+            *phase0_provider.get_assets(),
+            graph_promotion,
+            graph_snapshot,
+        ],
         instance=dagster_instance,
     )
 
@@ -83,17 +90,53 @@ def test_milestone2_missing_phase1_contract_is_rejected(
         )
 
 
-def _fake_graph_provider(dagster: Any) -> tuple[object, object, object, object]:
+def test_phase1_graph_promotion_without_phase0_dependency_is_rejected(
+    dagster_module: object,
+    dagster_dbt_module: object,
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+) -> None:
+    dagster = dagster_module
+
+    from orchestrator.definitions import build_definitions
+
+    provider, _graph_promotion, _graph_snapshot, _graph_check = _fake_graph_provider(
+        dagster,
+        include_phase0_dependency=False,
+    )
+
+    with pytest.raises(ValueError, match="phase1 graph_promotion.*Phase 0"):
+        build_definitions(
+            module_factories=[provider],
+            policy_path=stub_policy_path,
+        )
+
+
+def _fake_graph_provider(
+    dagster: Any,
+    *,
+    include_phase0_dependency: bool = True,
+) -> tuple[object, object, object, object]:
+    from orchestrator.jobs.phase0 import (
+        PHASE0_CANDIDATE_FREEZE_ASSET_KEY,
+        PHASE0_READINESS_ASSET_KEY,
+    )
     from orchestrator.jobs.phase1 import (
         PHASE1_GRAPH_PROMOTION_ASSET_KEY,
         PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
         PHASE1_GROUP_NAME,
     )
+    promotion_asset_kwargs: dict[str, object] = {
+        "name": PHASE1_GRAPH_PROMOTION_ASSET_KEY,
+        "group_name": PHASE1_GROUP_NAME,
+    }
+    if include_phase0_dependency:
+        promotion_asset_kwargs["deps"] = [
+            dagster.AssetKey([PHASE0_READINESS_ASSET_KEY]),
+            dagster.AssetKey([PHASE0_CANDIDATE_FREEZE_ASSET_KEY]),
+        ]
 
-    @dagster.asset(
-        name=PHASE1_GRAPH_PROMOTION_ASSET_KEY,
-        group_name=PHASE1_GROUP_NAME,
-    )
+    @dagster.asset(**promotion_asset_kwargs)
     def graph_promotion() -> str:
         return "promoted"
 

--- a/tests/integration/test_phase1_graph_provider_wiring.py
+++ b/tests/integration/test_phase1_graph_provider_wiring.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+
+def test_phase1_graph_provider_contributes_daily_cycle_selection(
+    dagster_module: object,
+    dagster_dbt_module: object,
+    dagster_instance: object,
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+) -> None:
+    dagster = dagster_module
+
+    from orchestrator.definitions import build_definitions
+    from orchestrator.jobs.cycle import daily_cycle_job
+    from orchestrator.jobs.phase0 import dbt_phase0_assets, phase0_readiness_ping
+    from orchestrator.jobs.phase1 import (
+        PHASE1_GRAPH_PROMOTION_ASSET_KEY,
+        PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
+        PHASE1_GROUP_NAME,
+    )
+
+    provider, graph_promotion, graph_snapshot, _graph_check = (
+        _fake_graph_provider(dagster)
+    )
+    defs = build_definitions(
+        module_factories=[provider],
+        policy_path=stub_policy_path,
+    )
+
+    dagster.Definitions.validate_loadable(defs)
+
+    promotion_key = dagster.AssetKey([PHASE1_GRAPH_PROMOTION_ASSET_KEY])
+    snapshot_key = dagster.AssetKey([PHASE1_GRAPH_SNAPSHOT_ASSET_KEY])
+    selected_keys = daily_cycle_job.selection.resolve(
+        [
+            phase0_readiness_ping,
+            dbt_phase0_assets,
+            graph_promotion,
+            graph_snapshot,
+        ],
+    )
+
+    assert dagster.AssetKey(["phase0_readiness_ping"]) in selected_keys
+    assert _heartbeat_asset_key(dbt_phase0_assets) in selected_keys
+    assert promotion_key in selected_keys
+    assert snapshot_key in selected_keys
+    assert _phase1_asset_keys(defs, PHASE1_GROUP_NAME) == {
+        promotion_key,
+        snapshot_key,
+    }
+    assert "fake_graph_snapshot_check" in _check_names(defs)
+
+    result = dagster.materialize(
+        [graph_promotion, graph_snapshot],
+        instance=dagster_instance,
+    )
+
+    assert result.success is True
+
+
+def test_milestone2_missing_phase1_contract_is_rejected(
+    dagster_module: object,
+    dagster_dbt_module: object,
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dagster = dagster_module
+
+    from orchestrator.definitions import build_definitions
+
+    monkeypatch.setenv("ORCHESTRATOR_DEFINITIONS_PROFILE", "milestone-2")
+
+    with pytest.raises(ValueError, match="phase1.*contract"):
+        build_definitions(
+            module_factories=[_fake_phase0_surface_provider(dagster)],
+            policy_path=stub_policy_path,
+        )
+
+
+def _fake_graph_provider(dagster: Any) -> tuple[object, object, object, object]:
+    from orchestrator.jobs.phase1 import (
+        PHASE1_GRAPH_PROMOTION_ASSET_KEY,
+        PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
+        PHASE1_GROUP_NAME,
+    )
+
+    @dagster.asset(
+        name=PHASE1_GRAPH_PROMOTION_ASSET_KEY,
+        group_name=PHASE1_GROUP_NAME,
+    )
+    def graph_promotion() -> str:
+        return "promoted"
+
+    @dagster.asset(
+        name=PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
+        group_name=PHASE1_GROUP_NAME,
+    )
+    def graph_snapshot(graph_promotion: str) -> str:
+        return f"snapshot:{graph_promotion}"
+
+    @dagster.asset_check(
+        asset=graph_snapshot,
+        name="fake_graph_snapshot_check",
+    )
+    def fake_graph_snapshot_check() -> object:
+        return dagster.AssetCheckResult(passed=True)
+
+    class FakeGraphProvider:
+        def get_assets(self) -> tuple[object, ...]:
+            return (graph_promotion, graph_snapshot)
+
+        def get_checks(self) -> tuple[object, ...]:
+            return (fake_graph_snapshot_check,)
+
+        def get_resources(self) -> dict[str, object]:
+            return {}
+
+    return (
+        FakeGraphProvider(),
+        graph_promotion,
+        graph_snapshot,
+        fake_graph_snapshot_check,
+    )
+
+
+def _fake_phase0_surface_provider(dagster: Any) -> object:
+    from orchestrator.checks import DataReadinessSignal
+    from orchestrator.sensors.data_readiness import DATA_READINESS_RESOURCE_KEY
+
+    class FakeDataReadinessProvider:
+        def get_data_readiness_signal(self) -> DataReadinessSignal:
+            return DataReadinessSignal(ready=True, cycle_id="cycle-20260416")
+
+    class FakeDataReadinessResource(dagster.ConfigurableResource):
+        def create_resource(self, context: object) -> FakeDataReadinessProvider:
+            return FakeDataReadinessProvider()
+
+    class FakeLLMHealthResult:
+        healthy = True
+        summary = "provider ready"
+        provider = "fake-llm"
+
+    class FakeLLMHealthProbe:
+        def check_health(self) -> FakeLLMHealthResult:
+            return FakeLLMHealthResult()
+
+    class FakeLLMHealthProbeResource(dagster.ConfigurableResource):
+        def create_resource(self, context: object) -> FakeLLMHealthProbe:
+            return FakeLLMHealthProbe()
+
+    @dagster.asset(name="candidate_freeze", group_name="phase0")
+    def candidate_freeze() -> str:
+        return "ok"
+
+    class FakePhase0SurfaceProvider:
+        def get_assets(self) -> tuple[object, ...]:
+            return (candidate_freeze,)
+
+        def get_checks(self) -> tuple[object, ...]:
+            return ()
+
+        def get_resources(self) -> dict[str, object]:
+            return {
+                DATA_READINESS_RESOURCE_KEY: cast(
+                    object,
+                    FakeDataReadinessResource(),
+                ),
+                "llm_health_probe": cast(object, FakeLLMHealthProbeResource()),
+            }
+
+    return FakePhase0SurfaceProvider()
+
+
+def _heartbeat_asset_key(dbt_phase0_assets: object) -> object:
+    for asset_key in getattr(dbt_phase0_assets, "keys", ()):
+        path = tuple(getattr(asset_key, "path", ()))
+        if path and path[-1] == "heartbeat":
+            return asset_key
+    pytest.fail("dbt heartbeat model asset key was not registered")
+
+
+def _phase1_asset_keys(defs: Any, phase1_group_name: str) -> set[object]:
+    return {
+        asset_key
+        for asset_def in defs.assets or ()
+        for asset_key in getattr(asset_def, "keys", ())
+        if getattr(asset_def, "group_names_by_key", {}).get(asset_key)
+        == phase1_group_name
+    }
+
+
+def _check_names(defs: Any) -> set[str]:
+    names: set[str] = set()
+    for check_def in defs.asset_checks or ():
+        names.update(
+            check_key.name
+            for check_key in getattr(check_def, "check_keys", ())
+        )
+        names.update(spec.name for spec in getattr(check_def, "specs", ()))
+        if name := getattr(check_def, "name", None):
+            names.add(name)
+    return names

--- a/tests/integration/test_phase1_graph_provider_wiring.py
+++ b/tests/integration/test_phase1_graph_provider_wiring.py
@@ -112,10 +112,33 @@ def test_phase1_graph_promotion_without_phase0_dependency_is_rejected(
         )
 
 
+def test_phase1_graph_snapshot_without_ancestry_is_rejected(
+    dagster_module: object,
+    dagster_dbt_module: object,
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+) -> None:
+    dagster = dagster_module
+
+    from orchestrator.definitions import build_definitions
+
+    provider, _graph_promotion, _graph_snapshot, _graph_check = _fake_graph_provider(
+        dagster,
+        snapshot_depends_on_promotion=False,
+    )
+
+    with pytest.raises(ValueError, match="phase1 graph_snapshot.*graph_promotion"):
+        build_definitions(
+            module_factories=[provider],
+            policy_path=stub_policy_path,
+        )
+
+
 def _fake_graph_provider(
     dagster: Any,
     *,
     include_phase0_dependency: bool = True,
+    snapshot_depends_on_promotion: bool = True,
 ) -> tuple[object, object, object, object]:
     from orchestrator.jobs.phase0 import (
         PHASE0_CANDIDATE_FREEZE_ASSET_KEY,
@@ -140,12 +163,23 @@ def _fake_graph_provider(
     def graph_promotion() -> str:
         return "promoted"
 
-    @dagster.asset(
-        name=PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
-        group_name=PHASE1_GROUP_NAME,
-    )
-    def graph_snapshot(graph_promotion: str) -> str:
-        return f"snapshot:{graph_promotion}"
+    if snapshot_depends_on_promotion:
+
+        @dagster.asset(
+            name=PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
+            group_name=PHASE1_GROUP_NAME,
+        )
+        def graph_snapshot(graph_promotion: str) -> str:
+            return f"snapshot:{graph_promotion}"
+
+    else:
+
+        @dagster.asset(
+            name=PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
+            group_name=PHASE1_GROUP_NAME,
+        )
+        def graph_snapshot() -> str:
+            return "snapshot:independent"
 
     @dagster.asset_check(
         asset=graph_snapshot,

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -217,6 +217,22 @@ def test_module_level_defs_loads_configured_milestone_surface(
         _clear_definition_imports()
 
 
+def test_require_milestone_surface_env_false_overrides_profile(
+    definitions_exports: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import orchestrator.definitions as definitions_module
+
+    monkeypatch.setenv("ORCHESTRATOR_DEFINITIONS_PROFILE", "milestone-1")
+    monkeypatch.setenv("ORCHESTRATOR_REQUIRE_MILESTONE_SURFACE", "false")
+
+    assert definitions_module._requires_milestone_surface() is False
+
+    monkeypatch.setenv("ORCHESTRATOR_REQUIRE_MILESTONE_SURFACE", "true")
+
+    assert definitions_module._requires_milestone_surface() is True
+
+
 def test_build_definitions_is_loadable(
     definitions_exports: dict[str, Any],
 ) -> None:


### PR DESCRIPTION
Closes #20

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/orchestrator/checks/dbt_events.py`, `src/orchestrator/definitions.py`, `src/orchestrator/sensors/manual_rerun.py`, `tests/integration/conftest.py`, `tests/test_definitions.py`


---
### 1. 背景与目标
项目文档 §8、§14、§21 要求 milestone-2 开始接入 Phase 1 graph update，并且 orchestrator 只装配 graph-engine 暴露的 assets，不实现图谱算法。实际基线中 src/orchestrator/jobs/cycle.py 的 daily_cycle_job 只选择 PHASE0_GROUP_NAME，src/orchestrator/definitions.py 只内置 phase0_readiness_ping、dbt_phase0_assets 和 provider 资产集合。目标是在现有 AssetFactoryProvider.get_assets()/get_checks()/get_resources() 合同上扩展 Phase 1 group wiring，让 graph promotion / snapshot assets 进入 Dagster Definitions 与 daily cycle selection。

### 2. 所属模块
src/orchestrator/jobs/phase1.py（新增）、src/orchestrator/jobs/cycle.py、src/orchestrator/jobs/__init__.py、src/orchestrator/definitions.py、tests/integration/test_phase1_graph_provider_wiring.py（新增）

### 3. 实现范围
- 新增 src/orchestrator/jobs/phase1.py，定义 PHASE1_GROUP_NAME: str = 'phase1'、PHASE1_GRAPH_PROMOTION_ASSET_KEY: str = 'graph_promotion'、PHASE1_GRAPH_SNAPSHOT_ASSET_KEY: str = 'graph_snapshot'，只做 Dagster metadata/asset key contract。
- 修改 src/orchestrator/jobs/cycle.py：保留 build_daily_cycle_jobs(phase_config: Mapping[str, Any] | None) -> tuple[object, ...] 签名，把 daily_cycle_job selection 从仅 Phase 0 扩展为 Phase 0 + Phase 1 group。
- 修改 src/orchestrator/definitions.py：在 module_factories: Iterable[AssetFactoryProvider] 收集路径上识别 group_name == 'phase1' 的 assets/checks，并在 milestone profile 下校验 promotion 与 snapshot contract。
- 更新 src/orchestrator/jobs/__init__.py re-export Phase 1 常量；测试通过 fake graph-engine provider 注入两个 Phase 1 assets。
- 新增集成测试验证 daily_cycle_job.selection.resolve(...) 同时包含 phase0_readiness_ping、dbt heartbeat、graph_promotion、graph_snapshot，并且 dagster.Definitions.validate_loadable(defs) 成功。

### 4. 不在本次范围
- 不 import graph_engine 私有模块；真实能力只能通过公开 AssetFactoryProvider 入口传入。
- 不实现 graph delta、Neo4j promotion、snapshot 写入或 ready graph 指针更新逻辑。
- 不实现 Phase 1 失败 Gate；该行为由 #21 落地。
- 不接入 Phase 2 / Phase 3 assets；后续 #22、#25 处理。

### 5. 关键交付物
- PHASE1_GROUP_NAME: str = 'phase1'、PHASE1_GRAPH_PROMOTION_ASSET_KEY: str、PHASE1_GRAPH_SNAPSHOT_ASSET_KEY: str。
- daily_cycle_job 的 AssetSelection 覆盖 PHASE0_GROUP_NAM