### PR TITLE
feat(#25): Phase 3 formal commit + manifest 发布

### DIFF
--- a/src/orchestrator/checks/__init__.py
+++ b/src/orchestrator/checks/__init__.py
@@ -30,6 +30,10 @@ from orchestrator.checks.phase2 import (
     inconclusive_metadata,
     phase2_failure_rate,
 )
+from orchestrator.checks.phase3 import (
+    FormalCommitFailureEvent,
+    classify_formal_commit_failure,
+)
 from orchestrator.policy import FailureClass, GateAction, PhaseEnum
 
 
@@ -51,6 +55,7 @@ def __getattr__(name: str) -> object:
 
 __all__ = [
     "FailureClass",
+    "FormalCommitFailureEvent",
     "GateAction",
     "DataReadinessSignal",
     "GateDecision",
@@ -68,6 +73,7 @@ __all__ = [
     "build_phase2_pool_failure_rate_check",
     "classify_gate_result",
     "classify_dbt_test_failure",
+    "classify_formal_commit_failure",
     "classify_graph_promotion_failure",
     "classify_phase2_pool_failure_rate",
     "classify_phase2_single_stock_failure",

--- a/src/orchestrator/checks/phase3.py
+++ b/src/orchestrator/checks/phase3.py
@@ -1,0 +1,34 @@
+"""Phase 3 formal commit and publish manifest gate adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from orchestrator.checks.classifier import classify_gate_result
+from orchestrator.checks.models import GateDecision
+from orchestrator.policy import FailureClass, GatePolicyProfile, PhaseEnum
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class FormalCommitFailureEvent:
+    """Normalized Phase 3 formal object commit failure event."""
+
+    failure_class: FailureClass = FailureClass.PUBLISH
+    failed_node: str
+    table_name: str | None = None
+    reason: str | None = None
+
+
+def classify_formal_commit_failure(
+    event: FormalCommitFailureEvent,
+    policy: GatePolicyProfile,
+) -> GateDecision:
+    """Classify a formal commit failure as a Phase 3 publish gate decision."""
+
+    return classify_gate_result(PhaseEnum.PHASE3, event, policy)
+
+
+__all__ = [
+    "FormalCommitFailureEvent",
+    "classify_formal_commit_failure",
+]

--- a/src/orchestrator/definitions.py
+++ b/src/orchestrator/definitions.py
@@ -37,6 +37,11 @@ from orchestrator.jobs.phase1 import (
     PHASE1_GROUP_NAME,
 )
 from orchestrator.jobs.phase2 import PHASE2_GROUP_NAME, PHASE2_STAGE_KEYS
+from orchestrator.jobs.phase3 import (
+    PHASE3_FORMAL_COMMIT_ASSET_KEY,
+    PHASE3_GROUP_NAME,
+    PHASE3_MANIFEST_ASSET_KEY,
+)
 from orchestrator.resources import AssetFactoryProvider, build_resource_bundle
 from orchestrator.schedules import daily_cycle_schedule
 from orchestrator.sensors.data_readiness import (
@@ -96,6 +101,16 @@ _PHASE2_SURFACE_PROFILES = frozenset(
         "p5",
         "p5+",
         "phase2",
+        "phase3",
+    }
+)
+_PHASE3_SURFACE_PROFILES = frozenset(
+    {
+        "milestone-3",
+        "milestone-4",
+        "p3",
+        "p5",
+        "p5+",
         "phase3",
     }
 )
@@ -164,6 +179,10 @@ def build_definitions(
         _validate_phase1_surface(provider_assets)
     if _requires_phase2_surface():
         _validate_phase2_surface(provider_assets)
+    _validate_phase3_provider_assets(
+        provider_assets,
+        require_surface=_requires_phase3_surface(),
+    )
     provider_checks = _collect_provider_checks(module_factory_list)
     phase2_builtin_checks = _build_phase2_builtin_checks(
         provider_assets,
@@ -399,6 +418,10 @@ def _requires_phase2_surface() -> bool:
     return _normalized_definitions_profile() in _PHASE2_SURFACE_PROFILES
 
 
+def _requires_phase3_surface() -> bool:
+    return _normalized_definitions_profile() in _PHASE3_SURFACE_PROFILES
+
+
 def _is_milestone_surface_profile() -> bool:
     return _normalized_definitions_profile() in _MILESTONE_SURFACE_PROFILES
 
@@ -484,6 +507,65 @@ def _validate_phase2_surface(provider_assets: Iterable[object]) -> None:
     raise ValueError(
         "phase2 milestone Definitions assembly requires provider assets "
         f"declaring group_name={PHASE2_GROUP_NAME!r}.",
+    )
+
+
+def _validate_phase3_provider_assets(
+    provider_assets: Iterable[object],
+    *,
+    require_surface: bool,
+) -> None:
+    formal_commit_key = AssetKey([PHASE3_FORMAL_COMMIT_ASSET_KEY])
+    manifest_key = AssetKey([PHASE3_MANIFEST_ASSET_KEY])
+    required_asset_key_names = {
+        formal_commit_key: PHASE3_FORMAL_COMMIT_ASSET_KEY,
+        manifest_key: PHASE3_MANIFEST_ASSET_KEY,
+    }
+    phase3_asset_defs: dict[AssetKey, object] = {}
+
+    for asset_def in provider_assets:
+        keys = tuple(getattr(asset_def, "keys", ()))
+        group_names = getattr(asset_def, "group_names_by_key", {})
+        for asset_key in keys:
+            if group_names.get(asset_key) == PHASE3_GROUP_NAME:
+                phase3_asset_defs[asset_key] = asset_def
+        for asset_key, asset_key_name in required_asset_key_names.items():
+            if asset_key not in keys:
+                continue
+            group_name = group_names.get(asset_key)
+            if group_name != PHASE3_GROUP_NAME:
+                raise ValueError(
+                    f"{asset_key_name} asset must declare "
+                    f"group_name={PHASE3_GROUP_NAME!r}; got {group_name!r}",
+                )
+
+    if not phase3_asset_defs and not require_surface:
+        return
+
+    missing = [
+        asset_key_name
+        for asset_key, asset_key_name in required_asset_key_names.items()
+        if asset_key not in phase3_asset_defs
+    ]
+    if missing:
+        missing_items = ", ".join(missing)
+        raise ValueError(
+            "phase3 provider assets must include formal commit and publish "
+            f"manifest assets. Missing: {missing_items}.",
+        )
+
+    if _has_required_dependency_ancestry(
+        manifest_key,
+        phase3_asset_defs,
+        frozenset({formal_commit_key}),
+        frozenset(phase3_asset_defs),
+        seen=frozenset(),
+    ):
+        return
+
+    raise ValueError(
+        "phase3 cycle_publish_manifest asset must depend on "
+        "formal_objects_commit before it can be included in daily_cycle_job.",
     )
 
 

--- a/src/orchestrator/definitions.py
+++ b/src/orchestrator/definitions.py
@@ -554,18 +554,38 @@ def _validate_phase3_provider_assets(
             f"manifest assets. Missing: {missing_items}.",
         )
 
-    if _has_required_dependency_ancestry(
+    if not _has_required_dependency_ancestry(
         manifest_key,
         phase3_asset_defs,
         frozenset({formal_commit_key}),
         frozenset(phase3_asset_defs),
         seen=frozenset(),
     ):
+        raise ValueError(
+            "phase3 cycle_publish_manifest asset must depend on "
+            "formal_objects_commit before it can be included in daily_cycle_job.",
+        )
+
+    phase2_boundary_key = _phase2_pool_gate_asset_key(provider_assets)
+    if phase2_boundary_key is None:
+        raise ValueError(
+            "phase3 formal_objects_commit asset requires a Phase 2 boundary "
+            "asset before it can be included in daily_cycle_job.",
+        )
+
+    if _has_required_dependency_ancestry(
+        formal_commit_key,
+        phase3_asset_defs,
+        frozenset({phase2_boundary_key}),
+        frozenset(phase3_asset_defs),
+        seen=frozenset(),
+    ):
         return
 
     raise ValueError(
-        "phase3 cycle_publish_manifest asset must depend on "
-        "formal_objects_commit before it can be included in daily_cycle_job.",
+        "phase3 formal_objects_commit asset must depend on the Phase 2 "
+        f"boundary asset {phase2_boundary_key.to_user_string()!r} before "
+        "cycle_publish_manifest can be included in daily_cycle_job.",
     )
 
 

--- a/src/orchestrator/jobs/__init__.py
+++ b/src/orchestrator/jobs/__init__.py
@@ -15,6 +15,11 @@ from orchestrator.jobs.phase1 import (
     PHASE1_GROUP_NAME,
 )
 from orchestrator.jobs.phase2 import PHASE2_GROUP_NAME, PHASE2_STAGE_KEYS
+from orchestrator.jobs.phase3 import (
+    PHASE3_FORMAL_COMMIT_ASSET_KEY,
+    PHASE3_GROUP_NAME,
+    PHASE3_MANIFEST_ASSET_KEY,
+)
 
 __all__ = [
     "PHASE0_CANDIDATE_FREEZE_ASSET_KEY",
@@ -26,6 +31,9 @@ __all__ = [
     "PHASE1_GROUP_NAME",
     "PHASE2_GROUP_NAME",
     "PHASE2_STAGE_KEYS",
+    "PHASE3_FORMAL_COMMIT_ASSET_KEY",
+    "PHASE3_GROUP_NAME",
+    "PHASE3_MANIFEST_ASSET_KEY",
     "build_daily_cycle_jobs",
     "daily_cycle_job",
     "dbt_phase0_assets",

--- a/src/orchestrator/jobs/cycle.py
+++ b/src/orchestrator/jobs/cycle.py
@@ -9,6 +9,7 @@ from orchestrator.checks.phase1 import build_phase1_graph_failure_gate_hook
 from orchestrator.jobs.phase0_constants import PHASE0_GROUP_NAME
 from orchestrator.jobs.phase1 import PHASE1_GROUP_NAME
 from orchestrator.jobs.phase2 import PHASE2_GROUP_NAME
+from orchestrator.jobs.phase3 import PHASE3_GROUP_NAME
 
 
 daily_cycle_job = define_asset_job(
@@ -17,6 +18,7 @@ daily_cycle_job = define_asset_job(
         PHASE0_GROUP_NAME,
         PHASE1_GROUP_NAME,
         PHASE2_GROUP_NAME,
+        PHASE3_GROUP_NAME,
     ),
     hooks={build_phase1_graph_failure_gate_hook()},
 )

--- a/src/orchestrator/jobs/phase3.py
+++ b/src/orchestrator/jobs/phase3.py
@@ -1,0 +1,11 @@
+"""Phase 3 publish asset group contract constants."""
+
+PHASE3_GROUP_NAME: str = "phase3"
+PHASE3_FORMAL_COMMIT_ASSET_KEY: str = "formal_objects_commit"
+PHASE3_MANIFEST_ASSET_KEY: str = "cycle_publish_manifest"
+
+__all__ = [
+    "PHASE3_FORMAL_COMMIT_ASSET_KEY",
+    "PHASE3_GROUP_NAME",
+    "PHASE3_MANIFEST_ASSET_KEY",
+]

--- a/tests/checks/test_phase3_publish_gate.py
+++ b/tests/checks/test_phase3_publish_gate.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import fields
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from orchestrator.checks import (
+    FormalCommitFailureEvent,
+    classify_formal_commit_failure,
+)
+from orchestrator.policy import FailureClass, GateAction, PhaseEnum, load_gate_policy
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LITE_POLICY_PATH = REPO_ROOT / "config" / "policy" / "gate_policy.lite.yaml"
+
+
+@pytest.fixture
+def gate_policy() -> Any:
+    return load_gate_policy(LITE_POLICY_PATH)
+
+
+def test_formal_commit_failure_event_fields_match_contract() -> None:
+    assert [field.name for field in fields(FormalCommitFailureEvent)] == [
+        "failure_class",
+        "failed_node",
+        "table_name",
+        "reason",
+    ]
+
+
+def test_classify_formal_commit_failure_uses_phase3_publish_policy(
+    gate_policy: Any,
+) -> None:
+    event = FormalCommitFailureEvent(
+        failed_node="formal_objects_commit",
+        table_name="formal.daily_scores",
+        reason="commit failed",
+    )
+
+    decision = classify_formal_commit_failure(event, gate_policy)
+
+    assert event.failure_class is FailureClass.PUBLISH
+    assert decision.phase is PhaseEnum.PHASE3
+    assert decision.failure_class is FailureClass.PUBLISH
+    assert decision.action is GateAction.FAIL_RUN
+    assert (
+        decision.reason
+        == "Formal table commit failed; fail Phase 3 before writing manifest."
+    )

--- a/tests/integration/test_phase3_publish_wiring.py
+++ b/tests/integration/test_phase3_publish_wiring.py
@@ -131,6 +131,34 @@ def test_phase3_manifest_without_formal_commit_dependency_is_rejected(
         )
 
 
+def test_phase3_formal_commit_without_phase2_dependency_is_rejected(
+    dagster_module: object,
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+) -> None:
+    dagster = dagster_module
+
+    from orchestrator.definitions import build_definitions
+
+    with pytest.raises(
+        ValueError,
+        match="formal_objects_commit.*Phase 2.*l7",
+    ):
+        build_definitions(
+            module_factories=[
+                _fake_phase0_surface_provider(dagster),
+                _fake_phase1_provider(dagster),
+                _fake_phase2_provider(dagster),
+                _fake_phase3_provider(
+                    dagster,
+                    phase3_calls=[],
+                    commit_depends_on_phase2=False,
+                ),
+            ],
+            policy_path=stub_policy_path,
+        )
+
+
 def test_phase3_provider_requires_publish_manifest_asset(
     dagster_module: object,
     stub_policy_path: str,
@@ -283,6 +311,7 @@ def _fake_phase3_provider(
     *,
     fail_commit: bool = False,
     include_manifest: bool = True,
+    commit_depends_on_phase2: bool = True,
     manifest_depends_on_commit: bool = True,
 ) -> object:
     from orchestrator.jobs.phase3 import (
@@ -291,16 +320,30 @@ def _fake_phase3_provider(
         PHASE3_MANIFEST_ASSET_KEY,
     )
 
-    @dagster.asset(
-        name=PHASE3_FORMAL_COMMIT_ASSET_KEY,
-        group_name=PHASE3_GROUP_NAME,
-    )
-    def formal_objects_commit(l7: str) -> str:
-        assert l7
-        phase3_calls.append(PHASE3_FORMAL_COMMIT_ASSET_KEY)
-        if fail_commit:
-            raise RuntimeError("fake formal commit failed")
-        return "formal-commit-ok"
+    if commit_depends_on_phase2:
+
+        @dagster.asset(
+            name=PHASE3_FORMAL_COMMIT_ASSET_KEY,
+            group_name=PHASE3_GROUP_NAME,
+        )
+        def formal_objects_commit(l7: str) -> str:
+            assert l7
+            phase3_calls.append(PHASE3_FORMAL_COMMIT_ASSET_KEY)
+            if fail_commit:
+                raise RuntimeError("fake formal commit failed")
+            return "formal-commit-ok"
+
+    else:
+
+        @dagster.asset(
+            name=PHASE3_FORMAL_COMMIT_ASSET_KEY,
+            group_name=PHASE3_GROUP_NAME,
+        )
+        def formal_objects_commit() -> str:
+            phase3_calls.append(PHASE3_FORMAL_COMMIT_ASSET_KEY)
+            if fail_commit:
+                raise RuntimeError("fake formal commit failed")
+            return "formal-commit-ok"
 
     if include_manifest and manifest_depends_on_commit:
 

--- a/tests/integration/test_phase3_publish_wiring.py
+++ b/tests/integration/test_phase3_publish_wiring.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.integration.conftest import asset_materialization_keys
+
+
+def test_phase3_publish_assets_materialize_after_formal_commit(
+    dagster_module: object,
+    dagster_instance: object,
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+) -> None:
+    dagster = dagster_module
+
+    from orchestrator.definitions import build_definitions
+    from orchestrator.jobs.cycle import daily_cycle_job
+    from orchestrator.jobs.phase3 import (
+        PHASE3_FORMAL_COMMIT_ASSET_KEY,
+        PHASE3_GROUP_NAME,
+        PHASE3_MANIFEST_ASSET_KEY,
+    )
+
+    phase3_calls: list[str] = []
+    phase3_provider = _fake_phase3_provider(dagster, phase3_calls)
+    defs = build_definitions(
+        module_factories=[
+            _fake_phase0_surface_provider(dagster),
+            _fake_phase1_provider(dagster),
+            _fake_phase2_provider(dagster),
+            phase3_provider,
+        ],
+        policy_path=stub_policy_path,
+    )
+
+    dagster.Definitions.validate_loadable(defs)
+
+    formal_commit_key = dagster.AssetKey([PHASE3_FORMAL_COMMIT_ASSET_KEY])
+    manifest_key = dagster.AssetKey([PHASE3_MANIFEST_ASSET_KEY])
+    selected_keys = daily_cycle_job.selection.resolve(defs.assets or ())
+    manifest_def = _asset_def_for_key(defs.assets or (), manifest_key)
+
+    assert _asset_keys_for_group(defs, PHASE3_GROUP_NAME) == {
+        formal_commit_key,
+        manifest_key,
+    }
+    assert formal_commit_key in selected_keys
+    assert manifest_key in selected_keys
+    assert formal_commit_key in _asset_dependency_keys(manifest_def, manifest_key)
+
+    result = defs.get_job_def("daily_cycle_job").execute_in_process(
+        instance=dagster_instance,
+        tags={"cycle_id": "cycle-20260416"},
+    )
+    materialized_keys = asset_materialization_keys(result)
+
+    assert result.success is True
+    assert formal_commit_key in materialized_keys
+    assert manifest_key in materialized_keys
+    assert phase3_calls == [
+        PHASE3_FORMAL_COMMIT_ASSET_KEY,
+        PHASE3_MANIFEST_ASSET_KEY,
+    ]
+
+
+def test_phase3_commit_failure_fails_run_without_manifest_materialization(
+    dagster_module: object,
+    dagster_instance: object,
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+) -> None:
+    dagster = dagster_module
+
+    from orchestrator.definitions import build_definitions
+    from orchestrator.jobs.phase3 import (
+        PHASE3_FORMAL_COMMIT_ASSET_KEY,
+        PHASE3_MANIFEST_ASSET_KEY,
+    )
+
+    phase3_calls: list[str] = []
+    defs = build_definitions(
+        module_factories=[
+            _fake_phase0_surface_provider(dagster),
+            _fake_phase1_provider(dagster),
+            _fake_phase2_provider(dagster),
+            _fake_phase3_provider(dagster, phase3_calls, fail_commit=True),
+        ],
+        policy_path=stub_policy_path,
+    )
+    dagster.Definitions.validate_loadable(defs)
+
+    result = defs.get_job_def("daily_cycle_job").execute_in_process(
+        instance=dagster_instance,
+        raise_on_error=False,
+        tags={"cycle_id": "cycle-20260416"},
+    )
+    materialized_keys = asset_materialization_keys(result)
+
+    assert result.success is False
+    assert dagster.AssetKey([PHASE3_FORMAL_COMMIT_ASSET_KEY]) not in materialized_keys
+    assert dagster.AssetKey([PHASE3_MANIFEST_ASSET_KEY]) not in materialized_keys
+    assert phase3_calls == [PHASE3_FORMAL_COMMIT_ASSET_KEY]
+
+
+def test_phase3_manifest_without_formal_commit_dependency_is_rejected(
+    dagster_module: object,
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+) -> None:
+    dagster = dagster_module
+
+    from orchestrator.definitions import build_definitions
+
+    with pytest.raises(
+        ValueError,
+        match="cycle_publish_manifest.*formal_objects_commit",
+    ):
+        build_definitions(
+            module_factories=[
+                _fake_phase3_provider(
+                    dagster,
+                    phase3_calls=[],
+                    manifest_depends_on_commit=False,
+                ),
+            ],
+            policy_path=stub_policy_path,
+        )
+
+
+def test_phase3_provider_requires_publish_manifest_asset(
+    dagster_module: object,
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+) -> None:
+    dagster = dagster_module
+
+    from orchestrator.definitions import build_definitions
+
+    with pytest.raises(ValueError, match="cycle_publish_manifest"):
+        build_definitions(
+            module_factories=[
+                _fake_phase3_provider(
+                    dagster,
+                    phase3_calls=[],
+                    include_manifest=False,
+                ),
+            ],
+            policy_path=stub_policy_path,
+        )
+
+
+def _fake_phase0_surface_provider(dagster: Any) -> object:
+    from orchestrator.checks import DataReadinessSignal
+    from orchestrator.jobs.phase0_constants import (
+        PHASE0_CANDIDATE_FREEZE_ASSET_KEY,
+        PHASE0_GROUP_NAME,
+    )
+    from orchestrator.sensors.data_readiness import DATA_READINESS_RESOURCE_KEY
+
+    class FakeDataReadinessProvider:
+        def get_data_readiness_signal(self) -> DataReadinessSignal:
+            return DataReadinessSignal(ready=True, cycle_id="cycle-20260416")
+
+    class FakeDataReadinessResource(dagster.ConfigurableResource):
+        def create_resource(self, context: object) -> FakeDataReadinessProvider:
+            return FakeDataReadinessProvider()
+
+    class FakeLLMHealthResult:
+        healthy = True
+        summary = "provider ready"
+        provider = "fake-llm"
+
+    class FakeLLMHealthProbe:
+        def check_health(self) -> FakeLLMHealthResult:
+            return FakeLLMHealthResult()
+
+    class FakeLLMHealthProbeResource(dagster.ConfigurableResource):
+        def create_resource(self, context: object) -> FakeLLMHealthProbe:
+            return FakeLLMHealthProbe()
+
+    @dagster.asset(
+        name=PHASE0_CANDIDATE_FREEZE_ASSET_KEY,
+        group_name=PHASE0_GROUP_NAME,
+    )
+    def candidate_freeze() -> str:
+        return "frozen"
+
+    class FakePhase0SurfaceProvider:
+        def get_assets(self) -> tuple[object, ...]:
+            return (candidate_freeze,)
+
+        def get_checks(self) -> tuple[object, ...]:
+            return ()
+
+        def get_resources(self) -> dict[str, object]:
+            return {
+                DATA_READINESS_RESOURCE_KEY: FakeDataReadinessResource(),
+                "llm_health_probe": FakeLLMHealthProbeResource(),
+            }
+
+    return FakePhase0SurfaceProvider()
+
+
+def _fake_phase1_provider(dagster: Any) -> object:
+    from orchestrator.jobs.phase0_constants import (
+        PHASE0_CANDIDATE_FREEZE_ASSET_KEY,
+        PHASE0_READINESS_ASSET_KEY,
+    )
+    from orchestrator.jobs.phase1 import (
+        PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
+        PHASE1_GROUP_NAME,
+    )
+
+    @dagster.asset(
+        name=PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
+        group_name=PHASE1_GROUP_NAME,
+        deps=[
+            dagster.AssetKey([PHASE0_READINESS_ASSET_KEY]),
+            dagster.AssetKey([PHASE0_CANDIDATE_FREEZE_ASSET_KEY]),
+        ],
+    )
+    def graph_snapshot() -> str:
+        return "snapshot"
+
+    class FakePhase1Provider:
+        def get_assets(self) -> tuple[object, ...]:
+            return (graph_snapshot,)
+
+        def get_checks(self) -> tuple[object, ...]:
+            return ()
+
+        def get_resources(self) -> dict[str, object]:
+            return {}
+
+    return FakePhase1Provider()
+
+
+def _fake_phase2_provider(dagster: Any) -> object:
+    from orchestrator.checks import (
+        PHASE2_POOL_FAILURE_RATE_RESOURCE_KEY,
+        Phase2PoolFailureRateEvent,
+    )
+    from orchestrator.jobs.phase2 import PHASE2_GROUP_NAME, PHASE2_STAGE_KEYS
+
+    @dagster.asset(name=PHASE2_STAGE_KEYS[-1], group_name=PHASE2_GROUP_NAME)
+    def phase2_l7(graph_snapshot: str) -> str:
+        return f"{graph_snapshot}:l7"
+
+    class FakePhase2PoolFailureRateResource(dagster.ConfigurableResource):
+        def get_phase2_pool_failure_rate_event(
+            self,
+        ) -> Phase2PoolFailureRateEvent:
+            return Phase2PoolFailureRateEvent(
+                failed_count=0,
+                total_count=10,
+                failed_nodes=(),
+            )
+
+    class FakePhase2Provider:
+        def get_assets(self) -> tuple[object, ...]:
+            return (phase2_l7,)
+
+        def get_checks(self) -> tuple[object, ...]:
+            return ()
+
+        def get_resources(self) -> dict[str, object]:
+            return {
+                PHASE2_POOL_FAILURE_RATE_RESOURCE_KEY: (
+                    FakePhase2PoolFailureRateResource()
+                ),
+            }
+
+    return FakePhase2Provider()
+
+
+def _fake_phase3_provider(
+    dagster: Any,
+    phase3_calls: list[str],
+    *,
+    fail_commit: bool = False,
+    include_manifest: bool = True,
+    manifest_depends_on_commit: bool = True,
+) -> object:
+    from orchestrator.jobs.phase3 import (
+        PHASE3_FORMAL_COMMIT_ASSET_KEY,
+        PHASE3_GROUP_NAME,
+        PHASE3_MANIFEST_ASSET_KEY,
+    )
+
+    @dagster.asset(
+        name=PHASE3_FORMAL_COMMIT_ASSET_KEY,
+        group_name=PHASE3_GROUP_NAME,
+    )
+    def formal_objects_commit(l7: str) -> str:
+        assert l7
+        phase3_calls.append(PHASE3_FORMAL_COMMIT_ASSET_KEY)
+        if fail_commit:
+            raise RuntimeError("fake formal commit failed")
+        return "formal-commit-ok"
+
+    if include_manifest and manifest_depends_on_commit:
+
+        @dagster.asset(
+            name=PHASE3_MANIFEST_ASSET_KEY,
+            group_name=PHASE3_GROUP_NAME,
+        )
+        def cycle_publish_manifest(formal_objects_commit: str) -> str:
+            assert formal_objects_commit
+            phase3_calls.append(PHASE3_MANIFEST_ASSET_KEY)
+            return "manifest-ok"
+
+    elif include_manifest:
+
+        @dagster.asset(
+            name=PHASE3_MANIFEST_ASSET_KEY,
+            group_name=PHASE3_GROUP_NAME,
+        )
+        def cycle_publish_manifest() -> str:
+            phase3_calls.append(PHASE3_MANIFEST_ASSET_KEY)
+            return "manifest-ok"
+
+    phase3_assets = [formal_objects_commit]
+    if include_manifest:
+        phase3_assets.append(cycle_publish_manifest)
+
+    class FakePhase3Provider:
+        def get_assets(self) -> tuple[object, ...]:
+            return tuple(phase3_assets)
+
+        def get_checks(self) -> tuple[object, ...]:
+            return ()
+
+        def get_resources(self) -> dict[str, object]:
+            return {}
+
+    return FakePhase3Provider()
+
+
+def _asset_keys_for_group(defs: Any, group_name: str) -> set[object]:
+    return {
+        asset_key
+        for asset_def in defs.assets or ()
+        for asset_key in getattr(asset_def, "keys", ())
+        if getattr(asset_def, "group_names_by_key", {}).get(asset_key) == group_name
+    }
+
+
+def _asset_def_for_key(asset_defs: Iterable[object], asset_key: object) -> object:
+    for asset_def in asset_defs:
+        if asset_key in getattr(asset_def, "keys", ()):
+            return asset_def
+    pytest.fail(f"missing asset definition for {asset_key}")
+
+
+def _asset_dependency_keys(asset_def: object, asset_key: object) -> set[object]:
+    dependency_keys: set[object] = set()
+    for attribute_name in (
+        "asset_deps",
+        "dependency_keys_by_key",
+        "deps_by_key",
+    ):
+        dependency_mapping = getattr(asset_def, attribute_name, None)
+        if isinstance(dependency_mapping, Mapping):
+            dependency_keys.update(dependency_mapping.get(asset_key, ()))
+
+    raw_dependency_keys = getattr(asset_def, "dependency_keys", ())
+    if raw_dependency_keys:
+        dependency_keys.update(raw_dependency_keys)
+
+    return dependency_keys


### PR DESCRIPTION
Closes #25

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/orchestrator/checks/dbt_events.py`, `src/orchestrator/checks/phase1.py`, `src/orchestrator/sensors/manual_rerun.py`, `tests/integration/conftest.py`, `tests/test_definitions.py`


---
### 1. 背景与目标
项目文档 §8、§12.3 第 7 行、§21 要求 Phase 3 完成 formal object commit 后写入 cycle_publish_manifest，并且 formal 单表 commit 失败时 Phase 3 失败且不写 manifest。当前代码还没有 phase3 asset group，daily_cycle_job 也不会选择发布资产。目标是在现有 provider assembly 上接入 main-core 暴露的 formal commit 与 manifest assets，保证依赖顺序由 Dagster asset graph 承担，orchestrator 不实现 formal 写入逻辑。

### 2. 所属模块
src/orchestrator/jobs/phase3.py（新增）、src/orchestrator/jobs/cycle.py、src/orchestrator/jobs/__init__.py、src/orchestrator/definitions.py、src/orchestrator/checks/phase3.py（新增）、tests/integration/test_phase3_publish_wiring.py（新增）

### 3. 实现范围
- 新增 src/orchestrator/jobs/phase3.py，定义 PHASE3_GROUP_NAME: str = 'phase3'、PHASE3_FORMAL_COMMIT_ASSET_KEY: str = 'formal_objects_commit'、PHASE3_MANIFEST_ASSET_KEY: str = 'cycle_publish_manifest'。
- 修改 src/orchestrator/jobs/cycle.py，在 #24 后的成功路径 selection 中加入 PHASE3_GROUP_NAME，保持 build_daily_cycle_jobs(phase_config) 签名稳定。
- 在 src/orchestrator/definitions.py 追加 Phase 3 provider asset validation：manifest asset 必须存在，且 fake/real provider 的 manifest asset 不能绕过 formal commit dependency。
- 新增 src/orchestrator/checks/phase3.py 中 FormalCommitFailureEvent 与 classify_formal_commit_failure(event, policy) -> GateDecision，映射到 PhaseEnum.PHASE3 + FailureClass.PUBLISH。
- 集成测试构造 fake formal commit asset 与 cycle_publish_manifest asset；commit 成功时两者 materialize，commit 失败时 run fail 且 manifest 不 materialize。

### 4. 不在本次范围
- 不实现 formal table commit 或 manifest 写入 IO；这些来自 main-core provider。
- 不实现 manifest 写入失败后的 repair-only；#26 单独处理。
- 不回滚 formal 表，也不定义事务边界。
- 不接入 audit-eval retrospective hook；#27 处理。

### 5. 关键交付物
- PHASE3_GROUP_NAME: str = 'phase3'、PHASE3_FORMAL_COMMIT_ASSET_KEY: str、PHASE3_MANIFEST_ASSET_KEY: str。
- FormalCommitFailureEvent frozen dataclass，字段包含 failure_class: FailureClass = FailureClass.PUBLISH、failed_node: str、table_name: str | None、reason: str | None。
- classify_formal_commit_failure(event: FormalCommitFailureEvent, policy: GatePolicyProfile) -> GateDecision。
- daily_cycle_job selection 包含 Phase 