### PR TITLE
feat(#76): [milestone-2 review] P0: Milestone-2 profile does not require the full milestone surface

### DIFF
--- a/src/orchestrator/definitions.py
+++ b/src/orchestrator/definitions.py
@@ -21,7 +21,10 @@ from orchestrator.checks.phase2 import (
     PHASE2_POOL_FAILURE_RATE_RESOURCE_KEY,
     build_phase2_pool_failure_rate_check,
 )
-from orchestrator.jobs.audit import AUDIT_EVAL_GROUP_NAME
+from orchestrator.jobs.audit import (
+    AUDIT_EVAL_GROUP_NAME,
+    RETROSPECTIVE_HOOK_ASSET_KEY,
+)
 from orchestrator.jobs.cycle import daily_cycle_job
 from orchestrator.jobs.phase0 import (
     DBT_PROFILES_DIR,
@@ -107,12 +110,25 @@ _PHASE2_SURFACE_PROFILES = frozenset(
 )
 _PHASE3_SURFACE_PROFILES = frozenset(
     {
+        "milestone-2",
         "milestone-3",
         "milestone-4",
+        "p2",
         "p3",
         "p5",
         "p5+",
         "phase3",
+    }
+)
+_AUDIT_EVAL_SURFACE_PROFILES = frozenset(
+    {
+        "milestone-2",
+        "milestone-3",
+        "milestone-4",
+        "p2",
+        "p3",
+        "p5",
+        "p5+",
     }
 )
 _TRUTHY_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
@@ -184,7 +200,10 @@ def build_definitions(
         provider_assets,
         require_surface=_requires_phase3_surface(),
     )
-    _validate_audit_eval_provider_assets(provider_assets)
+    _validate_audit_eval_provider_assets(
+        provider_assets,
+        require_surface=_requires_audit_eval_surface(),
+    )
     provider_checks = _collect_provider_checks(module_factory_list)
     phase2_builtin_checks = _build_phase2_builtin_checks(
         provider_assets,
@@ -424,6 +443,10 @@ def _requires_phase3_surface() -> bool:
     return _normalized_definitions_profile() in _PHASE3_SURFACE_PROFILES
 
 
+def _requires_audit_eval_surface() -> bool:
+    return _normalized_definitions_profile() in _AUDIT_EVAL_SURFACE_PROFILES
+
+
 def _is_milestone_surface_profile() -> bool:
     return _normalized_definitions_profile() in _MILESTONE_SURFACE_PROFILES
 
@@ -591,8 +614,13 @@ def _validate_phase3_provider_assets(
     )
 
 
-def _validate_audit_eval_provider_assets(provider_assets: Iterable[object]) -> None:
+def _validate_audit_eval_provider_assets(
+    provider_assets: Iterable[object],
+    *,
+    require_surface: bool = False,
+) -> None:
     manifest_key = AssetKey([PHASE3_MANIFEST_ASSET_KEY])
+    retrospective_hook_key = AssetKey([RETROSPECTIVE_HOOK_ASSET_KEY])
     all_provider_asset_defs: dict[AssetKey, object] = {}
     audit_asset_defs: dict[AssetKey, object] = {}
 
@@ -605,7 +633,18 @@ def _validate_audit_eval_provider_assets(provider_assets: Iterable[object]) -> N
                 audit_asset_defs[asset_key] = asset_def
 
     if not audit_asset_defs:
+        if require_surface:
+            raise ValueError(
+                "audit_eval milestone Definitions assembly requires the "
+                "retrospective_hook asset. Missing: retrospective_hook asset.",
+            )
         return
+
+    if retrospective_hook_key not in audit_asset_defs:
+        raise ValueError(
+            "audit_eval provider assets must include the retrospective_hook "
+            "asset before they can be included in daily_cycle_job.",
+        )
 
     provider_asset_keys = frozenset(all_provider_asset_defs)
     if manifest_key not in provider_asset_keys:

--- a/tests/integration/test_audit_eval_wiring.py
+++ b/tests/integration/test_audit_eval_wiring.py
@@ -152,6 +152,54 @@ def test_audit_eval_hook_without_manifest_dependency_is_rejected(
         )
 
 
+@pytest.mark.parametrize("profile", ["milestone-2", "p2"])
+def test_milestone2_profiles_require_retrospective_hook_surface(
+    dagster_module: object,
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    profile: str,
+) -> None:
+    dagster = dagster_module
+
+    from orchestrator.definitions import build_definitions
+
+    monkeypatch.setenv("ORCHESTRATOR_DEFINITIONS_PROFILE", profile)
+
+    with pytest.raises(ValueError, match="audit_eval.*retrospective_hook"):
+        build_definitions(
+            module_factories=[
+                _fake_phase0_surface_provider(dagster),
+                _fake_phase1_provider(dagster),
+                _fake_phase2_provider(dagster),
+                _fake_phase3_provider(dagster, phase3_calls=[]),
+            ],
+            policy_path=stub_policy_path,
+        )
+
+
+def test_audit_eval_provider_without_retrospective_hook_is_rejected(
+    dagster_module: object,
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+) -> None:
+    dagster = dagster_module
+
+    from orchestrator.definitions import build_definitions
+
+    with pytest.raises(ValueError, match="audit_eval.*retrospective_hook"):
+        build_definitions(
+            module_factories=[
+                _fake_phase0_surface_provider(dagster),
+                _fake_phase1_provider(dagster),
+                _fake_phase2_provider(dagster),
+                _fake_phase3_provider(dagster, phase3_calls=[]),
+                _fake_non_hook_audit_eval_provider(dagster),
+            ],
+            policy_path=stub_policy_path,
+        )
+
+
 def _fake_audit_eval_provider(
     dagster: Any,
     audit_calls: list[str],
@@ -202,6 +250,26 @@ def _fake_audit_eval_provider(
             return {"fake_audit_eval_resource": FakeAuditEvalResource()}
 
     return FakeAuditEvalProvider()
+
+
+def _fake_non_hook_audit_eval_provider(dagster: Any) -> object:
+    from orchestrator.jobs.audit import AUDIT_EVAL_GROUP_NAME
+
+    @dagster.asset(name="audit_summary", group_name=AUDIT_EVAL_GROUP_NAME)
+    def audit_summary(cycle_publish_manifest: str) -> str:
+        return f"{cycle_publish_manifest}:audit-summary"
+
+    class FakeNonHookAuditEvalProvider:
+        def get_assets(self) -> tuple[object, ...]:
+            return (audit_summary,)
+
+        def get_checks(self) -> tuple[object, ...]:
+            return ()
+
+        def get_resources(self) -> dict[str, object]:
+            return {}
+
+    return FakeNonHookAuditEvalProvider()
 
 
 def _fake_phase3_manifest_failure_provider(

--- a/tests/integration/test_phase3_publish_wiring.py
+++ b/tests/integration/test_phase3_publish_wiring.py
@@ -181,6 +181,34 @@ def test_phase3_provider_requires_publish_manifest_asset(
         )
 
 
+@pytest.mark.parametrize("profile", ["milestone-2", "p2"])
+def test_milestone2_profiles_require_phase3_publish_surface(
+    dagster_module: object,
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    profile: str,
+) -> None:
+    dagster = dagster_module
+
+    from orchestrator.definitions import build_definitions
+
+    monkeypatch.setenv("ORCHESTRATOR_DEFINITIONS_PROFILE", profile)
+
+    with pytest.raises(
+        ValueError,
+        match="phase3.*formal_objects_commit.*cycle_publish_manifest",
+    ):
+        build_definitions(
+            module_factories=[
+                _fake_phase0_surface_provider(dagster),
+                _fake_phase1_provider(dagster),
+                _fake_phase2_provider(dagster),
+            ],
+            policy_path=stub_policy_path,
+        )
+
+
 def _fake_phase0_surface_provider(dagster: Any) -> object:
     from orchestrator.checks import DataReadinessSignal
     from orchestrator.jobs.phase0_constants import (
@@ -239,24 +267,32 @@ def _fake_phase1_provider(dagster: Any) -> object:
         PHASE0_READINESS_ASSET_KEY,
     )
     from orchestrator.jobs.phase1 import (
+        PHASE1_GRAPH_PROMOTION_ASSET_KEY,
         PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
         PHASE1_GROUP_NAME,
     )
 
     @dagster.asset(
-        name=PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
+        name=PHASE1_GRAPH_PROMOTION_ASSET_KEY,
         group_name=PHASE1_GROUP_NAME,
         deps=[
             dagster.AssetKey([PHASE0_READINESS_ASSET_KEY]),
             dagster.AssetKey([PHASE0_CANDIDATE_FREEZE_ASSET_KEY]),
         ],
     )
-    def graph_snapshot() -> str:
-        return "snapshot"
+    def graph_promotion() -> str:
+        return "promoted"
+
+    @dagster.asset(
+        name=PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
+        group_name=PHASE1_GROUP_NAME,
+    )
+    def graph_snapshot(graph_promotion: str) -> str:
+        return f"snapshot:{graph_promotion}"
 
     class FakePhase1Provider:
         def get_assets(self) -> tuple[object, ...]:
-            return (graph_snapshot,)
+            return (graph_promotion, graph_snapshot)
 
         def get_checks(self) -> tuple[object, ...]:
             return ()


### PR DESCRIPTION
Closes #76

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/orchestrator/checks/dbt_events.py`, `src/orchestrator/checks/phase1.py`, `src/orchestrator/checks/phase2.py`, `src/orchestrator/checks/phase3.py`, `src/orchestrator/definitions.py`, `src/orchestrator/sensors/manual_rerun.py`, `tests/integration/test_daily_cycle_four_phase.py`, `tests/test_definitions.py`


---
## 背景与目标
Milestone review for milestone-2 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The milestone-2 profile requires Phase 1 and Phase 2 assets, but Phase 3 is only required for milestone-3 and later, and audit_eval has no required surface profile at all. As a result, ORCHESTRATOR_DEFINITIONS_PROFILE=milestone-2 can assemble a daily_cycle_job without formal_objects_commit, cycle_publish_manifest, or retrospective_hook, even though issues #25, #27, and #28 make those part of this milestone's closure.

## 实现范围
- 修改文件: `src/orchestrator/definitions.py`
- Include milestone-2 and p2 in the Phase 3 required surface profile, add an audit_eval required surface profile for milestone-2, and validate that RETROSPECTIVE_HOOK_ASSET_KEY is present and depends on cycle_publish_manifest.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/orchestrator/.venv/bin/python -m pytest
```
