### PR TITLE
feat(#26): Phase 3 manifest 补写 repair-only 路径

### DIFF
--- a/src/orchestrator/checks/__init__.py
+++ b/src/orchestrator/checks/__init__.py
@@ -32,7 +32,10 @@ from orchestrator.checks.phase2 import (
 )
 from orchestrator.checks.phase3 import (
     FormalCommitFailureEvent,
+    ManifestWriteFailureEvent,
     classify_formal_commit_failure,
+    classify_manifest_write_failure,
+    plan_manifest_repair_rerun,
 )
 from orchestrator.policy import FailureClass, GateAction, PhaseEnum
 
@@ -63,6 +66,7 @@ __all__ = [
     "GraphPromotionFailureEvent",
     "LLMHealthProbe",
     "LLMHealthResult",
+    "ManifestWriteFailureEvent",
     "PHASE2_POOL_FAILURE_RATE_CHECK_NAME",
     "PHASE2_POOL_FAILURE_RATE_RESOURCE_KEY",
     "Phase2PoolFailureRateEvent",
@@ -75,6 +79,7 @@ __all__ = [
     "classify_dbt_test_failure",
     "classify_formal_commit_failure",
     "classify_graph_promotion_failure",
+    "classify_manifest_write_failure",
     "classify_phase2_pool_failure_rate",
     "classify_phase2_single_stock_failure",
     "dispatch_gate_decision_alert",
@@ -84,5 +89,6 @@ __all__ = [
     "phase0_ping_check",
     "phase2_failure_rate",
     "plan_dbt_test_partial_rerun",
+    "plan_manifest_repair_rerun",
     "should_advance_ready_graph",
 ]

--- a/src/orchestrator/checks/phase3.py
+++ b/src/orchestrator/checks/phase3.py
@@ -7,6 +7,13 @@ from dataclasses import dataclass
 from orchestrator.checks.classifier import classify_gate_result
 from orchestrator.checks.models import GateDecision
 from orchestrator.policy import FailureClass, GatePolicyProfile, PhaseEnum
+from orchestrator.rerun import (
+    PartialRerunPlan,
+    RunHistorySnapshot,
+    compute_partial_rerun_plan,
+)
+
+PHASE3_MANIFEST_ASSET_KEY = "cycle_publish_manifest"
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -19,6 +26,16 @@ class FormalCommitFailureEvent:
     reason: str | None = None
 
 
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ManifestWriteFailureEvent:
+    """Normalized Phase 3 publish manifest write failure event."""
+
+    failure_class: FailureClass = FailureClass.INFRA
+    failed_node: str = PHASE3_MANIFEST_ASSET_KEY
+    repair_node: str
+    reason: str | None = None
+
+
 def classify_formal_commit_failure(
     event: FormalCommitFailureEvent,
     policy: GatePolicyProfile,
@@ -28,7 +45,46 @@ def classify_formal_commit_failure(
     return classify_gate_result(PhaseEnum.PHASE3, event, policy)
 
 
+def classify_manifest_write_failure(
+    event: ManifestWriteFailureEvent,
+    policy: GatePolicyProfile,
+) -> GateDecision:
+    """Classify a manifest write failure as a Phase 3 repair gate decision."""
+
+    return classify_gate_result(PhaseEnum.PHASE3, event, policy)
+
+
+def plan_manifest_repair_rerun(
+    run_id: str,
+    event: ManifestWriteFailureEvent,
+    policy: GatePolicyProfile,
+) -> PartialRerunPlan:
+    """Plan a repair-only rerun for the Phase 3 publish manifest asset."""
+
+    if not event.repair_node.strip():
+        raise ValueError("repair_node is required")
+
+    run_history = RunHistorySnapshot(
+        run_id=run_id,
+        node_to_phase={
+            event.failed_node: PhaseEnum.PHASE3,
+            event.repair_node: PhaseEnum.PHASE3,
+        },
+        node_dependencies={
+            event.failed_node: (),
+            event.repair_node: (),
+        },
+        failed_nodes=(event.failed_node,),
+        repairable_nodes={event.failed_node: event.repair_node},
+        node_failure_classes={event.failed_node: event.failure_class},
+    )
+    return compute_partial_rerun_plan(run_id, event.failed_node, run_history, policy)
+
+
 __all__ = [
     "FormalCommitFailureEvent",
+    "ManifestWriteFailureEvent",
     "classify_formal_commit_failure",
+    "classify_manifest_write_failure",
+    "plan_manifest_repair_rerun",
 ]

--- a/src/orchestrator/sensors/manual_rerun.py
+++ b/src/orchestrator/sensors/manual_rerun.py
@@ -11,6 +11,7 @@ from dagster import AssetKey, RunRequest, SkipReason, sensor
 
 from orchestrator.cli.rerun import DEFAULT_REQUEST_DIR
 from orchestrator.jobs.cycle import daily_cycle_job
+from orchestrator.jobs.phase3 import PHASE3_FORMAL_COMMIT_ASSET_KEY
 
 _REQUEST_DIR_ENV = "ORCHESTRATOR_RERUN_REQUEST_DIR"
 _FAILED_DIR_NAME = ".failed"
@@ -122,6 +123,16 @@ def _validate_request(
             f"{rerun_mode}",
         )
 
+    repair_only_error = _validate_repair_only_selection(
+        request_name,
+        failed_node=failed_node,
+        rerun_mode=rerun_mode,
+        rerun_selection=rerun_selection,
+        requires_manual_ack=requires_manual_ack,
+    )
+    if repair_only_error is not None:
+        return None, repair_only_error
+
     generated_at = payload.get("generated_at")
     if not _is_non_empty_str(generated_at):
         return (
@@ -137,6 +148,43 @@ def _validate_request(
         "rerun_mode": rerun_mode,
         "generated_at": generated_at,
     }, None
+
+
+def _validate_repair_only_selection(
+    request_name: str,
+    *,
+    failed_node: str,
+    rerun_mode: object,
+    rerun_selection: list[object],
+    requires_manual_ack: bool,
+) -> str | None:
+    if rerun_mode != "repair_only":
+        return None
+
+    if not requires_manual_ack:
+        return (
+            f"invalid manual rerun request {request_name}: "
+            "repair_only requests require manual acknowledgment"
+        )
+    if len(rerun_selection) != 1:
+        return (
+            f"invalid manual rerun request {request_name}: "
+            "repair_only rerun_selection must contain exactly one repair asset"
+        )
+    selected_node = rerun_selection[0]
+    if selected_node == failed_node:
+        return (
+            f"invalid manual rerun request {request_name}: "
+            "repair_only rerun_selection must target a repair asset, not "
+            "the failed node"
+        )
+    if selected_node == PHASE3_FORMAL_COMMIT_ASSET_KEY:
+        return (
+            f"invalid manual rerun request {request_name}: "
+            "repair_only rerun_selection must not include formal_objects_commit"
+        )
+
+    return None
 
 
 def _build_run_request(payload: dict[str, Any]) -> RunRequest:

--- a/tests/checks/test_phase3_manifest_repair.py
+++ b/tests/checks/test_phase3_manifest_repair.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import fields
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from orchestrator.checks import (
+    ManifestWriteFailureEvent,
+    classify_manifest_write_failure,
+    dispatch_gate_decision_alert,
+    plan_manifest_repair_rerun,
+)
+from orchestrator.policy import FailureClass, GateAction, PhaseEnum, load_gate_policy
+from orchestrator.rerun_request import request_from_plan
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LITE_POLICY_PATH = REPO_ROOT / "config" / "policy" / "gate_policy.lite.yaml"
+PHASE3_FORMAL_COMMIT_ASSET_KEY = "formal_objects_commit"
+PHASE3_MANIFEST_ASSET_KEY = "cycle_publish_manifest"
+REPAIR_MANIFEST_ASSET_KEY = "repair_cycle_publish_manifest"
+
+
+@pytest.fixture
+def gate_policy() -> Any:
+    return load_gate_policy(LITE_POLICY_PATH)
+
+
+def test_manifest_write_failure_event_fields_match_contract() -> None:
+    assert [field.name for field in fields(ManifestWriteFailureEvent)] == [
+        "failure_class",
+        "failed_node",
+        "repair_node",
+        "reason",
+    ]
+
+
+def test_classify_manifest_write_failure_repairs_manifest(
+    gate_policy: Any,
+) -> None:
+    event = ManifestWriteFailureEvent(
+        repair_node=REPAIR_MANIFEST_ASSET_KEY,
+        reason="manifest write failed",
+    )
+
+    decision = classify_manifest_write_failure(event, gate_policy)
+
+    assert event.failure_class is FailureClass.INFRA
+    assert event.failed_node == PHASE3_MANIFEST_ASSET_KEY
+    assert decision.phase is PhaseEnum.PHASE3
+    assert decision.failure_class is FailureClass.INFRA
+    assert decision.action is GateAction.REPAIR_MANIFEST
+    assert (
+        decision.reason
+        == "Manifest write failed; alert and expose repair-only rerun."
+    )
+
+
+def test_plan_manifest_repair_rerun_selects_only_repair_asset(
+    gate_policy: Any,
+) -> None:
+    event = ManifestWriteFailureEvent(
+        repair_node=REPAIR_MANIFEST_ASSET_KEY,
+        reason="manifest write failed",
+    )
+
+    plan = plan_manifest_repair_rerun("run-phase3", event, gate_policy)
+    request = request_from_plan(plan)
+
+    assert plan.failed_node == PHASE3_MANIFEST_ASSET_KEY
+    assert plan.rerun_selection == (REPAIR_MANIFEST_ASSET_KEY,)
+    assert plan.rerun_mode == "repair_only"
+    assert plan.requires_manual_ack is True
+    assert PHASE3_FORMAL_COMMIT_ASSET_KEY not in plan.rerun_selection
+    assert PHASE3_MANIFEST_ASSET_KEY not in plan.rerun_selection
+    assert request["rerun_selection"] == [REPAIR_MANIFEST_ASSET_KEY]
+    assert request["rerun_mode"] == "repair_only"
+    assert request["requires_manual_ack"] is True
+
+
+def test_plan_manifest_repair_rerun_rejects_missing_repair_node(
+    gate_policy: Any,
+) -> None:
+    event = ManifestWriteFailureEvent(repair_node=" ")
+
+    with pytest.raises(ValueError, match="repair_node is required"):
+        plan_manifest_repair_rerun("run-phase3", event, gate_policy)
+
+
+def test_manifest_write_failure_alert_payload_contains_repair_action(
+    gate_policy: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    event = ManifestWriteFailureEvent(
+        repair_node=REPAIR_MANIFEST_ASSET_KEY,
+        reason="manifest write failed",
+    )
+    decision = classify_manifest_write_failure(event, gate_policy)
+
+    with caplog.at_level(logging.WARNING):
+        dispatch_gate_decision_alert(
+            decision,
+            cycle_id="cycle-20260416",
+            failed_node=event.failed_node,
+            summary=event.reason or "manifest write failed",
+            channels=("logging",),
+        )
+
+    payload = json.loads(caplog.records[-1].message)
+
+    assert payload["phase"] == "phase3"
+    assert payload["failure_class"] == "infra"
+    assert payload["action"] == "repair_manifest"
+    assert payload["failed_node"] == PHASE3_MANIFEST_ASSET_KEY

--- a/tests/integration/test_phase3_manifest_repair_flow.py
+++ b/tests/integration/test_phase3_manifest_repair_flow.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tests.integration.conftest import asset_materialization_keys
+
+
+def test_phase3_manifest_failure_emits_repair_only_request_without_rollback(
+    dagster_module: object,
+    dagster_instance: object,
+    stub_policy_path: str,
+    tmp_path: Path,
+) -> None:
+    dagster = dagster_module
+
+    from orchestrator.checks import (
+        ManifestWriteFailureEvent,
+        plan_manifest_repair_rerun,
+    )
+    from orchestrator.jobs.phase3 import (
+        PHASE3_FORMAL_COMMIT_ASSET_KEY,
+        PHASE3_MANIFEST_ASSET_KEY,
+    )
+    from orchestrator.policy import load_gate_policy
+    from orchestrator.rerun_request import request_from_plan
+    from orchestrator.sensors.manual_rerun import evaluate_manual_rerun_requests
+
+    repair_node = "repair_cycle_publish_manifest"
+    phase3_calls: list[str] = []
+
+    @dagster.asset(name=PHASE3_FORMAL_COMMIT_ASSET_KEY)
+    def formal_objects_commit() -> str:
+        phase3_calls.append(PHASE3_FORMAL_COMMIT_ASSET_KEY)
+        return "formal-commit-ok"
+
+    @dagster.asset(name=PHASE3_MANIFEST_ASSET_KEY)
+    def cycle_publish_manifest(formal_objects_commit: str) -> str:
+        assert formal_objects_commit == "formal-commit-ok"
+        phase3_calls.append(PHASE3_MANIFEST_ASSET_KEY)
+        raise RuntimeError("fake manifest write failed")
+
+    @dagster.asset(name=repair_node)
+    def repair_cycle_publish_manifest() -> str:
+        phase3_calls.append(repair_node)
+        return "repair-ok"
+
+    failed_result = dagster.materialize(
+        [formal_objects_commit, cycle_publish_manifest],
+        instance=dagster_instance,
+        raise_on_error=False,
+    )
+    failed_materialized_keys = asset_materialization_keys(failed_result)
+
+    assert failed_result.success is False
+    assert (
+        dagster.AssetKey([PHASE3_FORMAL_COMMIT_ASSET_KEY])
+        in failed_materialized_keys
+    )
+    assert (
+        dagster.AssetKey([PHASE3_MANIFEST_ASSET_KEY])
+        not in failed_materialized_keys
+    )
+    assert phase3_calls == [
+        PHASE3_FORMAL_COMMIT_ASSET_KEY,
+        PHASE3_MANIFEST_ASSET_KEY,
+    ]
+
+    event = ManifestWriteFailureEvent(
+        repair_node=repair_node,
+        reason="fake manifest write failed",
+    )
+    plan = plan_manifest_repair_rerun(
+        "run-phase3-manifest",
+        event,
+        load_gate_policy(stub_policy_path),
+    )
+    request_path = tmp_path / "repair.json"
+    request_path.write_text(json.dumps(request_from_plan(plan)), encoding="utf-8")
+
+    run_request = evaluate_manual_rerun_requests(tmp_path)
+
+    assert isinstance(run_request, dagster.RunRequest)
+    assert run_request.job_name == "daily_cycle_job"
+    assert run_request.run_key.startswith(
+        "manual-rerun:run-phase3-manifest:cycle_publish_manifest:"
+    )
+    assert run_request.tags == {
+        "rerun_of": "run-phase3-manifest",
+        "failed_node": PHASE3_MANIFEST_ASSET_KEY,
+        "rerun_mode": "repair_only",
+    }
+    assert _asset_selection_strings(run_request.asset_selection) == [repair_node]
+    assert PHASE3_FORMAL_COMMIT_ASSET_KEY not in _asset_selection_strings(
+        run_request.asset_selection,
+    )
+
+    repair_result = dagster.materialize(
+        [repair_cycle_publish_manifest],
+        instance=dagster_instance,
+    )
+    repair_materialized_keys = asset_materialization_keys(repair_result)
+
+    assert repair_result.success is True
+    assert dagster.AssetKey([repair_node]) in repair_materialized_keys
+    assert phase3_calls == [
+        PHASE3_FORMAL_COMMIT_ASSET_KEY,
+        PHASE3_MANIFEST_ASSET_KEY,
+        repair_node,
+    ]
+
+
+def test_manual_repair_only_request_rejects_formal_commit_selection(
+    dagster_module: object,
+    tmp_path: Path,
+) -> None:
+    dagster = dagster_module
+
+    from orchestrator.jobs.phase3 import (
+        PHASE3_FORMAL_COMMIT_ASSET_KEY,
+        PHASE3_MANIFEST_ASSET_KEY,
+    )
+    from orchestrator.sensors.manual_rerun import evaluate_manual_rerun_requests
+
+    request_path = tmp_path / "bad-repair.json"
+    request_path.write_text(
+        json.dumps(
+            {
+                "run_id": "run-phase3-manifest",
+                "failed_node": PHASE3_MANIFEST_ASSET_KEY,
+                "rerun_selection": [PHASE3_FORMAL_COMMIT_ASSET_KEY],
+                "requires_manual_ack": True,
+                "rerun_mode": "repair_only",
+                "generated_at": "2026-04-16T00:00:00+00:00",
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    result = evaluate_manual_rerun_requests(tmp_path)
+
+    assert isinstance(result, dagster.SkipReason)
+    assert "formal_objects_commit" in result.skip_message
+    assert not request_path.exists()
+    assert (tmp_path / ".failed" / "bad-repair.json").exists()
+
+
+def _asset_selection_strings(asset_selection: object) -> list[str]:
+    output: list[str] = []
+    for asset_key in asset_selection or ():
+        if isinstance(asset_key, str):
+            output.append(asset_key)
+            continue
+        if hasattr(asset_key, "to_user_string"):
+            output.append(asset_key.to_user_string())
+            continue
+        path = getattr(asset_key, "path", None)
+        if isinstance(path, list):
+            output.append("/".join(path))
+            continue
+        output.append(str(asset_key))
+    return output


### PR DESCRIPTION
Closes #26

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/orchestrator/checks/dbt_events.py`, `src/orchestrator/checks/phase1.py`, `src/orchestrator/sensors/manual_rerun.py`, `tests/integration/conftest.py`, `tests/test_definitions.py`


---
### 1. 背景与目标
项目文档 §12.3 第 8 行要求 manifest 写入失败时告警并暴露 repair-only rerun 入口，同时不回滚已 commit 的 formal 表。当前 orchestrator.rerun.compute_partial_rerun_plan(...) 已支持 repair_only，manual_rerun_sensor 已支持 rerun_mode 包含 repair_only，policy 中也已有 phase3 + infra -> repair_manifest。目标是把 Phase 3 manifest failure 归一化为 REPAIR_MANIFEST，生成只选择 manifest repair asset 的 rerun plan/request。

### 2. 所属模块
src/orchestrator/checks/phase3.py、src/orchestrator/rerun.py（仅必要时扩展 helper，不改现有签名）、src/orchestrator/sensors/manual_rerun.py、tests/checks/test_phase3_manifest_repair.py（新增）、tests/integration/test_phase3_manifest_repair_flow.py（新增）

### 3. 实现范围
- 在 #25 新增的 src/orchestrator/checks/phase3.py 中增加 ManifestWriteFailureEvent dataclass，字段包含 failure_class: FailureClass = FailureClass.INFRA、failed_node: str = PHASE3_MANIFEST_ASSET_KEY、repair_node: str、reason: str | None = None。
- 实现 classify_manifest_write_failure(event: ManifestWriteFailureEvent, policy: GatePolicyProfile) -> GateDecision，内部调用 classify_gate_result(PhaseEnum.PHASE3, event, policy)，期望 action 为 GateAction.REPAIR_MANIFEST。
- 实现 plan_manifest_repair_rerun(run_id: str, event: ManifestWriteFailureEvent, policy: GatePolicyProfile) -> PartialRerunPlan，构造 RunHistorySnapshot 并调用 compute_partial_rerun_plan(...)，repairable_nodes 只映射 manifest failure node 到 event.repair_node。
- 通过现有 _request_from_plan(plan) / evaluate_manual_rerun_requests(request_dir) 路径验证 repair-only request，确保 asset_selection 只包含 repair asset，不包含 formal commit asset。
- 集成测试构造 fake Phase 3：formal commit 成功、manifest 写入失败、repair asset 可单独 materialize；断言 formal commit materialization 保留且 repair plan 不回滚。

### 4. 不在本次范围
- 不实现 manifest 文件/数据库写入或补写业务逻辑；repair asset 由 main-core provider 暴露。
- 不修改 compute_partial_rerun_plan(...) 的公开签名。
- 不增加全链重跑入口。
- 不处理 formal commit 失败；#25 已覆盖。

### 5. 关键交付物
- ManifestWriteFailureEvent frozen dataclass。
- classify_manifest_write_failure(event: ManifestWriteFailureEvent, policy: GatePolicyProfile) -> GateDecision。
- plan_manifest_repair_rerun(run_id: str, ev