### PR TITLE
feat(#31): 多通道告警 dispatcher（Slack / Webhook）

### DIFF
--- a/src/orchestrator/alerting/__init__.py
+++ b/src/orchestrator/alerting/__init__.py
@@ -1,4 +1,4 @@
-from orchestrator.alerting.dispatcher import dispatch_alert
+from orchestrator.alerting.dispatcher import AlertDispatchResult, dispatch_alert
 from orchestrator.alerting.payload import AlertPayload
 
-__all__ = ["AlertPayload", "dispatch_alert"]
+__all__ = ["AlertDispatchResult", "AlertPayload", "dispatch_alert"]

--- a/src/orchestrator/alerting/dispatcher.py
+++ b/src/orchestrator/alerting/dispatcher.py
@@ -1,21 +1,127 @@
 import dataclasses
 import json
 import logging
-from collections.abc import Iterable
+import os
+import urllib.request
+from collections.abc import Callable, Iterable
 
 from orchestrator.alerting.payload import AlertPayload
 
 logger = logging.getLogger(__name__)
 _LOGGING_CHANNELS = {"logging", "ops"}
+_SLACK_WEBHOOK_ENV = "ORCHESTRATOR_SLACK_WEBHOOK_URL"
+_ALERT_WEBHOOK_ENV = "ORCHESTRATOR_ALERT_WEBHOOK_URL"
+_HTTP_TIMEOUT_SECONDS = 5
+_HTTP_OPENER = urllib.request.build_opener()
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class AlertDispatchResult:
+    channel: str
+    delivered: bool
+    error: str | None = None
 
 
 def dispatch_alert(
     payload: AlertPayload,
     channels: Iterable[str] = ("logging",),
-) -> None:
+) -> tuple[AlertDispatchResult, ...]:
+    results: list[AlertDispatchResult] = []
+
     for channel in channels:
         if channel in _LOGGING_CHANNELS:
             logger.warning(json.dumps(dataclasses.asdict(payload)))
+            results.append(AlertDispatchResult(channel=channel, delivered=True))
             continue
 
