### PR TITLE
feat(#23): Phase 2 单股票 inconclusive 路径

### DIFF
--- a/src/orchestrator/checks/__init__.py
+++ b/src/orchestrator/checks/__init__.py
@@ -17,6 +17,12 @@ from orchestrator.checks.phase1 import (
     classify_graph_promotion_failure,
     should_advance_ready_graph,
 )
+from orchestrator.checks.phase2 import (
+    Phase2SingleStockFailureEvent,
+    classify_phase2_single_stock_failure,
+    inconclusive_metadata,
+    phase2_failure_rate,
+)
 from orchestrator.policy import FailureClass, GateAction, PhaseEnum
 
 
@@ -45,14 +51,18 @@ __all__ = [
     "GraphPromotionFailureEvent",
     "LLMHealthProbe",
     "LLMHealthResult",
+    "Phase2SingleStockFailureEvent",
     "PhaseEnum",
     "UnknownGateFailure",
     "classify_gate_result",
     "classify_dbt_test_failure",
     "classify_graph_promotion_failure",
+    "classify_phase2_single_stock_failure",
     "dispatch_gate_decision_alert",
+    "inconclusive_metadata",
     "llm_health_check",
     "phase0_ping_check",
+    "phase2_failure_rate",
     "plan_dbt_test_partial_rerun",
     "should_advance_ready_graph",
 ]

--- a/src/orchestrator/checks/phase2.py
+++ b/src/orchestrator/checks/phase2.py
@@ -1,0 +1,96 @@
+"""Phase 2 single-stock gate adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from orchestrator.checks.classifier import classify_gate_result
+from orchestrator.checks.models import GateDecision
+from orchestrator.policy import FailureClass, GatePolicyProfile, PhaseEnum
+
+_SINGLE_STOCK_TOLERANCE_KEY = "phase2_single_stock_tolerance"
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class Phase2SingleStockFailureEvent:
+    """Normalized Phase 2 single-stock task failure event."""
+
+    failure_class: FailureClass = FailureClass.TASK_LEVEL
+    stock_id: str
+    failed_node: str
+    failed_count: int
+    total_count: int
+    reason: str | None = None
+
+
+def phase2_failure_rate(failed_count: int, total_count: int) -> float:
+    """Return the failed-stock share for a Phase 2 pool."""
+
+    if total_count <= 0:
+        raise ValueError("total_count must be greater than 0")
+    if failed_count < 0:
+        raise ValueError("failed_count must be greater than or equal to 0")
+    if failed_count > total_count:
+        raise ValueError("failed_count must be less than or equal to total_count")
+
+    return failed_count / total_count
+
+
+def classify_phase2_single_stock_failure(
+    event: Phase2SingleStockFailureEvent,
+    policy: GatePolicyProfile,
+) -> GateDecision:
+    """Classify an in-tolerance Phase 2 stock failure as inconclusive."""
+
+    failure_rate = phase2_failure_rate(event.failed_count, event.total_count)
+    tolerance = _phase2_single_stock_tolerance(policy)
+    if failure_rate > tolerance:
+        msg = (
+            "phase2 single-stock failure rate exceeds "
+            f"{_SINGLE_STOCK_TOLERANCE_KEY}; use the pool threshold gate"
+        )
+        raise ValueError(msg)
+
+    return classify_gate_result(PhaseEnum.PHASE2, event, policy)
+
+
+def inconclusive_metadata(
+    event: Phase2SingleStockFailureEvent,
+    decision: GateDecision,
+) -> dict[str, str | float]:
+    """Build Dagster AssetCheckResult metadata for an inconclusive stock."""
+
+    metadata: dict[str, str | float] = {
+        "phase": decision.phase.value,
+        "failure_class": (
+            decision.failure_class.value if decision.failure_class is not None else ""
+        ),
+        "action": decision.action.value,
+        "stock_id": event.stock_id,
+        "failed_node": event.failed_node,
+        "failure_rate": phase2_failure_rate(event.failed_count, event.total_count),
+    }
+    if event.reason is not None:
+        metadata["reason"] = event.reason
+    return metadata
+
+
+def _phase2_single_stock_tolerance(policy: GatePolicyProfile) -> float:
+    try:
+        tolerance = policy.thresholds[_SINGLE_STOCK_TOLERANCE_KEY]
+    except KeyError as exc:
+        msg = f"gate policy missing thresholds.{_SINGLE_STOCK_TOLERANCE_KEY}"
+        raise ValueError(msg) from exc
+
+    if tolerance < 0 or tolerance > 1:
+        msg = f"thresholds.{_SINGLE_STOCK_TOLERANCE_KEY} must be between 0 and 1"
+        raise ValueError(msg)
+    return tolerance
+
+
+__all__ = [
+    "Phase2SingleStockFailureEvent",
+    "classify_phase2_single_stock_failure",
+    "inconclusive_metadata",
+    "phase2_failure_rate",
+]

--- a/tests/checks/test_phase2_single_stock_gate.py
+++ b/tests/checks/test_phase2_single_stock_gate.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from dataclasses import fields
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from orchestrator.checks import (
+    Phase2SingleStockFailureEvent,
+    classify_phase2_single_stock_failure,
+    inconclusive_metadata,
+    phase2_failure_rate,
+)
+from orchestrator.policy import FailureClass, GateAction, PhaseEnum, load_gate_policy
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LITE_POLICY_PATH = REPO_ROOT / "config" / "policy" / "gate_policy.lite.yaml"
+
+
+@pytest.fixture
+def gate_policy() -> Any:
+    return load_gate_policy(LITE_POLICY_PATH)
+
+
+def test_phase2_single_stock_failure_event_fields_match_contract() -> None:
+    assert [field.name for field in fields(Phase2SingleStockFailureEvent)] == [
+        "failure_class",
+        "stock_id",
+        "failed_node",
+        "failed_count",
+        "total_count",
+        "reason",
+    ]
+
+
+def test_phase2_failure_rate_calculates_share() -> None:
+    assert phase2_failure_rate(1, 10) == 0.1
+
+
+@pytest.mark.parametrize(
+    ("failed_count", "total_count", "message"),
+    [
+        (1, 0, "total_count must be greater than 0"),
+        (-1, 10, "failed_count must be greater than or equal to 0"),
+        (11, 10, "failed_count must be less than or equal to total_count"),
+    ],
+)
+def test_phase2_failure_rate_rejects_invalid_counts(
+    failed_count: int,
+    total_count: int,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        phase2_failure_rate(failed_count, total_count)
+
+
+def test_classify_phase2_single_stock_failure_marks_inconclusive(
+    gate_policy: Any,
+) -> None:
+    event = Phase2SingleStockFailureEvent(
+        stock_id="AAPL",
+        failed_node="phase2_llm_score_AAPL",
+        failed_count=1,
+        total_count=10,
+        reason="llm timeout",
+    )
+
+    decision = classify_phase2_single_stock_failure(event, gate_policy)
+
+    assert event.failure_class is FailureClass.TASK_LEVEL
+    assert decision.phase is PhaseEnum.PHASE2
+    assert decision.failure_class is FailureClass.TASK_LEVEL
+    assert decision.action is GateAction.MARK_INCONCLUSIVE
+    assert (
+        decision.reason
+        == "A single-stock LLM task failed within tolerance; continue the pool."
+    )
+
+
+def test_classify_phase2_single_stock_failure_allows_equal_tolerance(
+    gate_policy: Any,
+) -> None:
+    event = Phase2SingleStockFailureEvent(
+        stock_id="MSFT",
+        failed_node="phase2_llm_score_MSFT",
+        failed_count=5,
+        total_count=10,
+    )
+
+    decision = classify_phase2_single_stock_failure(event, gate_policy)
+
+    assert decision.action is GateAction.MARK_INCONCLUSIVE
+
+
+def test_classify_phase2_single_stock_failure_requires_tolerance(
+    gate_policy: Any,
+) -> None:
+    policy = gate_policy.model_copy(update={"thresholds": {}})
+    event = Phase2SingleStockFailureEvent(
+        stock_id="AAPL",
+        failed_node="phase2_llm_score_AAPL",
+        failed_count=1,
+        total_count=10,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="missing thresholds.phase2_single_stock_tolerance",
+    ):
+        classify_phase2_single_stock_failure(event, policy)
+
+
+def test_classify_phase2_single_stock_failure_rejects_pool_threshold_case(
+    gate_policy: Any,
+) -> None:
+    event = Phase2SingleStockFailureEvent(
+        stock_id="AAPL",
+        failed_node="phase2_llm_score_AAPL",
+        failed_count=6,
+        total_count=10,
+    )
+
+    with pytest.raises(ValueError, match="use the pool threshold gate"):
+        classify_phase2_single_stock_failure(event, gate_policy)
+
+
+def test_inconclusive_metadata_contains_asset_check_fields(gate_policy: Any) -> None:
+    event = Phase2SingleStockFailureEvent(
+        stock_id="AAPL",
+        failed_node="phase2_llm_score_AAPL",
+        failed_count=1,
+        total_count=10,
+        reason="llm timeout",
+    )
+    decision = classify_phase2_single_stock_failure(event, gate_policy)
+
+    metadata = inconclusive_metadata(event, decision)
+
+    assert metadata == {
+        "phase": "phase2",
+        "failure_class": "task_level",
+        "action": "mark_inconclusive",
+        "stock_id": "AAPL",
+        "failed_node": "phase2_llm_score_AAPL",
+        "failure_rate": 0.1,
+        "reason": "llm timeout",
+    }

--- a/tests/integration/test_phase2_inconclusive_path.py
+++ b/tests/integration/test_phase2_inconclusive_path.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from tests.integration.conftest import (
+    asset_check_evaluations,
+    asset_materialization_keys,
+    metadata_value,
+)
+
+
+def test_phase2_single_stock_inconclusive_check_does_not_block_daily_cycle(
+    dagster_module: object,
+    dagster_instance: object,
+    stub_policy_path: str,
+) -> None:
+    dagster = dagster_module
+
+    from orchestrator.checks import (
+        Phase2SingleStockFailureEvent,
+        classify_phase2_single_stock_failure,
+        inconclusive_metadata,
+    )
+    from orchestrator.checks.resources import GatePolicyResource
+    from orchestrator.jobs.cycle import daily_cycle_job
+    from orchestrator.jobs.phase0_constants import (
+        PHASE0_CANDIDATE_FREEZE_ASSET_KEY,
+        PHASE0_GROUP_NAME,
+        PHASE0_READINESS_ASSET_KEY,
+    )
+    from orchestrator.jobs.phase1 import (
+        PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
+        PHASE1_GROUP_NAME,
+    )
+    from orchestrator.jobs.phase2 import PHASE2_GROUP_NAME
+    from orchestrator.policy import GateAction
+
+    @dagster.asset(name=PHASE0_READINESS_ASSET_KEY, group_name=PHASE0_GROUP_NAME)
+    def phase0_readiness_ping() -> str:
+        return "ready"
+
+    @dagster.asset(name=PHASE0_CANDIDATE_FREEZE_ASSET_KEY, group_name=PHASE0_GROUP_NAME)
+    def candidate_freeze() -> str:
+        return "frozen"
+
+    @dagster.asset(
+        name=PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
+        group_name=PHASE1_GROUP_NAME,
+        deps=[
+            dagster.AssetKey([PHASE0_READINESS_ASSET_KEY]),
+            dagster.AssetKey([PHASE0_CANDIDATE_FREEZE_ASSET_KEY]),
+        ],
+    )
+    def graph_snapshot() -> str:
+        return "snapshot"
+
+    @dagster.asset(
+        name="phase2_stock_AAPL",
+        group_name=PHASE2_GROUP_NAME,
+        deps=[dagster.AssetKey([PHASE1_GRAPH_SNAPSHOT_ASSET_KEY])],
+    )
+    def phase2_stock_aapl() -> str:
+        return "aapl placeholder"
+
+    @dagster.asset(
+        name="phase2_stock_MSFT",
+        group_name=PHASE2_GROUP_NAME,
+        deps=[dagster.AssetKey([PHASE1_GRAPH_SNAPSHOT_ASSET_KEY])],
+    )
+    def phase2_stock_msft() -> str:
+        return "msft placeholder"
+
+    @dagster.asset_check(
+        asset=phase2_stock_aapl,
+        name="phase2_aapl_single_stock_gate",
+        blocking=False,
+    )
+    def phase2_aapl_single_stock_gate(gate_policy: GatePolicyResource) -> object:
+        event = Phase2SingleStockFailureEvent(
+            stock_id="AAPL",
+            failed_node="phase2_stock_AAPL",
+            failed_count=1,
+            total_count=10,
+            reason="fake LLM task failed",
+        )
+        decision = classify_phase2_single_stock_failure(event, gate_policy.policy)
+        return dagster.AssetCheckResult(
+            passed=decision.action is GateAction.CONTINUE,
+            metadata=inconclusive_metadata(event, decision),
+        )
+
+    defs = dagster.Definitions(
+        assets=[
+            phase0_readiness_ping,
+            candidate_freeze,
+            graph_snapshot,
+            phase2_stock_aapl,
+            phase2_stock_msft,
+        ],
+        asset_checks=[phase2_aapl_single_stock_gate],
+        jobs=[daily_cycle_job],
+        resources={
+            "gate_policy": GatePolicyResource(policy_path=stub_policy_path),
+        },
+    )
+    dagster.Definitions.validate_loadable(defs)
+
+    result = defs.get_job_def("daily_cycle_job").execute_in_process(
+        instance=dagster_instance,
+        tags={"cycle_id": "cycle-20260416"},
+    )
+    materialized_keys = asset_materialization_keys(result)
+    evaluation = _single_evaluation(
+        asset_check_evaluations(result),
+        "phase2_aapl_single_stock_gate",
+    )
+
+    assert result.success is True
+    assert dagster.AssetKey(["phase2_stock_AAPL"]) in materialized_keys
+    assert dagster.AssetKey(["phase2_stock_MSFT"]) in materialized_keys
+    assert getattr(evaluation, "passed", None) is False
+    assert metadata_value(evaluation, "action") == "mark_inconclusive"
+    assert metadata_value(evaluation, "stock_id") == "AAPL"
+    assert metadata_value(evaluation, "failure_rate") == 0.1
+
+
+def _single_evaluation(evaluations: list[object], check_name: str) -> object:
+    matches = [
+        evaluation
+        for evaluation in evaluations
+        if _check_name(evaluation) == check_name
+    ]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _check_name(evaluation: object) -> str | None:
+    check_name = getattr(evaluation, "check_name", None)
+    if isinstance(check_name, str):
+        return check_name
+    check_key = getattr(evaluation, "check_key", None)
+    name = getattr(check_key, "name", None)
+    return name if isinstance(name, str) else None


### PR DESCRIPTION
Closes #23

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/orchestrator/checks/dbt_events.py`, `src/orchestrator/checks/phase1.py`, `src/orchestrator/sensors/manual_rerun.py`, `tests/integration/conftest.py`, `tests/test_definitions.py`


---
### 1. 背景与目标
项目文档 §12.3 第 5 行要求 Phase 2 单股票 LLM 任务失败且未超阈值时标记 inconclusive 并继续其他股票。当前 policy 已有 phase2 + task_level -> mark_inconclusive，config/policy/gate_policy.lite.yaml 也有 thresholds.phase2_single_stock_tolerance，但实际代码还没有 Phase 2 task failure event adapter。目标是新增纯判定与非阻塞 Dagster 检查 wiring，让单股票失败在阈值内进入 MARK_INCONCLUSIVE，同时不阻断同池其他股票 fake assets。

### 2. 所属模块
src/orchestrator/checks/phase2.py（新增）、src/orchestrator/checks/__init__.py、tests/checks/test_phase2_single_stock_gate.py（新增）、tests/integration/test_phase2_inconclusive_path.py（新增）

### 3. 实现范围
- 新增 Phase2SingleStockFailureEvent dataclass，字段包含 failure_class: FailureClass = FailureClass.TASK_LEVEL、stock_id: str、failed_node: str、failed_count: int、total_count: int、reason: str | None = None。
- 实现 phase2_failure_rate(failed_count: int, total_count: int) -> float，校验 total_count > 0、0 <= failed_count <= total_count。
- 实现 classify_phase2_single_stock_failure(event: Phase2SingleStockFailureEvent, policy: GatePolicyProfile) -> GateDecision：当 failure rate <= policy.thresholds['phase2_single_stock_tolerance'] 时调用 classify_gate_result(PhaseEnum.PHASE2, event, policy)；超过阈值时抛 ValueError，由 #24 的整池 Gate 处理。
- 提供 inconclusive_metadata(event: Phase2SingleStockFailureEvent, decision: GateDecision) -> dict[str, str | float]，供 AssetCheckResult metadata 使用。
- 集成测试创建两个 fake stock assets：一个通过非阻塞 check 产出 mark_inconclusive metadata，另一个仍然 materialize，证明 run 继续。

### 4. 不在本次范围
- 不实现整池失败率超过阈值后的 fail_run；#24 处理。
- 不修改 main-core 的 LLM 调用、retry、业务标记写入逻辑。
- 不落库 inconclusive 结果；本 issue 只输出 GateDecision/metadata。
- 不创建 repair 或 rerun request。

### 5. 关键交付物
- Phase2SingleStockFailureEvent frozen dataclass，位于 orchestrator.checks.phase2。
- phase2_failure_rate(failed_count: int, total_count: int) -> float。
- classify_phase2_single_stock_failure(event: Phase2SingleStockFailureEvent, policy: GatePolicyProfile) -> GateDecision。
- inconclusive_metadata(event: Phase2SingleStockFailureEvent, decision: GateDecision) -> dict[str, str | float]。
- src/orchestrato