### PR TITLE
feat(#35): 编排层越界静态检查与反向依赖扫描

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test integration-test lint dagster-dev dbt-compile
+.PHONY: install test integration-test lint boundary-check dagster-dev dbt-compile
 
 install:
 	python3 -m pip install -e ".[dev]"
@@ -11,6 +11,9 @@ integration-test:
 
 lint:
 	python3 -m mypy src tests
+
+boundary-check:
+	python3 scripts/check_boundaries.py
 
 dagster-dev:
 	DAGSTER_HOME=./dagster_home dagster dev -m orchestrator.definitions

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository-local maintenance scripts."""

--- a/scripts/check_boundaries.py
+++ b/scripts/check_boundaries.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+
+FORBIDDEN_RUNTIME_IMPORT_ROOTS: tuple[str, ...] = (
+    "data_platform",
+    "graph_engine",
+    "main_core",
+    "audit_eval",
+    "stream_layer",
+    "kafka",
+    "flink",
+)
+
+BUSINESS_ALGORITHM_KEYWORDS: tuple[str, ...] = (
+    "pagerank",
+    "embedding",
+    "feature_",
+    "alpha_",
+    "factor_",
+    "rank_score",
+    "recommendation_score",
+)
+
+DEFAULT_SIBLING_MODULES: tuple[str, ...] = (
+    "data-platform",
+    "graph-engine",
+    "main-core",
+    "audit-eval",
+    "reasoner-runtime",
+    "stream-layer",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class BoundaryViolation:
+    path: Path
+    line: int
+    code: str
+    message: str
+
+
+def scan_orchestrator_boundaries(root: Path) -> list[BoundaryViolation]:
+    source_root = root / "src" / "orchestrator"
+    violations: list[BoundaryViolation] = []
+
+    for path, tree in _parse_python_files(source_root):
+        violations.extend(_scan_forbidden_imports(path, tree))
+        violations.extend(_scan_business_keywords(path, tree))
+
+    return violations
+
+
+def scan_reverse_imports(
+    workspace_root: Path,
+    module_names: Iterable[str],
+) -> list[BoundaryViolation]:
+    violations: list[BoundaryViolation] = []
+
+    for module_name in module_names:
+        source_root = workspace_root / module_name / "src"
+        if not source_root.exists():
+            continue
+
+        for path, tree in _parse_python_files(source_root):
+            for imported_module, line in _absolute_imports(tree):
+                if _matches_module_root(imported_module, ("orchestrator",)):
+                    violations.append(
+                        BoundaryViolation(
+                            path=path,
+                            line=line,
+                            code="reverse-import",
+                            message=(
+                                f"sibling module {module_name!r} imports "
+                                f"orchestrator runtime module {imported_module!r}"
+                            ),
+                        )
+                    )
+
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Check orchestrator module boundary rules.",
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path.cwd(),
+        help="Current orchestrator repository root. Defaults to cwd.",
+    )
+    args = parser.parse_args(argv)
+
+    root = args.root.resolve()
+    workspace_root = root.parent
+    violations = [
+        *scan_orchestrator_boundaries(root),
+        *scan_reverse_imports(workspace_root, DEFAULT_SIBLING_MODULES),
+    ]
+
+    for violation in violations:
+        print(_format_violation(violation, (root, workspace_root)))
+
+    return 1 if violations else 0
+
+
+def _parse_python_files(source_root: Path) -> Iterator[tuple[Path, ast.AST]]:
+    if not source_root.exists():
+        return
+
+    for path in sorted(source_root.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        yield path, ast.parse(source, filename=str(path))
+
+
+def _scan_forbidden_imports(
+    path: Path,
+    tree: ast.AST,
+) -> list[BoundaryViolation]:
+    violations: list[BoundaryViolation] = []
+
+    for module_name, line in _absolute_imports(tree):
+        if _matches_module_root(module_name, FORBIDDEN_RUNTIME_IMPORT_ROOTS):
+            violations.append(
+                BoundaryViolation(
+                    path=path,
+                    line=line,
+                    code="forbidden-import",
+                    message=f"forbidden runtime import {module_name!r}",
+                )
+            )
+
+    return violations
+
+
+def _scan_business_keywords(
+    path: Path,
+    tree: ast.AST,
+) -> list[BoundaryViolation]:
+    violations: list[BoundaryViolation] = []
+
+    for value, line, subject in _business_keyword_subjects(tree):
+        if keyword := _matched_business_keyword(value):
+            violations.append(
+                BoundaryViolation(
+                    path=path,
+                    line=line,
+                    code="business-keyword",
+                    message=(
+                        f"business algorithm keyword {keyword!r} found in "
+                        f"{subject} {value!r}"
+                    ),
+                )
+            )
+
+    return violations
+
+
+def _absolute_imports(tree: ast.AST) -> Iterator[tuple[str, int]]:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                yield alias.name, node.lineno
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            yield node.module, node.lineno
+
+
+def _business_keyword_subjects(tree: ast.AST) -> Iterator[tuple[str, int, str]]:
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            yield node.name, node.lineno, "function name"
+        elif isinstance(node, ast.ClassDef):
+            yield node.name, node.lineno, "class name"
+        elif isinstance(node, ast.arg):
+            yield node.arg, node.lineno, "argument name"
+        elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+            yield node.id, node.lineno, "variable name"
+        elif isinstance(node, ast.Attribute) and isinstance(node.ctx, ast.Store):
+            yield node.attr, node.lineno, "attribute name"
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                yield alias.name.rsplit(".", maxsplit=1)[-1], node.lineno, "import name"
+                if alias.asname:
+                    yield alias.asname, node.lineno, "import alias"
+        elif isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                yield alias.name, node.lineno, "import name"
+                if alias.asname:
+                    yield alias.asname, node.lineno, "import alias"
+        elif isinstance(node, ast.Constant) and isinstance(node.value, str):
+            yield node.value, node.lineno, "string constant"
+
+
+def _matched_business_keyword(value: str) -> str | None:
+    lowered = value.lower()
+    for keyword in BUSINESS_ALGORITHM_KEYWORDS:
+        if keyword in lowered:
+            return keyword
+    return None
+
+
+def _matches_module_root(module_name: str, roots: Iterable[str]) -> bool:
+    return any(
+        module_name == root or module_name.startswith(f"{root}.")
+        for root in roots
+    )
+
+
+def _format_violation(violation: BoundaryViolation, roots: Iterable[Path]) -> str:
+    path = violation.path
+    for root in roots:
+        try:
+            path = violation.path.relative_to(root)
+            break
+        except ValueError:
+            continue
+    return f"{path}:{violation.line}: {violation.code}: {violation.message}"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_phase0_minimal_cycle.py
+++ b/tests/integration/test_phase0_minimal_cycle.py
@@ -1,22 +1,16 @@
 from __future__ import annotations
 
-import ast
 from pathlib import Path
 
 import pytest
 
+from scripts.check_boundaries import scan_orchestrator_boundaries
 from tests.integration.conftest import (
     asset_check_evaluations,
     asset_materialization_keys,
 )
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
-_FORBIDDEN_ROOT_MODULES = (
-    "graph" + "_engine",
-    "main" + "_core",
-    "data" + "_platform",
-    "audit" + "_eval",
-)
 
 
 def test_materialize_phase0_readiness_ping(
@@ -145,35 +139,7 @@ def test_daily_cycle_job_executes_in_process(
 
 
 def test_no_business_imports() -> None:
-    violations: list[str] = []
-
-    for path in sorted((_REPO_ROOT / "src" / "orchestrator").rglob("*.py")):
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        for module_name, lineno in _absolute_imports(tree):
-            if _is_forbidden_business_import(module_name):
-                relative_path = path.relative_to(_REPO_ROOT)
-                violations.append(f"{relative_path}:{lineno}: {module_name}")
-
-    assert violations == []
-
-
-def _absolute_imports(tree: ast.AST) -> list[tuple[str, int]]:
-    imports: list[tuple[str, int]] = []
-
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            imports.extend((alias.name, node.lineno) for alias in node.names)
-        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
-            imports.append((node.module, node.lineno))
-
-    return imports
-
-
-def _is_forbidden_business_import(module_name: str) -> bool:
-    return any(
-        module_name == root or module_name.startswith(f"{root}.")
-        for root in _FORBIDDEN_ROOT_MODULES
-    )
+    assert scan_orchestrator_boundaries(_REPO_ROOT) == []
 
 
 def _heartbeat_asset_key(dbt_phase0_assets: object) -> object:

--- a/tests/integration/test_phase2_main_core_wiring.py
+++ b/tests/integration/test_phase2_main_core_wiring.py
@@ -1,18 +1,17 @@
 from __future__ import annotations
 
-import ast
 from pathlib import Path
 from typing import Any, cast
 
 import pytest
 
+from scripts.check_boundaries import scan_orchestrator_boundaries
 from tests.integration.conftest import (
     asset_check_evaluations,
     asset_materialization_keys,
 )
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
-_FORBIDDEN_RUNTIME_MODULE_ROOTS = ("main_core", "kafka", "flink")
 
 
 def test_phase2_provider_contributes_daily_cycle_assets_and_checks(
@@ -96,16 +95,7 @@ def test_milestone2_requires_phase2_provider_assets(
 
 
 def test_orchestrator_has_no_forbidden_phase2_runtime_imports() -> None:
-    violations: list[str] = []
-
-    for path in sorted((_REPO_ROOT / "src" / "orchestrator").rglob("*.py")):
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        for module_name, lineno in _absolute_imports(tree):
-            if _is_forbidden_runtime_import(module_name):
-                relative_path = path.relative_to(_REPO_ROOT)
-                violations.append(f"{relative_path}:{lineno}: {module_name}")
-
-    assert violations == []
+    assert scan_orchestrator_boundaries(_REPO_ROOT) == []
 
 
 def _fake_phase0_surface_provider(dagster: Any) -> object:
@@ -324,21 +314,3 @@ def _check_name(evaluation: object) -> str | None:
     name = getattr(check_key, "name", None)
     return name if isinstance(name, str) else None
 
-
-def _absolute_imports(tree: ast.AST) -> list[tuple[str, int]]:
-    imports: list[tuple[str, int]] = []
-
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            imports.extend((alias.name, node.lineno) for alias in node.names)
-        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
-            imports.append((node.module, node.lineno))
-
-    return imports
-
-
-def _is_forbidden_runtime_import(module_name: str) -> bool:
-    return any(
-        module_name == root or module_name.startswith(f"{root}.")
-        for root in _FORBIDDEN_RUNTIME_MODULE_ROOTS
-    )

--- a/tests/static/test_boundaries.py
+++ b/tests/static/test_boundaries.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.check_boundaries import (
+    DEFAULT_SIBLING_MODULES,
+    BoundaryViolation,
+    scan_orchestrator_boundaries,
+    scan_reverse_imports,
+)
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_current_workspace_has_no_boundary_violations() -> None:
+    violations = [
+        *scan_orchestrator_boundaries(_REPO_ROOT),
+        *scan_reverse_imports(_REPO_ROOT.parent, DEFAULT_SIBLING_MODULES),
+    ]
+
+    assert violations == []
+
+
+def test_business_keyword_violation_in_orchestrator_source(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "orchestrator"
+    source_path = repo_root / "src" / "orchestrator" / "business.py"
+    _write_source(
+        source_path,
+        "def compute_pagerank() -> str:\n"
+        "    return 'delegated'\n",
+    )
+
+    violations = scan_orchestrator_boundaries(repo_root)
+
+    assert _violation_codes(violations) == {"business-keyword"}
+    assert violations[0].path == source_path
+    assert violations[0].line == 1
+    assert "pagerank" in violations[0].message
+
+
+def test_forbidden_runtime_import_violation_in_orchestrator_source(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "orchestrator"
+    source_path = repo_root / "src" / "orchestrator" / "imports.py"
+    _write_source(source_path, "import main_core.foo\n")
+
+    violations = scan_orchestrator_boundaries(repo_root)
+
+    assert _violation_codes(violations) == {"forbidden-import"}
+    assert violations[0].path == source_path
+    assert violations[0].line == 1
+    assert "main_core.foo" in violations[0].message
+
+
+def test_reverse_import_violation_in_sibling_source(tmp_path: Path) -> None:
+    source_path = tmp_path / "main-core" / "src" / "main_core" / "flow.py"
+    _write_source(
+        source_path,
+        "from orchestrator.definitions import build_definitions\n",
+    )
+
+    violations = scan_reverse_imports(tmp_path, ("main-core",))
+
+    assert _violation_codes(violations) == {"reverse-import"}
+    assert violations[0].path == source_path
+    assert violations[0].line == 1
+    assert "orchestrator.definitions" in violations[0].message
+
+
+def test_missing_sibling_directory_is_skipped(tmp_path: Path) -> None:
+    assert scan_reverse_imports(tmp_path, ("main-core",)) == []
+
+
+def _write_source(path: Path, source: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+
+
+def _violation_codes(violations: list[BoundaryViolation]) -> set[str]:
+    return {violation.code for violation in violations}


### PR DESCRIPTION
Closes #35

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/orchestrator/checks/dbt_events.py`, `src/orchestrator/checks/phase1.py`, `src/orchestrator/checks/phase2.py`, `src/orchestrator/checks/phase3.py`, `src/orchestrator/definitions.py`, `src/orchestrator/jobs/cycle.py`, `src/orchestrator/sensors/manual_rerun.py`, `tests/integration/test_daily_cycle_four_phase.py`, `tests/test_definitions.py`


---
### 1. 背景与目标
`docs/orchestrator.project-doc.md` §5.4、§18.3、§18.4 和 §23 要求 `orchestrator` 不承载业务算法、不引入 Kafka/Flink 事件流接口，并且下游业务模块不得反向 import `orchestrator` 内部。当前仓库只有零散 AST 检查：`tests/integration/test_phase0_minimal_cycle.py::test_no_business_imports` 和 `tests/integration/test_phase2_main_core_wiring.py::test_orchestrator_has_no_forbidden_phase2_runtime_imports`，覆盖面有限且重复。本 issue 的目标是把这些边界检查提升为独立静态检查脚本和 pytest 回归，扫描业务算法关键词、禁止 runtime import，以及扫描 sibling 模块的反向依赖。

### 2. 所属模块
`scripts/`（新目录）、`tests/static/`（新目录）、`tests/integration/`、`Makefile`。

### 3. 实现范围
- 新增 `scripts/check_boundaries.py`：使用 `ast.parse()` 扫描 `src/orchestrator/**/*.py` 的 `Import` / `ImportFrom` / 函数名 / 类名 / 变量名 / 字符串常量，输出 `path:line: reason`，发现违规返回非 0。
- 在脚本中定义禁止 runtime import 根：`data_platform`、`graph_engine`、`main_core`、`audit_eval`、`stream_layer`、`kafka`、`flink`。
- 定义业务算法关键词 denylist：`pagerank`、`embedding`、`feature_`、`alpha_`、`factor_`、`rank_score`、`recommendation_score`；只扫描 `src/orchestrator` Python 源码，避免 docs 误报。
- 增加反向依赖扫描：从当前仓库父目录查找 sibling `data-platform`、`graph-engine`、`main-core`、`audit-eval`、`reasoner-runtime`、`stream-layer` 的 `src/`，扫描是否 import `orchestrator` 或 `orchestrator.*`；缺失目录跳过。
- 新增 `tests/static/test_boundaries.py`：调用脚本内部纯函数，断言当前仓库违规列表为空，并用 tmp fixture 构造正/反例。
- 更新 `Makefile`：新增 `boundary-check` 目标；不要删除现有 `test`、`integration-test`、`lint` 目标。

### 4. 不在本次范围
- 不自动修改 sibling 仓库代码；发现反向依赖只报错。
- 不实现完整安全扫描或 secret scan。
- 不禁止测试目录中的 fake business names；默认只扫描 `src/orchestrator` 和 sibling `src`。
- 不把 `contracts` 适配层切到真实 package；这里只检查边界。

### 5. 关键交付物
- `@dataclass(frozen=True, slots=True) class BoundaryViolation`，字段至少包含 `path: Path`、`line: int`、`code: str`、`message: str`。
- `scan_orchestrator_boundaries(root: Path) -> list[BoundaryViolation]`。
- `scan_reverse_imports(workspace_root: Path, module_names: Iterable[str]) -> list[BoundaryViolation]`。
- CLI：`python3 scripts/check_boundaries.py`，默认 root 为当前 repo，返回码 0/1 可用于 CI。
- `tests/static/test_boundaries.py` 覆盖当前仓库无违规、业务关键词命中、禁止 import 命中、sibli