-        logger.warning("unknown alert channel: %s", channel)
+        if channel == "slack":
+            results.append(
+                _dispatch_configured_http_channel(
+                    channel=channel,
+                    payload=payload,
+                    endpoint_env_var=_SLACK_WEBHOOK_ENV,
+                    dispatcher=_dispatch_slack,
+                ),
+            )
+            continue
+
+        if channel == "webhook":
+            results.append(
+                _dispatch_configured_http_channel(
+                    channel=channel,
+                    payload=payload,
+                    endpoint_env_var=_ALERT_WEBHOOK_ENV,
+                    dispatcher=_dispatch_webhook,
+                ),
+            )
+            continue
+
+        error = f"unknown alert channel: {channel}"
+        logger.warning(error)
+        results.append(
+            AlertDispatchResult(channel=channel, delivered=False, error=error),
+        )
+
+    return tuple(results)
+
+
+def _dispatch_configured_http_channel(
+    *,
+    channel: str,
+    payload: AlertPayload,
+    endpoint_env_var: str,
+    dispatcher: Callable[[AlertPayload, str], None],
+) -> AlertDispatchResult:
+    webhook_url = os.environ.get(endpoint_env_var)
+    if not webhook_url or not webhook_url.strip():
+        error = f"missing alert endpoint: {endpoint_env_var}"
+        logger.warning("%s alert channel failed: %s", channel, error)
+        return AlertDispatchResult(channel=channel, delivered=False, error=error)
+
+    try:
+        dispatcher(payload, webhook_url)
+    except Exception as exc:
+        error = str(exc) or exc.__class__.__name__
+        logger.warning("%s alert channel failed: %s", channel, error)
+        return AlertDispatchResult(channel=channel, delivered=False, error=error)
+
+    return AlertDispatchResult(channel=channel, delivered=True)
+
+
+def _dispatch_slack(payload: AlertPayload, webhook_url: str) -> None:
+    _post_json(
+        webhook_url,
+        {
+            "text": f"{payload.phase} {payload.action}: {payload.summary}",
+            "cycle_id": payload.cycle_id,
+            "phase": payload.phase,
+            "action": payload.action,
+            "failure_class": payload.failure_class,
+            "summary": payload.summary,
+            "runbook_url": payload.runbook_url,
+        },
+    )
+
+
+def _dispatch_webhook(payload: AlertPayload, webhook_url: str) -> None:
+    _post_json(webhook_url, dataclasses.asdict(payload))
+
+
+def _post_json(webhook_url: str, payload: dict[str, object]) -> None:
+    request = urllib.request.Request(
+        webhook_url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    response = _HTTP_OPENER.open(request, timeout=_HTTP_TIMEOUT_SECONDS)
+    try:
+        response.read()
+    finally:
+        response.close()
+
+
+__all__ = [
+    "AlertDispatchResult",
+    "dispatch_alert",
+]

--- a/tests/alerting/test_dispatcher.py
+++ b/tests/alerting/test_dispatcher.py
@@ -1,26 +1,63 @@
 import dataclasses
 import json
 import logging
+import urllib.error
+import urllib.request
 
 import pytest
 
-from orchestrator.alerting import AlertPayload, dispatch_alert
+import orchestrator.alerting.dispatcher as dispatcher
+from orchestrator.alerting import AlertDispatchResult, AlertPayload, dispatch_alert
 
 
-def test_dispatch_alert_logging_channel_writes_json(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    payload = AlertPayload(
+class _FakeResponse:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def read(self) -> bytes:
+        return b"ok"
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _RecordingOpener:
+    def __init__(self, exception: Exception | None = None) -> None:
+        self.exception = exception
+        self.requests: list[tuple[urllib.request.Request, int]] = []
+
+    def open(
+        self,
+        request: urllib.request.Request,
+        *,
+        timeout: int,
+    ) -> _FakeResponse:
+        self.requests.append((request, timeout))
+        if self.exception is not None:
+            raise self.exception
+        return _FakeResponse()
+
+
+@pytest.fixture
+def payload() -> AlertPayload:
+    return AlertPayload(
         cycle_id="c1",
         phase="phase0",
         status="failed",
         failed_node="phase0_readiness_ping",
         action="fail_run",
         summary="test",
+        failure_class="infra",
+        runbook_url="https://runbooks.example/c1",
     )
 
+
+def test_dispatch_alert_logging_channel_writes_json(
+    caplog: pytest.LogCaptureFixture,
+    payload: AlertPayload,
+) -> None:
     with caplog.at_level(logging.WARNING):
-        dispatch_alert(payload)
+        results = dispatch_alert(payload)
 
     record = caplog.records[-1]
     logged_payload = json.loads(record.message)
@@ -28,45 +65,173 @@ def test_dispatch_alert_logging_channel_writes_json(
     assert record.levelno == logging.WARNING
     assert logged_payload["cycle_id"] == "c1"
     assert logged_payload["action"] == "fail_run"
+    assert results == (
+        AlertDispatchResult(channel="logging", delivered=True),
+    )
 
 
 def test_dispatch_alert_unknown_channel_warns_without_raising(
     caplog: pytest.LogCaptureFixture,
+    payload: AlertPayload,
 ) -> None:
-    payload = AlertPayload(
-        cycle_id="c1",
-        phase="phase0",
-        status="failed",
-        failed_node="phase0_readiness_ping",
-        action="fail_run",
-        summary="test",
-    )
-
     with caplog.at_level(logging.WARNING):
-        dispatch_alert(payload, channels=("unknown",))
+        results = dispatch_alert(payload, channels=("unknown",))
 
     assert caplog.records[-1].message == "unknown alert channel: unknown"
+    assert results == (
+        AlertDispatchResult(
+            channel="unknown",
+            delivered=False,
+            error="unknown alert channel: unknown",
+        ),
+    )
 
 
 def test_dispatch_alert_ops_channel_uses_logging_backend(
     caplog: pytest.LogCaptureFixture,
+    payload: AlertPayload,
 ) -> None:
-    payload = AlertPayload(
-        cycle_id="c1",
-        phase="phase0",
-        status="failed",
-        failed_node="phase0_readiness_ping",
-        action="fail_run",
-        summary="test",
-    )
-
     with caplog.at_level(logging.WARNING):
-        dispatch_alert(payload, channels=("ops",))
+        results = dispatch_alert(payload, channels=("ops",))
 
     logged_payload = json.loads(caplog.records[-1].message)
 
     assert logged_payload["cycle_id"] == "c1"
     assert logged_payload["action"] == "fail_run"
+    assert results == (
+        AlertDispatchResult(channel="ops", delivered=True),
+    )
+
+
+def test_dispatch_alert_slack_channel_posts_minimal_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    payload: AlertPayload,
+) -> None:
+    opener = _RecordingOpener()
+    monkeypatch.setattr(dispatcher, "_HTTP_OPENER", opener)
+    monkeypatch.setenv(
+        "ORCHESTRATOR_SLACK_WEBHOOK_URL",
+        "https://hooks.slack.example/test",
+    )
+
+    results = dispatch_alert(payload, channels=("slack",))
+
+    assert results == (
+        AlertDispatchResult(channel="slack", delivered=True),
+    )
+    assert len(opener.requests) == 1
+    request, timeout = opener.requests[0]
+    body = json.loads(request.data.decode("utf-8"))
+
+    assert request.full_url == "https://hooks.slack.example/test"
+    assert request.get_method() == "POST"
+    assert request.headers["Content-type"] == "application/json"
+    assert timeout == 5
+    assert body["cycle_id"] == payload.cycle_id
+    assert body["phase"] == payload.phase
+    assert body["action"] == payload.action
+    assert body["failure_class"] == payload.failure_class
+    assert body["summary"] == payload.summary
+    assert body["runbook_url"] == payload.runbook_url
+
+
+def test_dispatch_alert_webhook_channel_posts_alert_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    payload: AlertPayload,
+) -> None:
+    opener = _RecordingOpener()
+    monkeypatch.setattr(dispatcher, "_HTTP_OPENER", opener)
+    monkeypatch.setenv(
+        "ORCHESTRATOR_ALERT_WEBHOOK_URL",
+        "https://alerts.example/gate",
+    )
+
+    results = dispatch_alert(payload, channels=("webhook",))
+
+    assert results == (
+        AlertDispatchResult(channel="webhook", delivered=True),
+    )
+    assert len(opener.requests) == 1
+    request, _timeout = opener.requests[0]
+    body = json.loads(request.data.decode("utf-8"))
+
+    assert request.full_url == "https://alerts.example/gate"
+    assert request.get_method() == "POST"
+    assert request.headers["Content-type"] == "application/json"
+    assert body == dataclasses.asdict(payload)
+
+
+@pytest.mark.parametrize(
+    ("channel", "env_var"),
+    [
+        ("slack", "ORCHESTRATOR_SLACK_WEBHOOK_URL"),
+        ("webhook", "ORCHESTRATOR_ALERT_WEBHOOK_URL"),
+    ],
+)
+def test_dispatch_alert_http_channel_missing_endpoint_warns_without_raising(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    payload: AlertPayload,
+    channel: str,
+    env_var: str,
+) -> None:
+    opener = _RecordingOpener()
+    monkeypatch.setattr(dispatcher, "_HTTP_OPENER", opener)
+    monkeypatch.delenv(env_var, raising=False)
+
+    with caplog.at_level(logging.WARNING):
+        results = dispatch_alert(payload, channels=(channel,))
+
+    assert opener.requests == []
+    assert results == (
+        AlertDispatchResult(
+            channel=channel,
+            delivered=False,
+            error=f"missing alert endpoint: {env_var}",
+        ),
+    )
+    assert f"{channel} alert channel failed" in caplog.records[-1].message
+    assert env_var in caplog.records[-1].message
+
+
+@pytest.mark.parametrize(
+    ("channel", "env_var"),
+    [
+        ("slack", "ORCHESTRATOR_SLACK_WEBHOOK_URL"),
+        ("webhook", "ORCHESTRATOR_ALERT_WEBHOOK_URL"),
+    ],
+)
+def test_dispatch_alert_http_error_warns_without_raising(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    payload: AlertPayload,
+    channel: str,
+    env_var: str,
+) -> None:
+    http_error = urllib.error.HTTPError(
+        url="https://alerts.example/gate",
+        code=500,
+        msg="server error",
+        hdrs=None,
+        fp=None,
+    )
+    opener = _RecordingOpener(exception=http_error)
+    monkeypatch.setattr(dispatcher, "_HTTP_OPENER", opener)
+    monkeypatch.setenv(env_var, "https://alerts.example/gate")
+
+    with caplog.at_level(logging.WARNING):
+        results = dispatch_alert(payload, channels=(channel,))
+
+    assert len(opener.requests) == 1
+    assert results == (
+        AlertDispatchResult(
+            channel=channel,
+            delivered=False,
+            error="HTTP Error 500: server error",
+        ),
+    )
+    assert f"{channel} alert channel failed" in caplog.records[-1].message
+    assert "HTTP Error 500: server error" in caplog.records[-1].message
 
 
 def test_alert_payload_optional_fields_allow_none() -> None:


### PR DESCRIPTION
Closes #31

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `scripts/check_boundaries.py`, `src/orchestrator/checks/classifier.py`, `src/orchestrator/checks/dbt_events.py`, `src/orchestrator/checks/phase1.py`, `src/orchestrator/checks/phase2.py`, `src/orchestrator/checks/phase3.py`, `src/orchestrator/definitions.py`, `src/orchestrator/jobs/cycle.py`, `src/orchestrator/sensors/manual_rerun.py`


---
### 1. 背景与目标
`docs/orchestrator.project-doc.md` §13.3 和 §21 阶段 3 要求影子运行期间有稳定告警入口；当前 `src/orchestrator/alerting/dispatcher.py` 只支持 `logging` / `ops` 两个本地日志通道，未知通道仅 warning。Skeleton #31 要扩展 #10 的 `dispatch_alert`，让 `GatePolicyProfile.alert_channels` 可以选择 Slack 和通用 Webhook，同时保持本地测试不触网。本 issue 的目标是提供可配置、可单测、不会因单个通道失败中断 run 的多通道 dispatcher。

### 2. 所属模块
`src/orchestrator/alerting/`、`src/orchestrator/checks/decision_handler.py`、`tests/alerting/`、`config/policy/gate_policy.lite.yaml`。

### 3. 实现范围
- 修改 `src/orchestrator/alerting/dispatcher.py`：保留 `dispatch_alert(payload: AlertPayload, channels: Iterable[str] = ('logging',))` 现有调用方式，扩展支持 `slack`、`webhook` 通道。
- 新增 `AlertDispatchResult` dataclass（可放在 `dispatcher.py` 或新文件 `src/orchestrator/alerting/channels.py`），字段建议为 `channel: str`、`delivered: bool`、`error: str | None = None`；`dispatch_alert()` 返回 `tuple[AlertDispatchResult, ...]`，现有调用方可继续忽略返回值。
- 使用标准库 `urllib.request` 发送 HTTP POST，避免新增依赖；Slack endpoint 从 `ORCHESTRATOR_SLACK_WEBHOOK_URL` 读取，通用 Webhook endpoint 从 `ORCHESTRATOR_ALERT_WEBHOOK_URL` 读取，测试中通过 monkeypatch 替换 opener。
- 定义 JSON payload 格式：通用 Webhook 发送 `dataclasses.asdict(AlertPayload)`；Slack 发送最小 JSON，但必须包含 `cycle_id`、`phase`、`action`、`failure_class`、`summary`、`runbook_url`。
- 通道失败只记录 warning 并返回 `AlertDispatchResult(delivered=False, error=...)`，不得向上抛出阻断 `dispatch_gate_decision_alert()`。
- 更新 `src/orchestrator/alerting/__init__.py` 导出 `AlertPayload`、`AlertDispatchResult`、`dispatch_alert`；补充 `tests/alerting/test_dispatcher.py` 覆盖 logging/ops/slack/webhook/unknown/endpoint missing/HTTP error。

### 4. 不在本次范围
- 不引入 Slack SDK、requests、httpx 或异步队列。
- 不把 webhook secret 写进 YAML policy；policy 只保留通道名，endpoint 通过环境变量注入。
- 不实现告警去重、节流、重试或 dead-letter queue。
- 不生成 runbook_url；该 payload enrichment 由 #32 提供。

### 5. 关键交付物
- `@dataclass(frozen=True, slots=True) class AlertDispatchResult`。
- `dispatch_alert(payload: AlertPayload, channels: Iterable[str] = ('logging',)) -> tuple[AlertDispatchResult, ...]`，兼容现有调用。
- `_dispatch_slack(p