### PR TITLE
feat(#27): audit-eval asset 接入与 retrospective hook

### DIFF
--- a/src/orchestrator/definitions.py
+++ b/src/orchestrator/definitions.py
@@ -21,6 +21,7 @@ from orchestrator.checks.phase2 import (
     PHASE2_POOL_FAILURE_RATE_RESOURCE_KEY,
     build_phase2_pool_failure_rate_check,
 )
+from orchestrator.jobs.audit import AUDIT_EVAL_GROUP_NAME
 from orchestrator.jobs.cycle import daily_cycle_job
 from orchestrator.jobs.phase0 import (
     DBT_PROFILES_DIR,
@@ -183,6 +184,7 @@ def build_definitions(
         provider_assets,
         require_surface=_requires_phase3_surface(),
     )
+    _validate_audit_eval_provider_assets(provider_assets)
     provider_checks = _collect_provider_checks(module_factory_list)
     phase2_builtin_checks = _build_phase2_builtin_checks(
         provider_assets,
@@ -587,6 +589,51 @@ def _validate_phase3_provider_assets(
         f"boundary asset {phase2_boundary_key.to_user_string()!r} before "
         "cycle_publish_manifest can be included in daily_cycle_job.",
     )
+
+
+def _validate_audit_eval_provider_assets(provider_assets: Iterable[object]) -> None:
+    manifest_key = AssetKey([PHASE3_MANIFEST_ASSET_KEY])
+    all_provider_asset_defs: dict[AssetKey, object] = {}
+    audit_asset_defs: dict[AssetKey, object] = {}
+
+    for asset_def in provider_assets:
+        keys = tuple(getattr(asset_def, "keys", ()))
+        group_names = getattr(asset_def, "group_names_by_key", {})
+        for asset_key in keys:
+            all_provider_asset_defs[asset_key] = asset_def
+            if group_names.get(asset_key) == AUDIT_EVAL_GROUP_NAME:
+                audit_asset_defs[asset_key] = asset_def
+
+    if not audit_asset_defs:
+        return
+
+    provider_asset_keys = frozenset(all_provider_asset_defs)
+    if manifest_key not in provider_asset_keys:
+        raise ValueError(
+            "audit_eval provider assets require the Phase 3 "
+            "cycle_publish_manifest asset before they can be included in "
+            "daily_cycle_job.",
+        )
+
+    for asset_key in sorted(
+        audit_asset_defs,
+        key=lambda key: key.to_user_string(),
+    ):
+        if _has_required_dependency_ancestry(
+            asset_key,
+            all_provider_asset_defs,
+            frozenset({manifest_key}),
+            provider_asset_keys,
+            seen=frozenset(),
+        ):
+            continue
+
+        raise ValueError(
+            "audit_eval asset "
+            f"{asset_key.to_user_string()!r} must depend on "
+            "cycle_publish_manifest before it can be included in "
+            "daily_cycle_job.",
+        )
 
 
 def _build_phase2_builtin_checks(

--- a/src/orchestrator/jobs/__init__.py
+++ b/src/orchestrator/jobs/__init__.py
@@ -1,5 +1,9 @@
 """Dagster job and asset group exports."""
 
+from orchestrator.jobs.audit import (
+    AUDIT_EVAL_GROUP_NAME,
+    RETROSPECTIVE_HOOK_ASSET_KEY,
+)
 from orchestrator.jobs.cycle import build_daily_cycle_jobs, daily_cycle_job
 from orchestrator.jobs.phase0 import (
     PHASE0_CANDIDATE_FREEZE_ASSET_KEY,
@@ -22,6 +26,7 @@ from orchestrator.jobs.phase3 import (
 )
 
 __all__ = [
+    "AUDIT_EVAL_GROUP_NAME",
     "PHASE0_CANDIDATE_FREEZE_ASSET_KEY",
     "PHASE0_GROUP_NAME",
     "PHASE0_READINESS_ASSET_KEY",
@@ -34,6 +39,7 @@ __all__ = [
     "PHASE3_FORMAL_COMMIT_ASSET_KEY",
     "PHASE3_GROUP_NAME",
     "PHASE3_MANIFEST_ASSET_KEY",
+    "RETROSPECTIVE_HOOK_ASSET_KEY",
     "build_daily_cycle_jobs",
     "daily_cycle_job",
     "dbt_phase0_assets",

--- a/src/orchestrator/jobs/audit.py
+++ b/src/orchestrator/jobs/audit.py
@@ -1,0 +1,9 @@
+"""Audit-eval asset group contract constants."""
+
+AUDIT_EVAL_GROUP_NAME: str = "audit_eval"
+RETROSPECTIVE_HOOK_ASSET_KEY: str = "retrospective_hook"
+
+__all__ = [
+    "AUDIT_EVAL_GROUP_NAME",
+    "RETROSPECTIVE_HOOK_ASSET_KEY",
+]

--- a/src/orchestrator/jobs/cycle.py
+++ b/src/orchestrator/jobs/cycle.py
@@ -6,6 +6,7 @@ from typing import Any
 from dagster import AssetSelection, define_asset_job
 
 from orchestrator.checks.phase1 import build_phase1_graph_failure_gate_hook
+from orchestrator.jobs.audit import AUDIT_EVAL_GROUP_NAME
 from orchestrator.jobs.phase0_constants import PHASE0_GROUP_NAME
 from orchestrator.jobs.phase1 import PHASE1_GROUP_NAME
 from orchestrator.jobs.phase2 import PHASE2_GROUP_NAME
@@ -19,6 +20,7 @@ daily_cycle_job = define_asset_job(
         PHASE1_GROUP_NAME,
         PHASE2_GROUP_NAME,
         PHASE3_GROUP_NAME,
+        AUDIT_EVAL_GROUP_NAME,
     ),
     hooks={build_phase1_graph_failure_gate_hook()},
 )

--- a/tests/integration/test_audit_eval_wiring.py
+++ b/tests/integration/test_audit_eval_wiring.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.integration.conftest import (
+    asset_check_evaluations,
+    asset_materialization_keys,
+)
+from tests.integration.test_phase3_publish_wiring import (
+    _asset_def_for_key,
+    _asset_dependency_keys,
+    _fake_phase0_surface_provider,
+    _fake_phase1_provider,
+    _fake_phase2_provider,
+    _fake_phase3_provider,
+)
+
+
+def test_audit_eval_hook_materializes_after_publish_manifest(
+    dagster_module: object,
+    dagster_instance: object,
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+) -> None:
+    dagster = dagster_module
+
+    from orchestrator.definitions import build_definitions
+    from orchestrator.jobs.audit import (
+        AUDIT_EVAL_GROUP_NAME,
+        RETROSPECTIVE_HOOK_ASSET_KEY,
+    )
+    from orchestrator.jobs.cycle import daily_cycle_job
+    from orchestrator.jobs.phase3 import PHASE3_MANIFEST_ASSET_KEY
+
+    phase3_calls: list[str] = []
+    audit_calls: list[str] = []
+    defs = build_definitions(
+        module_factories=[
+            _fake_phase0_surface_provider(dagster),
+            _fake_phase1_provider(dagster),
+            _fake_phase2_provider(dagster),
+            _fake_phase3_provider(dagster, phase3_calls),
+            _fake_audit_eval_provider(dagster, audit_calls),
+        ],
+        policy_path=stub_policy_path,
+    )
+
+    dagster.Definitions.validate_loadable(defs)
+
+    manifest_key = dagster.AssetKey([PHASE3_MANIFEST_ASSET_KEY])
+    hook_key = dagster.AssetKey([RETROSPECTIVE_HOOK_ASSET_KEY])
+    selected_keys = daily_cycle_job.selection.resolve(defs.assets or ())
+    hook_def = _asset_def_for_key(defs.assets or (), hook_key)
+
+    assert _asset_keys_for_group(defs, AUDIT_EVAL_GROUP_NAME) == {hook_key}
+    assert hook_key in selected_keys
+    assert manifest_key in _asset_dependency_keys(hook_def, hook_key)
+    assert "fake_audit_eval_check" in _check_names(defs)
+    assert "fake_audit_eval_resource" in defs.resources
+
+    result = defs.get_job_def("daily_cycle_job").execute_in_process(
+        instance=dagster_instance,
+        tags={"cycle_id": "cycle-20260416"},
+    )
+    materialized_keys = asset_materialization_keys(result)
+    materialized_key_sequence = _asset_materialization_key_sequence(result)
+    evaluations = asset_check_evaluations(result)
+
+    assert result.success is True
+    assert manifest_key in materialized_keys
+    assert hook_key in materialized_keys
+    assert materialized_key_sequence.index(manifest_key) < (
+        materialized_key_sequence.index(hook_key)
+    )
+    assert audit_calls == [RETROSPECTIVE_HOOK_ASSET_KEY]
+    assert any(
+        _check_name(evaluation) == "fake_audit_eval_check"
+        and getattr(evaluation, "passed", None) is True
+        for evaluation in evaluations
+    )
+
+
+def test_audit_eval_hook_is_skipped_when_publish_manifest_fails(
+    dagster_module: object,
+    dagster_instance: object,
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+) -> None:
+    dagster = dagster_module
+
+    from orchestrator.definitions import build_definitions
+    from orchestrator.jobs.audit import RETROSPECTIVE_HOOK_ASSET_KEY
+    from orchestrator.jobs.phase3 import PHASE3_MANIFEST_ASSET_KEY
+
+    phase3_calls: list[str] = []
+    audit_calls: list[str] = []
+    defs = build_definitions(
+        module_factories=[
+            _fake_phase0_surface_provider(dagster),
+            _fake_phase1_provider(dagster),
+            _fake_phase2_provider(dagster),
+            _fake_phase3_manifest_failure_provider(dagster, phase3_calls),
+            _fake_audit_eval_provider(dagster, audit_calls),
+        ],
+        policy_path=stub_policy_path,
+    )
+
+    dagster.Definitions.validate_loadable(defs)
+
+    result = defs.get_job_def("daily_cycle_job").execute_in_process(
+        instance=dagster_instance,
+        raise_on_error=False,
+        tags={"cycle_id": "cycle-20260416"},
+    )
+    materialized_keys = asset_materialization_keys(result)
+
+    assert result.success is False
+    assert dagster.AssetKey([PHASE3_MANIFEST_ASSET_KEY]) not in materialized_keys
+    assert dagster.AssetKey([RETROSPECTIVE_HOOK_ASSET_KEY]) not in materialized_keys
+    assert audit_calls == []
+
+
+def test_audit_eval_hook_without_manifest_dependency_is_rejected(
+    dagster_module: object,
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+) -> None:
+    dagster = dagster_module
+
+    from orchestrator.definitions import build_definitions
+
+    with pytest.raises(
+        ValueError,
+        match="audit_eval.*retrospective_hook.*cycle_publish_manifest",
+    ):
+        build_definitions(
+            module_factories=[
+                _fake_phase0_surface_provider(dagster),
+                _fake_phase1_provider(dagster),
+                _fake_phase2_provider(dagster),
+                _fake_phase3_provider(dagster, phase3_calls=[]),
+                _fake_audit_eval_provider(
+                    dagster,
+                    audit_calls=[],
+                    depends_on_manifest=False,
+                ),
+            ],
+            policy_path=stub_policy_path,
+        )
+
+
+def _fake_audit_eval_provider(
+    dagster: Any,
+    audit_calls: list[str],
+    *,
+    depends_on_manifest: bool = True,
+) -> object:
+    from orchestrator.jobs.audit import (
+        AUDIT_EVAL_GROUP_NAME,
+        RETROSPECTIVE_HOOK_ASSET_KEY,
+    )
+
+    if depends_on_manifest:
+
+        @dagster.asset(
+            name=RETROSPECTIVE_HOOK_ASSET_KEY,
+            group_name=AUDIT_EVAL_GROUP_NAME,
+        )
+        def retrospective_hook(cycle_publish_manifest: str) -> str:
+            assert cycle_publish_manifest
+            audit_calls.append(RETROSPECTIVE_HOOK_ASSET_KEY)
+            return "retrospective-ok"
+
+    else:
+
+        @dagster.asset(
+            name=RETROSPECTIVE_HOOK_ASSET_KEY,
+            group_name=AUDIT_EVAL_GROUP_NAME,
+        )
+        def retrospective_hook() -> str:
+            audit_calls.append(RETROSPECTIVE_HOOK_ASSET_KEY)
+            return "retrospective-ok"
+
+    @dagster.asset_check(asset=retrospective_hook, name="fake_audit_eval_check")
+    def fake_audit_eval_check() -> object:
+        return dagster.AssetCheckResult(passed=True)
+
+    class FakeAuditEvalResource(dagster.ConfigurableResource):
+        enabled: bool = True
+
+    class FakeAuditEvalProvider:
+        def get_assets(self) -> tuple[object, ...]:
+            return (retrospective_hook,)
+
+        def get_checks(self) -> tuple[object, ...]:
+            return (fake_audit_eval_check,)
+
+        def get_resources(self) -> dict[str, object]:
+            return {"fake_audit_eval_resource": FakeAuditEvalResource()}
+
+    return FakeAuditEvalProvider()
+
+
+def _fake_phase3_manifest_failure_provider(
+    dagster: Any,
+    phase3_calls: list[str],
+) -> object:
+    from orchestrator.jobs.phase3 import (
+        PHASE3_FORMAL_COMMIT_ASSET_KEY,
+        PHASE3_GROUP_NAME,
+        PHASE3_MANIFEST_ASSET_KEY,
+    )
+
+    @dagster.asset(
+        name=PHASE3_FORMAL_COMMIT_ASSET_KEY,
+        group_name=PHASE3_GROUP_NAME,
+    )
+    def formal_objects_commit(l7: str) -> str:
+        assert l7
+        phase3_calls.append(PHASE3_FORMAL_COMMIT_ASSET_KEY)
+        return "formal-commit-ok"
+
+    @dagster.asset(
+        name=PHASE3_MANIFEST_ASSET_KEY,
+        group_name=PHASE3_GROUP_NAME,
+    )
+    def cycle_publish_manifest(formal_objects_commit: str) -> str:
+        assert formal_objects_commit
+        phase3_calls.append(PHASE3_MANIFEST_ASSET_KEY)
+        raise RuntimeError("fake manifest write failed")
+
+    class FakePhase3ManifestFailureProvider:
+        def get_assets(self) -> tuple[object, ...]:
+            return (formal_objects_commit, cycle_publish_manifest)
+
+        def get_checks(self) -> tuple[object, ...]:
+            return ()
+
+        def get_resources(self) -> dict[str, object]:
+            return {}
+
+    return FakePhase3ManifestFailureProvider()
+
+
+def _asset_keys_for_group(defs: Any, group_name: str) -> set[object]:
+    return {
+        asset_key
+        for asset_def in defs.assets or ()
+        for asset_key in getattr(asset_def, "keys", ())
+        if getattr(asset_def, "group_names_by_key", {}).get(asset_key) == group_name
+    }
+
+
+def _check_names(defs: Any) -> set[str]:
+    names: set[str] = set()
+    for check_def in defs.asset_checks or ():
+        names.update(
+            check_key.name
+            for check_key in getattr(check_def, "check_keys", ())
+        )
+        names.update(spec.name for spec in getattr(check_def, "specs", ()))
+        if name := getattr(check_def, "name", None):
+            names.add(name)
+    return names
+
+
+def _check_name(evaluation: object) -> str | None:
+    check_name = getattr(evaluation, "check_name", None)
+    if isinstance(check_name, str):
+        return check_name
+    check_key = getattr(evaluation, "check_key", None)
+    name = getattr(check_key, "name", None)
+    return name if isinstance(name, str) else None
+
+
+def _asset_materialization_key_sequence(result: object) -> list[object]:
+    keys: list[object] = []
+    for event in tuple(getattr(result, "all_events", ())):
+        if not (
+            getattr(event, "is_step_materialization", False)
+            or getattr(event, "event_type_value", None) == "ASSET_MATERIALIZATION"
+        ):
+            continue
+
+        asset_key = getattr(event, "asset_key", None)
+        if asset_key is None:
+            event_specific_data = getattr(event, "event_specific_data", None)
+            materialization = getattr(event_specific_data, "materialization", None)
+            asset_key = getattr(materialization, "asset_key", None)
+        if asset_key is not None:
+            keys.append(asset_key)
+    return keys

--- a/tests/integration/test_phase0_minimal_cycle.py
+++ b/tests/integration/test_phase0_minimal_cycle.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import ast
-import re
 from pathlib import Path
 
 import pytest
@@ -17,9 +16,6 @@ _FORBIDDEN_ROOT_MODULES = (
     "main" + "_core",
     "data" + "_platform",
     "audit" + "_eval",
-)
-_FORBIDDEN_BUSINESS_IMPORT = re.compile(
-    r"^(" + "|".join(re.escape(module) for module in _FORBIDDEN_ROOT_MODULES) + r")\.",
 )
 
 
@@ -154,7 +150,7 @@ def test_no_business_imports() -> None:
     for path in sorted((_REPO_ROOT / "src" / "orchestrator").rglob("*.py")):
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         for module_name, lineno in _absolute_imports(tree):
-            if _FORBIDDEN_BUSINESS_IMPORT.match(module_name):
+            if _is_forbidden_business_import(module_name):
                 relative_path = path.relative_to(_REPO_ROOT)
                 violations.append(f"{relative_path}:{lineno}: {module_name}")
 
@@ -171,6 +167,13 @@ def _absolute_imports(tree: ast.AST) -> list[tuple[str, int]]:
             imports.append((node.module, node.lineno))
 
     return imports
+
+
+def _is_forbidden_business_import(module_name: str) -> bool:
+    return any(
+        module_name == root or module_name.startswith(f"{root}.")
+        for root in _FORBIDDEN_ROOT_MODULES
+    )
 
 
 def _heartbeat_asset_key(dbt_phase0_assets: object) -> object:


### PR DESCRIPTION
Closes #27

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/orchestrator/checks/dbt_events.py`, `src/orchestrator/checks/phase1.py`, `src/orchestrator/sensors/manual_rerun.py`, `tests/integration/conftest.py`, `tests/test_definitions.py`


---
### 1. 背景与目标
项目文档 §5.2、§14 将 audit-eval 定位为审计、回放、retrospective assets 的提供方，orchestrator 只负责接入执行图，不承载业务定义。当前 build_definitions(...) 已能收集 provider assets/checks，但 daily cycle 尚无 audit-eval group，也没有 Phase 3 成功后的 retrospective hook 约束。目标是在 manifest 发布成功之后装配 audit-eval assets，使其作为执行图尾部 hook 运行。

### 2. 所属模块
src/orchestrator/jobs/audit.py（新增）、src/orchestrator/jobs/cycle.py、src/orchestrator/jobs/__init__.py、src/orchestrator/definitions.py、tests/integration/test_audit_eval_wiring.py（新增）

### 3. 实现范围
- 新增 src/orchestrator/jobs/audit.py，定义 AUDIT_EVAL_GROUP_NAME: str = 'audit_eval'、RETROSPECTIVE_HOOK_ASSET_KEY: str = 'retrospective_hook'，只描述 Dagster group/key contract。
- 修改 daily_cycle_job selection，在 #25 的 Phase 0-3 selection 后追加 AUDIT_EVAL_GROUP_NAME，保证 audit assets 被纳入同一 daily cycle。
- 在 src/orchestrator/definitions.py 复用 AssetFactoryProvider 收集 audit-eval provider assets/checks/resources；只校验 audit group asset 依赖 cycle_publish_manifest 或等价 manifest key，不实现 retrospective 逻辑。
- 新增集成测试 fake audit-eval provider：retrospective_hook(cycle_publish_manifest) 依赖 manifest asset，执行成功路径时 hook materialize，manifest 失败路径时 hook 不 materialize。
- 更新静态边界测试，禁止 audit_eval 私有业务 import 出现在 src/orchestrator。

### 4. 不在本次范围
- 不实现审计、回放、retrospective 计算逻辑。
- 不写 audit storage、报告、指标推送。
- 不处理 manifest repair-only；#26 已覆盖。
- 不引入 Kafka/Flink 事件流审计。

### 5. 关键交付物
- AUDIT_EVAL_GROUP_NAME: str = 'audit_eval'、RETROSPECTIVE_HOOK_ASSET_KEY: str = 'retrospective_hook'。
- daily_cycle_job selection 包含 audit-eval group，但执行顺序由 fake/real asset dependency retrospective_hook(cycle_publish_manifest) 保证。
- build_definitions(...) 能装配 fake audit provider 的 assets/checks/resources，不需要特殊业务 import。
- tests/integration/test_audit_eval_wiring.py 覆盖 manifest success -> audit hook runs，以及 manifest failure -> audit hook skipped。

### 6. 验收标准
- [ ] fake audit-eval provider 经 build_definitions(...) 后 Definitions.validate_loadable(defs) 成功。
- [ ] 成功路径中 retrospective_hook materialization 出现在 cycle_publish_manifest 之后。
- [ ] manifest f