### PR TITLE
feat(#21): Phase 1 graph promotion 失败 Gate（保留上一轮 ready graph）

### DIFF
--- a/src/orchestrator/checks/__init__.py
+++ b/src/orchestrator/checks/__init__.py
@@ -12,6 +12,11 @@ from orchestrator.checks.models import (
     LLMHealthProbe,
     LLMHealthResult,
 )
+from orchestrator.checks.phase1 import (
+    GraphPromotionFailureEvent,
+    classify_graph_promotion_failure,
+    should_advance_ready_graph,
+)
 from orchestrator.policy import FailureClass, GateAction, PhaseEnum
 
 
@@ -37,14 +42,17 @@ __all__ = [
     "DataReadinessSignal",
     "GateDecision",
     "GatePolicyResource",
+    "GraphPromotionFailureEvent",
     "LLMHealthProbe",
     "LLMHealthResult",
     "PhaseEnum",
     "UnknownGateFailure",
     "classify_gate_result",
     "classify_dbt_test_failure",
+    "classify_graph_promotion_failure",
     "dispatch_gate_decision_alert",
     "llm_health_check",
     "phase0_ping_check",
     "plan_dbt_test_partial_rerun",
+    "should_advance_ready_graph",
 ]

--- a/src/orchestrator/checks/phase1.py
+++ b/src/orchestrator/checks/phase1.py
@@ -1,0 +1,173 @@
+"""Phase 1 graph promotion gate adapters."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from orchestrator.checks.classifier import classify_gate_result
+from orchestrator.checks.decision_handler import dispatch_gate_decision_alert
+from orchestrator.checks.models import GateDecision
+from orchestrator.policy import FailureClass, GateAction, GatePolicyProfile, PhaseEnum
+
+_PHASE1_GRAPH_PROMOTION_ASSET_KEY = "graph_promotion"
+_PHASE1_GRAPH_SNAPSHOT_ASSET_KEY = "graph_snapshot"
+_PHASE1_GRAPH_FAILURE_NODES = frozenset(
+    {
+        _PHASE1_GRAPH_PROMOTION_ASSET_KEY,
+        _PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
+    },
+)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class GraphPromotionFailureEvent:
+    """Normalized Phase 1 graph promotion or snapshot failure event."""
+
+    failure_class: FailureClass = FailureClass.PUBLISH
+    failed_node: str
+    snapshot_id: str | None = None
+    reason: str | None = None
+
+
+def classify_graph_promotion_failure(
+    event: GraphPromotionFailureEvent | Mapping[str, object],
+    policy: GatePolicyProfile,
+) -> GateDecision:
+    """Classify a graph promotion/snapshot failure as a Phase 1 gate decision."""
+
+    return classify_gate_result(PhaseEnum.PHASE1, event, policy)
+
+
+def should_advance_ready_graph(decision: GateDecision) -> bool:
+    """Return whether a ready graph marker can be advanced for the decision."""
+
+    return decision.action is GateAction.CONTINUE
+
+
+def build_phase1_graph_failure_gate_hook() -> object:
+    """Build a Dagster failure hook for Phase 1 graph promotion assets."""
+
+    from dagster import failure_hook
+
+    @failure_hook(required_resource_keys={"gate_policy"})
+    def phase1_graph_failure_gate(context: object) -> None:
+        event = _graph_failure_event_from_hook_context(context)
+        if event is None:
+            return
+
+        policy = _policy_from_hook_context(context)
+        decision = classify_graph_promotion_failure(event, policy)
+        dispatch_gate_decision_alert(
+            decision,
+            cycle_id=_cycle_id_from_hook_context(context),
+            failed_node=event.failed_node,
+            summary=event.reason or decision.reason or "Phase 1 graph failure",
+            channels=policy.alert_channels,
+        )
+
+    return phase1_graph_failure_gate
+
+
+def _graph_failure_event_from_hook_context(
+    context: object,
+) -> GraphPromotionFailureEvent | None:
+    failed_node = _failed_node_from_hook_context(context)
+    if failed_node is None:
+        return None
+
+    return GraphPromotionFailureEvent(
+        failed_node=failed_node,
+        snapshot_id=_snapshot_id_from_hook_context(context),
+        reason=_reason_from_hook_context(context),
+    )
+
+
+def _failed_node_from_hook_context(context: object) -> str | None:
+    op = getattr(context, "op", None)
+    for value in (
+        getattr(op, "name", None),
+        getattr(context, "op_name", None),
+        getattr(context, "step_key", None),
+    ):
+        failed_node = _phase1_graph_node_name(value)
+        if failed_node is not None:
+            return failed_node
+    return None
+
+
+def _phase1_graph_node_name(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    if value in _PHASE1_GRAPH_FAILURE_NODES:
+        return value
+    return None
+
+
+def _snapshot_id_from_hook_context(context: object) -> str | None:
+    tags = _hook_context_tags(context)
+    snapshot_id = tags.get("snapshot_id")
+    return snapshot_id if isinstance(snapshot_id, str) and snapshot_id else None
+
+
+def _reason_from_hook_context(context: object) -> str | None:
+    exception = getattr(context, "op_exception", None)
+    if exception is None:
+        return None
+
+    message = str(exception)
+    if message:
+        return f"{type(exception).__name__}: {message}"
+    return type(exception).__name__
+
+
+def _policy_from_hook_context(context: object) -> GatePolicyProfile:
+    resources = getattr(context, "resources", None)
+    gate_policy_resource = getattr(resources, "gate_policy", None)
+    policy = getattr(gate_policy_resource, "policy", gate_policy_resource)
+    if not isinstance(policy, GatePolicyProfile):
+        msg = "gate_policy resource must expose a GatePolicyProfile policy"
+        raise TypeError(msg)
+    return policy
+
+
+def _cycle_id_from_hook_context(context: object) -> str:
+    tags = _hook_context_tags(context)
+    cycle_id = tags.get("cycle_id")
+    if isinstance(cycle_id, str) and cycle_id:
+        return cycle_id
+
+    run_id = getattr(context, "run_id", None)
+    if isinstance(run_id, str) and run_id:
+        return run_id
+
+    run = getattr(context, "run", None)
+    run_id = getattr(run, "run_id", None) if run is not None else None
+    if isinstance(run_id, str) and run_id:
+        return run_id
+
+    return "unknown-phase1-run"
+
+
+def _hook_context_tags(context: object) -> Mapping[str, Any]:
+    for container in (
+        context,
+        getattr(context, "run", None),
+        getattr(context, "dagster_run", None),
+    ):
+        if container is None:
+            continue
+        for attribute_name in ("run_tags", "tags"):
+            tags = getattr(container, attribute_name, None)
+            if isinstance(tags, Mapping):
+                return tags
+    return {}
+
+
+__all__ = [
+    "GraphPromotionFailureEvent",
+    "build_phase1_graph_failure_gate_hook",
+    "classify_graph_promotion_failure",
+    "should_advance_ready_graph",
+]

--- a/src/orchestrator/jobs/cycle.py
+++ b/src/orchestrator/jobs/cycle.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from dagster import AssetSelection, define_asset_job
 
+from orchestrator.checks.phase1 import build_phase1_graph_failure_gate_hook
 from orchestrator.jobs.phase0_constants import PHASE0_GROUP_NAME
 from orchestrator.jobs.phase1 import PHASE1_GROUP_NAME
 
@@ -12,6 +13,7 @@ from orchestrator.jobs.phase1 import PHASE1_GROUP_NAME
 daily_cycle_job = define_asset_job(
     name="daily_cycle_job",
     selection=AssetSelection.groups(PHASE0_GROUP_NAME, PHASE1_GROUP_NAME),
+    hooks={build_phase1_graph_failure_gate_hook()},
 )
 
 

--- a/tests/checks/test_phase1_gate.py
+++ b/tests/checks/test_phase1_gate.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from dataclasses import fields
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from orchestrator.checks import (
+    GateDecision,
+    GraphPromotionFailureEvent,
+    classify_graph_promotion_failure,
+    should_advance_ready_graph,
+)
+from orchestrator.policy import FailureClass, GateAction, PhaseEnum, load_gate_policy
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LITE_POLICY_PATH = REPO_ROOT / "config" / "policy" / "gate_policy.lite.yaml"
+
+
+@pytest.fixture
+def gate_policy() -> Any:
+    return load_gate_policy(LITE_POLICY_PATH)
+
+
+def test_graph_promotion_failure_event_fields_match_contract() -> None:
+    assert [field.name for field in fields(GraphPromotionFailureEvent)] == [
+        "failure_class",
+        "failed_node",
+        "snapshot_id",
+        "reason",
+    ]
+
+
+def test_classify_graph_promotion_failure_uses_phase1_publish_policy(
+    gate_policy: Any,
+) -> None:
+    event = GraphPromotionFailureEvent(
+        failed_node="graph_snapshot",
+        snapshot_id="snapshot-20260416",
+        reason="snapshot write failed",
+    )
+
+    decision = classify_graph_promotion_failure(event, gate_policy)
+
+    assert event.failure_class is FailureClass.PUBLISH
+    assert decision.phase is PhaseEnum.PHASE1
+    assert decision.failure_class is FailureClass.PUBLISH
+    assert decision.action is GateAction.FAIL_RUN
+    assert (
+        decision.reason
+        == "Graph promotion or snapshot failed; retain the previous ready graph."
+    )
+
+
+def test_classify_graph_promotion_failure_accepts_mapping_event(
+    gate_policy: Any,
+) -> None:
+    decision = classify_graph_promotion_failure(
+        {
+            "failure_class": "publish",
+            "failed_node": "graph_promotion",
+            "reason": "promotion failed",
+        },
+        gate_policy,
+    )
+
+    assert decision.phase is PhaseEnum.PHASE1
+    assert decision.failure_class is FailureClass.PUBLISH
+    assert decision.action is GateAction.FAIL_RUN
+
+
+def test_classify_graph_promotion_failure_rejects_unknown_event_shape(
+    gate_policy: Any,
+) -> None:
+    with pytest.raises(TypeError, match="must include failure_class"):
+        classify_graph_promotion_failure({"failed_node": "graph_snapshot"}, gate_policy)
+
+
+def test_should_advance_ready_graph_only_allows_continue() -> None:
+    fail_decision = GateDecision(
+        phase=PhaseEnum.PHASE1,
+        failure_class=FailureClass.PUBLISH,
+        action=GateAction.FAIL_RUN,
+    )
+    continue_decision = GateDecision(
+        phase=PhaseEnum.PHASE1,
+        failure_class=None,
+        action=GateAction.CONTINUE,
+    )
+
+    assert should_advance_ready_graph(fail_decision) is False
+    assert should_advance_ready_graph(continue_decision) is True

--- a/tests/integration/test_phase1_graph_gate.py
+++ b/tests/integration/test_phase1_graph_gate.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from tests.integration.conftest import asset_materialization_keys
+
+
+def test_phase1_snapshot_failure_alerts_and_does_not_advance_ready_graph(
+    dagster_module: object,
+    dagster_instance: object,
+    stub_policy_path: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    dagster = dagster_module
+
+    from orchestrator.checks.resources import GatePolicyResource
+    from orchestrator.jobs.cycle import daily_cycle_job
+    from orchestrator.jobs.phase0_constants import (
+        PHASE0_CANDIDATE_FREEZE_ASSET_KEY,
+        PHASE0_GROUP_NAME,
+        PHASE0_READINESS_ASSET_KEY,
+    )
+    from orchestrator.jobs.phase1 import (
+        PHASE1_GRAPH_PROMOTION_ASSET_KEY,
+        PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
+        PHASE1_GROUP_NAME,
+    )
+
+    ready_marker_calls: list[str] = []
+
+    @dagster.asset(name=PHASE0_READINESS_ASSET_KEY, group_name=PHASE0_GROUP_NAME)
+    def phase0_readiness_ping() -> str:
+        return "ready"
+
+    @dagster.asset(name=PHASE0_CANDIDATE_FREEZE_ASSET_KEY, group_name=PHASE0_GROUP_NAME)
+    def candidate_freeze() -> str:
+        return "frozen"
+
+    @dagster.asset(
+        name=PHASE1_GRAPH_PROMOTION_ASSET_KEY,
+        group_name=PHASE1_GROUP_NAME,
+        deps=[
+            dagster.AssetKey([PHASE0_READINESS_ASSET_KEY]),
+            dagster.AssetKey([PHASE0_CANDIDATE_FREEZE_ASSET_KEY]),
+        ],
+    )
+    def graph_promotion() -> str:
+        return "promoted"
+
+    @dagster.asset(
+        name=PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
+        group_name=PHASE1_GROUP_NAME,
+    )
+    def graph_snapshot(graph_promotion: str) -> str:
+        raise RuntimeError(f"snapshot writer failed after {graph_promotion}")
+
+    @dagster.asset(name="ready_graph_marker", group_name=PHASE1_GROUP_NAME)
+    def ready_graph_marker(graph_snapshot: str) -> str:
+        ready_marker_calls.append(graph_snapshot)
+        return graph_snapshot
+
+    defs = dagster.Definitions(
+        assets=[
+            phase0_readiness_ping,
+            candidate_freeze,
+            graph_promotion,
+            graph_snapshot,
+            ready_graph_marker,
+        ],
+        jobs=[daily_cycle_job],
+        resources={
+            "gate_policy": GatePolicyResource(policy_path=stub_policy_path),
+        },
+    )
+    dagster.Definitions.validate_loadable(defs)
+
+    cycle_id = "cycle-20260416"
+    with caplog.at_level(logging.WARNING):
+        result = defs.get_job_def("daily_cycle_job").execute_in_process(
+            instance=dagster_instance,
+            raise_on_error=False,
+            tags={
+                "cycle_id": cycle_id,
+                "snapshot_id": "snapshot-20260416",
+            },
+        )
+
+    materialized_keys = asset_materialization_keys(result)
+    alert = _alert_payloads(caplog)[-1]
+
+    assert result.success is False
+    assert dagster.AssetKey([PHASE1_GRAPH_PROMOTION_ASSET_KEY]) in materialized_keys
+    assert dagster.AssetKey([PHASE1_GRAPH_SNAPSHOT_ASSET_KEY]) not in materialized_keys
+    assert dagster.AssetKey(["ready_graph_marker"]) not in materialized_keys
+    assert ready_marker_calls == []
+    assert alert["cycle_id"] == cycle_id
+    assert alert["phase"] == "phase1"
+    assert alert["failed_node"] == "graph_snapshot"
+    assert alert["action"] == "fail_run"
+    assert alert["failure_class"] == "publish"
+    assert "snapshot writer failed after promoted" in str(alert["summary"])
+
+
+def _alert_payloads(caplog: pytest.LogCaptureFixture) -> list[dict[str, object]]:
+    payloads: list[dict[str, object]] = []
+    for record in caplog.records:
+        if record.name != "orchestrator.alerting.dispatcher":
+            continue
+        payloads.append(json.loads(record.message))
+    return payloads


### PR DESCRIPTION
Closes #21

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/orchestrator/checks/dbt_events.py`, `src/orchestrator/definitions.py`, `src/orchestrator/sensors/manual_rerun.py`, `tests/integration/conftest.py`, `tests/test_definitions.py`


---
### 1. 背景与目标
项目文档 §12.3 第 4 行规定 Phase 1 graph promotion / snapshot 异常必须 fail_run，并保留上一轮 ready graph。当前代码已有 classify_gate_result(phase, event, policy)、GateDecision、dispatch_gate_decision_alert(...)，policy 中也已有 phase1 + publish -> fail_run 行，但还没有 Phase 1 失败事件适配层。目标是把 graph promotion/snapshot 的失败归一化为 Phase 1 GateDecision，并通过 Dagster 失败事件测试证明不会推进新的 ready graph 标记。

### 2. 所属模块
src/orchestrator/checks/phase1.py（新增）、src/orchestrator/checks/__init__.py、src/orchestrator/definitions.py、tests/checks/test_phase1_gate.py（新增）、tests/integration/test_phase1_graph_gate.py（新增）

### 3. 实现范围
- 新增 src/orchestrator/checks/phase1.py，定义 frozen dataclass GraphPromotionFailureEvent，字段包含 failure_class: FailureClass = FailureClass.PUBLISH、failed_node: str、snapshot_id: str | None = None、reason: str | None = None。
- 实现 classify_graph_promotion_failure(event: GraphPromotionFailureEvent | Mapping[str, object], policy: GatePolicyProfile) -> GateDecision，内部只调用 classify_gate_result(PhaseEnum.PHASE1, event, policy)。
- 实现 should_advance_ready_graph(decision: GateDecision) -> bool：仅当 decision.action is GateAction.CONTINUE 时返回 True。
- 在 Phase 1 Dagster wiring 中接入失败处理：fake graph promotion/snapshot asset 失败时，通过 #61 已补齐的统一 gate event pipeline 或等价 post-run/event adapter 生成 alert payload，不能把 ready graph marker materialize。
- 更新 src/orchestrator/checks/__init__.py re-export Phase 1 helper，新增 unit test 覆盖 policy 查表、unknown event validation、should_advance_ready_graph(False)。

### 4. 不在本次范围
- 不实现或修改 graph-engine 的 promotion/snapshot 业务逻辑。
- 不写 Neo4j ready graph 指针；只提供是否允许推进的编排判定。
- 不实现 Phase 2/3 Gate。
- 不引入 Temporal pause/resume。

### 5. 关键交付物
- GraphPromotionFailureEvent dataclass，位于 orchestrator.checks.phase1。
- classify_graph_promotion_failure(event: GraphPromotionFailureEvent | Mapping[str, object], policy: GatePolicyProfile) -> GateDecision。
- should_advance_ready_graph(decision: GateDecision) -> bool。
- fake Phase 1 assets：graph_promotion 成功后 graph_snapshot 失败，run result 失败且 alert JSON 为 phase=phase1、failu