### PR TITLE
feat(#22): Phase 2 main-core 主链 asset 接入

### DIFF
--- a/src/orchestrator/definitions.py
+++ b/src/orchestrator/definitions.py
@@ -32,6 +32,7 @@ from orchestrator.jobs.phase1 import (
     PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
     PHASE1_GROUP_NAME,
 )
+from orchestrator.jobs.phase2 import PHASE2_GROUP_NAME
 from orchestrator.resources import AssetFactoryProvider, build_resource_bundle
 from orchestrator.schedules import daily_cycle_schedule
 from orchestrator.sensors.data_readiness import (
@@ -77,6 +78,19 @@ _PHASE1_SURFACE_PROFILES = frozenset(
         "p5",
         "p5+",
         "phase1",
+        "phase2",
+        "phase3",
+    }
+)
+_PHASE2_SURFACE_PROFILES = frozenset(
+    {
+        "milestone-2",
+        "milestone-3",
+        "milestone-4",
+        "p2",
+        "p3",
+        "p5",
+        "p5+",
         "phase2",
         "phase3",
     }
@@ -137,22 +151,16 @@ def build_definitions(
         if reserved in resource_bundle.resource_keys:
             raise ValueError(f"duplicate resource key: {reserved}")
 
-    provider_assets = [
-        asset
-        for module_factory in module_factory_list
-        for asset in module_factory.get_assets()
-    ]
+    provider_assets = _collect_provider_assets(module_factory_list)
     _validate_phase0_provider_assets(provider_assets)
     _validate_phase1_provider_assets(provider_assets)
     if _requires_milestone_surface():
         _validate_milestone_surface(provider_assets, resource_bundle.resources)
     if _requires_phase1_surface():
         _validate_phase1_surface(provider_assets)
-    provider_checks = [
-        check
-        for module_factory in module_factory_list
-        for check in module_factory.get_checks()
-    ]
+    if _requires_phase2_surface():
+        _validate_phase2_surface(provider_assets)
+    provider_checks = _collect_provider_checks(module_factory_list)
     builtin_checks = [phase0_ping_check, llm_health_check]
     llm_health_probe_resource = resource_bundle.resources.get(
         _LLM_HEALTH_PROBE_RESOURCE_KEY,
@@ -249,6 +257,26 @@ def _load_configured_module_factory(factory_path: str) -> AssetFactoryProvider:
         )
 
     return resolved
+
+
+def _collect_provider_assets(
+    module_factories: Iterable[AssetFactoryProvider],
+) -> tuple[object, ...]:
+    return tuple(
+        asset
+        for module_factory in module_factories
+        for asset in module_factory.get_assets()
+    )
+
+
+def _collect_provider_checks(
+    module_factories: Iterable[AssetFactoryProvider],
+) -> tuple[object, ...]:
+    return tuple(
+        check
+        for module_factory in module_factories
+        for check in module_factory.get_checks()
+    )
 
 
 def _validate_phase0_provider_assets(provider_assets: Iterable[object]) -> None:
@@ -355,6 +383,10 @@ def _requires_phase1_surface() -> bool:
     return _normalized_definitions_profile() in _PHASE1_SURFACE_PROFILES
 
 
+def _requires_phase2_surface() -> bool:
+    return _normalized_definitions_profile() in _PHASE2_SURFACE_PROFILES
+
+
 def _is_milestone_surface_profile() -> bool:
     return _normalized_definitions_profile() in _MILESTONE_SURFACE_PROFILES
 
@@ -430,6 +462,29 @@ def _validate_phase1_surface(provider_assets: Iterable[object]) -> None:
             "assets that satisfy the graph promotion/snapshot contract. "
             f"Missing: {missing_items}.",
         )
+
+
+def _validate_phase2_surface(provider_assets: Iterable[object]) -> None:
+    phase2_asset_keys = _asset_keys_for_group(provider_assets, PHASE2_GROUP_NAME)
+    if phase2_asset_keys:
+        return
+
+    raise ValueError(
+        "phase2 milestone Definitions assembly requires provider assets "
+        f"declaring group_name={PHASE2_GROUP_NAME!r}.",
+    )
+
+
+def _asset_keys_for_group(
+    provider_assets: Iterable[object],
+    group_name: str,
+) -> frozenset[AssetKey]:
+    return frozenset(
+        asset_key
+        for asset_def in provider_assets
+        for asset_key in getattr(asset_def, "keys", ())
+        if getattr(asset_def, "group_names_by_key", {}).get(asset_key) == group_name
+    )
 
 
 def _asset_dependency_keys(

--- a/src/orchestrator/jobs/__init__.py
+++ b/src/orchestrator/jobs/__init__.py
@@ -14,6 +14,7 @@ from orchestrator.jobs.phase1 import (
     PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
     PHASE1_GROUP_NAME,
 )
+from orchestrator.jobs.phase2 import PHASE2_GROUP_NAME, PHASE2_STAGE_KEYS
 
 __all__ = [
     "PHASE0_CANDIDATE_FREEZE_ASSET_KEY",
@@ -23,6 +24,8 @@ __all__ = [
     "PHASE1_GRAPH_PROMOTION_ASSET_KEY",
     "PHASE1_GRAPH_SNAPSHOT_ASSET_KEY",
     "PHASE1_GROUP_NAME",
+    "PHASE2_GROUP_NAME",
+    "PHASE2_STAGE_KEYS",
     "build_daily_cycle_jobs",
     "daily_cycle_job",
     "dbt_phase0_assets",

--- a/src/orchestrator/jobs/cycle.py
+++ b/src/orchestrator/jobs/cycle.py
@@ -8,11 +8,16 @@ from dagster import AssetSelection, define_asset_job
 from orchestrator.checks.phase1 import build_phase1_graph_failure_gate_hook
 from orchestrator.jobs.phase0_constants import PHASE0_GROUP_NAME
 from orchestrator.jobs.phase1 import PHASE1_GROUP_NAME
+from orchestrator.jobs.phase2 import PHASE2_GROUP_NAME
 
 
 daily_cycle_job = define_asset_job(
     name="daily_cycle_job",
-    selection=AssetSelection.groups(PHASE0_GROUP_NAME, PHASE1_GROUP_NAME),
+    selection=AssetSelection.groups(
+        PHASE0_GROUP_NAME,
+        PHASE1_GROUP_NAME,
+        PHASE2_GROUP_NAME,
+    ),
     hooks={build_phase1_graph_failure_gate_hook()},
 )
 

--- a/src/orchestrator/jobs/phase2.py
+++ b/src/orchestrator/jobs/phase2.py
@@ -1,0 +1,9 @@
+"""Phase 2 asset group contract constants."""
+
+PHASE2_GROUP_NAME: str = "phase2"
+PHASE2_STAGE_KEYS: tuple[str, ...] = ("l1", "l2", "l3", "l4", "l5", "l6", "l7")
+
+__all__ = [
+    "PHASE2_GROUP_NAME",
+    "PHASE2_STAGE_KEYS",
+]

--- a/src/orchestrator/resources/__init__.py
+++ b/src/orchestrator/resources/__init__.py
@@ -1,8 +1,9 @@
 from orchestrator.resources.bundle import ResourceBundle, build_resource_bundle
-from orchestrator.resources.providers import AssetFactoryProvider
+from orchestrator.resources.providers import AssetFactoryProvider, PureCheckProvider
 
 __all__ = [
     "AssetFactoryProvider",
+    "PureCheckProvider",
     "ResourceBundle",
     "build_resource_bundle",
 ]

--- a/src/orchestrator/resources/providers.py
+++ b/src/orchestrator/resources/providers.py
@@ -7,15 +7,20 @@ from dagster import ResourceDefinition
 
 
 @runtime_checkable
-class AssetFactoryProvider(Protocol):
+class PureCheckProvider(Protocol):
+    """Provider interface for upstream pure Dagster AssetCheck wrappers."""
+
+    def get_checks(self) -> Sequence[object]:
+        """Return pure check wrappers with no orchestrator-side business IO."""
+        ...
+
+
+@runtime_checkable
+class AssetFactoryProvider(PureCheckProvider, Protocol):
     """Structural provider interface consumed by orchestrator assembly."""
 
     def get_assets(self) -> Sequence[object]:
         """Return Dagster assets exposed by the upstream module."""
-        ...
-
-    def get_checks(self) -> Sequence[object]:
-        """Return Dagster checks exposed by the upstream module."""
         ...
 
     def get_resources(self) -> Mapping[str, ResourceDefinition]:

--- a/tests/integration/test_phase2_main_core_wiring.py
+++ b/tests/integration/test_phase2_main_core_wiring.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from tests.integration.conftest import (
+    asset_check_evaluations,
+    asset_materialization_keys,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FORBIDDEN_RUNTIME_MODULE_ROOTS = ("main_core", "kafka", "flink")
+
+
+def test_phase2_provider_contributes_daily_cycle_assets_and_checks(
+    dagster_module: object,
+    dagster_dbt_module: object,
+    dagster_instance: object,
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+) -> None:
+    dagster = dagster_module
+
+    from orchestrator.definitions import build_definitions
+    from orchestrator.jobs.cycle import daily_cycle_job
+    from orchestrator.jobs.phase2 import PHASE2_GROUP_NAME, PHASE2_STAGE_KEYS
+
+    phase2_calls: list[str] = []
+    phase0_provider = _fake_phase0_surface_provider(dagster)
+    phase1_provider = _fake_phase1_provider(dagster)
+    phase2_provider, _phase2_assets, _phase2_check = _fake_phase2_provider(
+        dagster,
+        phase2_calls,
+    )
+    defs = build_definitions(
+        module_factories=[phase0_provider, phase1_provider, phase2_provider],
+        policy_path=stub_policy_path,
+    )
+
+    dagster.Definitions.validate_loadable(defs)
+
+    phase2_asset_keys = {dagster.AssetKey([stage]) for stage in PHASE2_STAGE_KEYS}
+    selected_keys = daily_cycle_job.selection.resolve(defs.assets or ())
+
+    assert phase2_asset_keys <= selected_keys
+    assert _asset_keys_for_group(defs, PHASE2_GROUP_NAME) == phase2_asset_keys
+    assert "fake_phase2_l7_pure_check" in _check_names(defs)
+
+    result = defs.get_job_def("daily_cycle_job").execute_in_process(
+        instance=dagster_instance,
+        tags={"cycle_id": "cycle-20260416"},
+    )
+    materialized_keys = asset_materialization_keys(result)
+    evaluations = asset_check_evaluations(result)
+
+    assert result.success is True
+    assert phase2_asset_keys <= materialized_keys
+    assert phase2_calls == list(PHASE2_STAGE_KEYS)
+    assert any(
+        _check_name(evaluation) == "fake_phase2_l7_pure_check"
+        and getattr(evaluation, "passed", None) is True
+        for evaluation in evaluations
+    )
+
+
+def test_milestone2_requires_phase2_provider_assets(
+    dagster_module: object,
+    dagster_dbt_module: object,
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dagster = dagster_module
+
+    from orchestrator.definitions import build_definitions
+
+    monkeypatch.setenv("ORCHESTRATOR_DEFINITIONS_PROFILE", "milestone-2")
+
+    with pytest.raises(ValueError, match="phase2.*group_name='phase2'"):
+        build_definitions(
+            module_factories=[
+                _fake_phase0_surface_provider(dagster),
+                _fake_phase1_provider(dagster),
+            ],
+            policy_path=stub_policy_path,
+        )
+
+
+def test_orchestrator_has_no_forbidden_phase2_runtime_imports() -> None:
+    violations: list[str] = []
+
+    for path in sorted((_REPO_ROOT / "src" / "orchestrator").rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for module_name, lineno in _absolute_imports(tree):
+            if _is_forbidden_runtime_import(module_name):
+                relative_path = path.relative_to(_REPO_ROOT)
+                violations.append(f"{relative_path}:{lineno}: {module_name}")
+
+    assert violations == []
+
+
+def _fake_phase0_surface_provider(dagster: Any) -> object:
+    from orchestrator.checks import DataReadinessSignal
+    from orchestrator.jobs.phase0_constants import (
+        PHASE0_CANDIDATE_FREEZE_ASSET_KEY,
+        PHASE0_GROUP_NAME,
+    )
+    from orchestrator.sensors.data_readiness import DATA_READINESS_RESOURCE_KEY
+
+    class FakeDataReadinessProvider:
+        def get_data_readiness_signal(self) -> DataReadinessSignal:
+            return DataReadinessSignal(ready=True, cycle_id="cycle-20260416")
+
+    class FakeDataReadinessResource(dagster.ConfigurableResource):
+        def create_resource(self, context: object) -> FakeDataReadinessProvider:
+            return FakeDataReadinessProvider()
+
+    class FakeLLMHealthResult:
+        healthy = True
+        summary = "provider ready"
+        provider = "fake-llm"
+
+    class FakeLLMHealthProbe:
+        def check_health(self) -> FakeLLMHealthResult:
+            return FakeLLMHealthResult()
+
+    class FakeLLMHealthProbeResource(dagster.ConfigurableResource):
+        def create_resource(self, context: object) -> FakeLLMHealthProbe:
+            return FakeLLMHealthProbe()
+
+    @dagster.asset(
+        name=PHASE0_CANDIDATE_FREEZE_ASSET_KEY,
+        group_name=PHASE0_GROUP_NAME,
+    )
+    def candidate_freeze() -> str:
+        return "frozen"
+
+    class FakePhase0SurfaceProvider:
+        def get_assets(self) -> tuple[object, ...]:
+            return (candidate_freeze,)
+
+        def get_checks(self) -> tuple[object, ...]:
+            return ()
+
+        def get_resources(self) -> dict[str, object]:
+            return {
+                DATA_READINESS_RESOURCE_KEY: cast(
+                    object,
+                    FakeDataReadinessResource(),
+                ),
+                "llm_health_probe": cast(object, FakeLLMHealthProbeResource()),
+            }
+
+    return FakePhase0SurfaceProvider()
+
+
+def _fake_phase1_provider(dagster: Any) -> object:
+    from orchestrator.jobs.phase0_constants import (
+        PHASE0_CANDIDATE_FREEZE_ASSET_KEY,
+        PHASE0_READINESS_ASSET_KEY,
+    )
+    from orchestrator.jobs.phase1 import (
+        PHASE1_GRAPH_PROMOTION_ASSET_KEY,
+        PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
+        PHASE1_GROUP_NAME,
+    )
+
+    @dagster.asset(
+        name=PHASE1_GRAPH_PROMOTION_ASSET_KEY,
+        group_name=PHASE1_GROUP_NAME,
+        deps=[
+            dagster.AssetKey([PHASE0_READINESS_ASSET_KEY]),
+            dagster.AssetKey([PHASE0_CANDIDATE_FREEZE_ASSET_KEY]),
+        ],
+    )
+    def graph_promotion() -> str:
+        return "promoted"
+
+    @dagster.asset(
+        name=PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
+        group_name=PHASE1_GROUP_NAME,
+    )
+    def graph_snapshot(graph_promotion: str) -> str:
+        return f"snapshot:{graph_promotion}"
+
+    class FakePhase1Provider:
+        def get_assets(self) -> tuple[object, ...]:
+            return (graph_promotion, graph_snapshot)
+
+        def get_checks(self) -> tuple[object, ...]:
+            return ()
+
+        def get_resources(self) -> dict[str, object]:
+            return {}
+
+    return FakePhase1Provider()
+
+
+def _fake_phase2_provider(
+    dagster: Any,
+    calls: list[str],
+) -> tuple[object, tuple[object, ...], object]:
+    from orchestrator.jobs.phase2 import PHASE2_GROUP_NAME, PHASE2_STAGE_KEYS
+
+    @dagster.asset(name=PHASE2_STAGE_KEYS[0], group_name=PHASE2_GROUP_NAME)
+    def phase2_l1(graph_snapshot: str) -> str:
+        calls.append(PHASE2_STAGE_KEYS[0])
+        return f"{graph_snapshot}:l1"
+
+    @dagster.asset(name=PHASE2_STAGE_KEYS[1], group_name=PHASE2_GROUP_NAME)
+    def phase2_l2(l1: str) -> str:
+        calls.append(PHASE2_STAGE_KEYS[1])
+        return f"{l1}:l2"
+
+    @dagster.asset(name=PHASE2_STAGE_KEYS[2], group_name=PHASE2_GROUP_NAME)
+    def phase2_l3(l2: str) -> str:
+        calls.append(PHASE2_STAGE_KEYS[2])
+        return f"{l2}:l3"
+
+    @dagster.asset(name=PHASE2_STAGE_KEYS[3], group_name=PHASE2_GROUP_NAME)
+    def phase2_l4(l3: str) -> str:
+        calls.append(PHASE2_STAGE_KEYS[3])
+        return f"{l3}:l4"
+
+    @dagster.asset(name=PHASE2_STAGE_KEYS[4], group_name=PHASE2_GROUP_NAME)
+    def phase2_l5(l4: str) -> str:
+        calls.append(PHASE2_STAGE_KEYS[4])
+        return f"{l4}:l5"
+
+    @dagster.asset(name=PHASE2_STAGE_KEYS[5], group_name=PHASE2_GROUP_NAME)
+    def phase2_l6(l5: str) -> str:
+        calls.append(PHASE2_STAGE_KEYS[5])
+        return f"{l5}:l6"
+
+    @dagster.asset(name=PHASE2_STAGE_KEYS[6], group_name=PHASE2_GROUP_NAME)
+    def phase2_l7(l6: str) -> str:
+        calls.append(PHASE2_STAGE_KEYS[6])
+        return f"{l6}:l7"
+
+    @dagster.asset_check(
+        asset=phase2_l7,
+        name="fake_phase2_l7_pure_check",
+    )
+    def fake_phase2_l7_pure_check() -> object:
+        return dagster.AssetCheckResult(passed=True)
+
+    phase2_assets = (
+        phase2_l1,
+        phase2_l2,
+        phase2_l3,
+        phase2_l4,
+        phase2_l5,
+        phase2_l6,
+        phase2_l7,
+    )
+
+    class FakePhase2Provider:
+        def get_assets(self) -> tuple[object, ...]:
+            return phase2_assets
+
+        def get_checks(self) -> tuple[object, ...]:
+            return (fake_phase2_l7_pure_check,)
+
+        def get_resources(self) -> dict[str, object]:
+            return {}
+
+    return FakePhase2Provider(), phase2_assets, fake_phase2_l7_pure_check
+
+
+def _asset_keys_for_group(defs: Any, group_name: str) -> set[object]:
+    return {
+        asset_key
+        for asset_def in defs.assets or ()
+        for asset_key in getattr(asset_def, "keys", ())
+        if getattr(asset_def, "group_names_by_key", {}).get(asset_key) == group_name
+    }
+
+
+def _check_names(defs: Any) -> set[str]:
+    names: set[str] = set()
+    for check_def in defs.asset_checks or ():
+        names.update(
+            check_key.name
+            for check_key in getattr(check_def, "check_keys", ())
+        )
+        names.update(spec.name for spec in getattr(check_def, "specs", ()))
+        if name := getattr(check_def, "name", None):
+            names.add(name)
+    return names
+
+
+def _check_name(evaluation: object) -> str | None:
+    check_name = getattr(evaluation, "check_name", None)
+    if isinstance(check_name, str):
+        return check_name
+    check_key = getattr(evaluation, "check_key", None)
+    name = getattr(check_key, "name", None)
+    return name if isinstance(name, str) else None
+
+
+def _absolute_imports(tree: ast.AST) -> list[tuple[str, int]]:
+    imports: list[tuple[str, int]] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend((alias.name, node.lineno) for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            imports.append((node.module, node.lineno))
+
+    return imports
+
+
+def _is_forbidden_runtime_import(module_name: str) -> bool:
+    return any(
+        module_name == root or module_name.startswith(f"{root}.")
+        for root in _FORBIDDEN_RUNTIME_MODULE_ROOTS
+    )


### PR DESCRIPTION
Closes #22

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/orchestrator/checks/dbt_events.py`, `src/orchestrator/checks/phase1.py`, `src/orchestrator/definitions.py`, `src/orchestrator/sensors/manual_rerun.py`, `tests/integration/conftest.py`, `tests/test_definitions.py`


---
### 1. 背景与目标
项目文档 §8、§14、§21 要求 milestone-2 接入 Phase 2 main-core 主链，但 §4.2、§5.4 明确禁止 orchestrator 实现 L1-L7 业务算法。当前实际代码的 provider 合同是 AssetFactoryProvider.get_assets()/get_checks()/get_resources()，build_definitions(...) 会收集 provider assets/checks，daily job 目前只覆盖 Phase 0/1。目标是把 main-core 暴露的 L1-L7 assets 与纯检查 wrapper 作为 phase2 asset group 装配进 daily cycle。

### 2. 所属模块
src/orchestrator/jobs/phase2.py（新增）、src/orchestrator/jobs/cycle.py、src/orchestrator/jobs/__init__.py、src/orchestrator/definitions.py、src/orchestrator/resources/providers.py、tests/integration/test_phase2_main_core_wiring.py（新增）

### 3. 实现范围
- 新增 src/orchestrator/jobs/phase2.py，定义 PHASE2_GROUP_NAME: str = 'phase2' 与 PHASE2_STAGE_KEYS: tuple[str, ...] = ('l1', 'l2', 'l3', 'l4', 'l5', 'l6', 'l7')，仅用于 wiring/test contract。
- 修改 src/orchestrator/jobs/cycle.py：在 #20 的 Phase 0+1 selection 基础上纳入 PHASE2_GROUP_NAME，保持 build_daily_cycle_jobs(phase_config) 公开签名不变。
- 在 src/orchestrator/definitions.py 中复用 provider 收集逻辑，校验 milestone profile 下至少存在 group_name == 'phase2' 的 provider assets，并把 provider checks 一并放入 asset_checks。
- 如当前 provider 协议不足以表达纯检查来源，在 src/orchestrator/resources/providers.py 中补充 PureCheckProvider Protocol 或在 docstring 中明确 AssetFactoryProvider.get_checks() 只接收上游纯检查 wrapper。
- 新增集成测试用 fake main-core provider 暴露 L1-L7 链式 assets 与一个 fake pure AssetCheck，执行 job 后断言七个 phase2 asset materialize 且 check evaluation 出现。

### 4. 不在本次范围
- 不实现 L1-L7 的业务计算、股票筛选、LLM prompt、Formal recommendation 逻辑。
- 不处理 Phase 2 单股票 inconclusive 或整池失败率 Gate；#23、#24 单独实现。
- 不接入真实 main_core 私有模块。
- 不发布 Phase 3 formal output。

### 5. 关键交付物
- PHASE2_GROUP_NAME: str = 'phase2' 与 PHASE2_STAGE_KEYS: tuple[str, ...]。
- daily_cycle_job selection 包含 PHASE0_GROUP_NAME、PHASE1_GROUP_NAME、PHASE2_GROUP_NAME。
- build_definitions(module_factories: Iterable[AssetFactoryProvider], policy_path: str | Path | None) -> Definitions 能收集 fake main-core provider 的 L1-L7 assets/checks/resources。
- tests/integration/test_phase2_main_core_wiring.py 中 fake provider