### PR TITLE
feat(#30): 基础设施不可用（PG/Iceberg/Neo4j）硬停路径

### DIFF
--- a/src/orchestrator/checks/asset_checks.py
+++ b/src/orchestrator/checks/asset_checks.py
@@ -96,6 +96,8 @@ def _read_llm_health(
     try:
         raw_result = check_health()
     except Exception as exc:
+        if _is_infrastructure_unavailable_error(exc):
+            raise
         return _unhealthy_probe_result(llm_health_probe, exc)
 
     try:
@@ -155,6 +157,12 @@ def _provider_from_probe_or_result(
         if isinstance(provider, str) and provider:
             return provider
     return None
+
+
+def _is_infrastructure_unavailable_error(exc: Exception) -> bool:
+    from orchestrator.resources.infra import InfrastructureUnavailableError
+
+    return isinstance(exc, InfrastructureUnavailableError)
 
 
 def _llm_health_metadata(

--- a/src/orchestrator/checks/classifier.py
+++ b/src/orchestrator/checks/classifier.py
@@ -28,6 +28,15 @@ def classify_gate_result(
             action=GateAction.CONTINUE,
         )
 
+    scenario_id = _scenario_id_from_event(event)
+    if scenario_id is not None:
+        return _classify_scenario(
+            phase=phase,
+            failure_class=failure_class,
+            scenario_id=scenario_id,
+            policy=policy,
+        )
+
     for entry in policy.phase_matrix:
         if entry.phase is phase and entry.failure_class is failure_class:
             return GateDecision(
@@ -44,6 +53,44 @@ def classify_gate_result(
     raise UnknownGateFailure(msg)
 
 
+def _classify_scenario(
+    *,
+    phase: PhaseEnum,
+    failure_class: FailureClass,
+    scenario_id: str,
+    policy: GatePolicyProfile,
+) -> GateDecision:
+    matching_entries = [
+        entry for entry in policy.phase_matrix if entry.scenario_id == scenario_id
+    ]
+    if not matching_entries:
+        msg = (
+            "unknown gate failure policy entry for "
+            f"scenario_id={scenario_id} phase={phase.value} "
+            f"failure_class={failure_class.value}"
+        )
+        raise UnknownGateFailure(msg)
+    if len(matching_entries) > 1:
+        raise ValueError(f"ambiguous gate policy scenario_id={scenario_id}")
+
+    entry = matching_entries[0]
+    applies_to_phases = entry.applies_to_phases or (entry.phase,)
+    if phase not in applies_to_phases or entry.failure_class is not failure_class:
+        msg = (
+            "unknown gate failure policy entry for "
+            f"scenario_id={scenario_id} phase={phase.value} "
+            f"failure_class={failure_class.value}"
+        )
+        raise UnknownGateFailure(msg)
+
+    return GateDecision(
+        phase=phase,
+        failure_class=failure_class,
+        action=entry.action,
+        reason=entry.description,
+    )
+
+
 def _failure_class_from_event(event: object | None) -> FailureClass | None:
     if event is None:
         return None
@@ -54,6 +101,18 @@ def _failure_class_from_event(event: object | None) -> FailureClass | None:
     if hasattr(event, "failure_class"):
         return _coerce_failure_class(getattr(event, "failure_class"))
     raise TypeError("gate event must expose failure_class")
+
+
+def _scenario_id_from_event(event: object | None) -> str | None:
+    if event is None:
+        return None
+    if isinstance(event, Mapping):
+        if "scenario_id" not in event:
+            return None
+        return _coerce_scenario_id(event["scenario_id"])
+    if hasattr(event, "scenario_id"):
+        return _coerce_scenario_id(getattr(event, "scenario_id"))
+    return None
 
 
 def _coerce_failure_class(value: Any) -> FailureClass | None:
@@ -67,6 +126,12 @@ def _coerce_failure_class(value: Any) -> FailureClass | None:
         except ValueError as exc:
             raise ValueError(f"unknown failure_class: {value}") from exc
     raise TypeError("failure_class must be a FailureClass or string")
+
+
+def _coerce_scenario_id(value: Any) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("gate event scenario_id must be a non-empty string")
+    return value.strip()
 
 
 __all__ = ["UnknownGateFailure", "classify_gate_result"]

--- a/src/orchestrator/definitions.py
+++ b/src/orchestrator/definitions.py
@@ -46,7 +46,12 @@ from orchestrator.jobs.phase3 import (
     PHASE3_GROUP_NAME,
     PHASE3_MANIFEST_ASSET_KEY,
 )
-from orchestrator.resources import AssetFactoryProvider, build_resource_bundle
+from orchestrator.resources import (
+    INFRASTRUCTURE_RESOURCE_PHASES,
+    AssetFactoryProvider,
+    build_resource_bundle,
+    guard_infrastructure_resource,
+)
 from orchestrator.schedules import daily_cycle_schedule
 from orchestrator.sensors.data_readiness import (
     DATA_READINESS_PROVIDER_RESOURCE_KEY,
@@ -219,6 +224,20 @@ def build_definitions(
         _FailClosedLLMHealthProbeResource(),
     )
     data_readiness_resource = _data_readiness_resource(resource_bundle.resources)
+    resources = _guard_infrastructure_resources(
+        {
+            "gate_policy": GatePolicyResource(policy_path=str(policy_path)),
+            "dbt": DbtCliResource(
+                project_dir=str(DBT_PROJECT_DIR),
+                profiles_dir=str(DBT_PROFILES_DIR),
+            ),
+            _LLM_HEALTH_PROBE_RESOURCE_KEY: llm_health_probe_resource,
+            DATA_READINESS_RESOURCE_KEY: data_readiness_resource,
+            "resource_bundle": resource_bundle,
+            **resource_bundle.resources,
+        },
+        policy_path=str(policy_path),
+    )
 
     return Definitions(
         assets=[
@@ -233,17 +252,7 @@ def build_definitions(
         jobs=[daily_cycle_job],
         schedules=[daily_cycle_schedule],
         sensors=[data_readiness_sensor, manual_rerun_sensor],
-        resources={
-            "gate_policy": GatePolicyResource(policy_path=str(policy_path)),
-            "dbt": DbtCliResource(
-                project_dir=str(DBT_PROJECT_DIR),
-                profiles_dir=str(DBT_PROFILES_DIR),
-            ),
-            _LLM_HEALTH_PROBE_RESOURCE_KEY: llm_health_probe_resource,
-            DATA_READINESS_RESOURCE_KEY: data_readiness_resource,
-            "resource_bundle": resource_bundle,
-            **resource_bundle.resources,
-        },
+        resources=resources,
     )
 
 
@@ -791,6 +800,24 @@ def _data_readiness_resource(resources: Mapping[str, object]) -> object:
             return resource
 
     return _FailClosedDataReadinessResource()
+
+
+def _guard_infrastructure_resources(
+    resources: Mapping[str, object],
+    policy_path: str,
+) -> dict[str, object]:
+    guarded_resources = dict(resources)
+    for resource_key, phase in INFRASTRUCTURE_RESOURCE_PHASES.items():
+        resource = guarded_resources.get(resource_key)
+        if resource is None:
+            continue
+        guarded_resources[resource_key] = guard_infrastructure_resource(
+            resource_key,
+            resource,
+            phase=phase,
+            policy_path=policy_path,
+        )
+    return guarded_resources
 
 
 defs = build_definitions()

--- a/src/orchestrator/resources/__init__.py
+++ b/src/orchestrator/resources/__init__.py
@@ -1,9 +1,25 @@
 from orchestrator.resources.bundle import ResourceBundle, build_resource_bundle
+from orchestrator.resources.infra import (
+    CORE_INFRASTRUCTURE_RESOURCE_KEYS,
+    INFRASTRUCTURE_RESOURCE_PHASES,
+    INFRA_UNAVAILABLE_HARD_STOP_SCENARIO_ID,
+    InfrastructureUnavailableError,
+    InfrastructureUnavailableEvent,
+    classify_infrastructure_failure,
+    guard_infrastructure_resource,
+)
 from orchestrator.resources.providers import AssetFactoryProvider, PureCheckProvider
 
 __all__ = [
     "AssetFactoryProvider",
+    "CORE_INFRASTRUCTURE_RESOURCE_KEYS",
+    "INFRASTRUCTURE_RESOURCE_PHASES",
+    "INFRA_UNAVAILABLE_HARD_STOP_SCENARIO_ID",
+    "InfrastructureUnavailableError",
+    "InfrastructureUnavailableEvent",
     "PureCheckProvider",
     "ResourceBundle",
     "build_resource_bundle",
+    "classify_infrastructure_failure",
+    "guard_infrastructure_resource",
 ]

--- a/src/orchestrator/resources/infra.py
+++ b/src/orchestrator/resources/infra.py
@@ -20,6 +20,10 @@ from orchestrator.policy import (
 )
 
 INFRA_UNAVAILABLE_HARD_STOP_SCENARIO_ID = "infra_unavailable_hard_stop"
+_INFRA_HARD_STOP_REASON = (
+    "Core storage or graph infrastructure is unavailable; hard stop."
+)
+_FALLBACK_ALERT_CHANNELS = ("logging",)
 CORE_INFRASTRUCTURE_RESOURCE_KEYS = frozenset(
     {
         "dbt",
@@ -43,6 +47,7 @@ _GUARDED_METHODS_BY_RESOURCE_KEY: Mapping[str, frozenset[str]] = MappingProxyTyp
         "data_readiness": frozenset(
             {
                 "get_data_readiness_signal",
+                "get_readiness_signal",
                 "get_data_readiness",
             },
         ),
@@ -184,6 +189,8 @@ class _GuardedInfrastructureValue:
     def __getattr__(self, name: str) -> object:
         try:
             attribute = getattr(self._value, name)
+        except AttributeError:
+            raise
         except InfrastructureUnavailableError:
             raise
         except Exception as exc:
@@ -293,16 +300,32 @@ def _raise_infrastructure_unavailable(
         phase=phase,
         reason=_exception_summary(exc),
     )
-    policy = load_gate_policy(policy_path)
-    decision = classify_infrastructure_failure(phase, event, policy)
+    try:
+        policy = load_gate_policy(policy_path)
+    except Exception:
+        decision = _fallback_infrastructure_decision(phase)
+        channels = _FALLBACK_ALERT_CHANNELS
+    else:
+        decision = classify_infrastructure_failure(phase, event, policy)
+        channels = policy.alert_channels
+
     dispatch_gate_decision_alert(
         decision,
         cycle_id=_cycle_id_from_context(context),
         failed_node=resource_key,
         summary=_infra_summary(resource_key, exc),
-        channels=policy.alert_channels,
+        channels=channels,
     )
     raise InfrastructureUnavailableError(event, decision, exc) from exc
+
+
+def _fallback_infrastructure_decision(phase: PhaseEnum) -> GateDecision:
+    return GateDecision(
+        phase=phase,
+        failure_class=FailureClass.INFRA,
+        action=GateAction.FAIL_RUN,
+        reason=_INFRA_HARD_STOP_REASON,
+    )
 
 
 def _infra_summary(resource_key: str, exc: BaseException) -> str:

--- a/src/orchestrator/resources/infra.py
+++ b/src/orchestrator/resources/infra.py
@@ -1,0 +1,340 @@
+"""Infrastructure hard-stop adapters for core Dagster resources."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from inspect import isgenerator
+from types import MappingProxyType
+from typing import NoReturn
+
+from orchestrator.checks.classifier import classify_gate_result
+from orchestrator.checks.decision_handler import dispatch_gate_decision_alert
+from orchestrator.checks.models import GateDecision
+from orchestrator.policy import (
+    FailureClass,
+    GateAction,
+    GatePolicyProfile,
+    PhaseEnum,
+    load_gate_policy,
+)
+
+INFRA_UNAVAILABLE_HARD_STOP_SCENARIO_ID = "infra_unavailable_hard_stop"
+CORE_INFRASTRUCTURE_RESOURCE_KEYS = frozenset(
+    {
+        "dbt",
+        "gate_policy",
+        "data_readiness",
+        "llm_health_probe",
+        "phase2_pool_failure_rate",
+    },
+)
+INFRASTRUCTURE_RESOURCE_PHASES: Mapping[str, PhaseEnum] = MappingProxyType(
+    {
+        "dbt": PhaseEnum.PHASE0,
+        "gate_policy": PhaseEnum.PHASE0,
+        "data_readiness": PhaseEnum.PHASE0,
+        "llm_health_probe": PhaseEnum.PHASE0,
+        "phase2_pool_failure_rate": PhaseEnum.PHASE2,
+    },
+)
+_GUARDED_METHODS_BY_RESOURCE_KEY: Mapping[str, frozenset[str]] = MappingProxyType(
+    {
+        "data_readiness": frozenset(
+            {
+                "get_data_readiness_signal",
+                "get_data_readiness",
+            },
+        ),
+        "llm_health_probe": frozenset({"check_health"}),
+        "phase2_pool_failure_rate": frozenset(
+            {"get_phase2_pool_failure_rate_event"},
+        ),
+    },
+)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class InfrastructureUnavailableEvent:
+    """Normalized event for a core infrastructure resource outage."""
+
+    failure_class: FailureClass = FailureClass.INFRA
+    resource_key: str
+    phase: PhaseEnum
+    reason: str
+    scenario_id: str = INFRA_UNAVAILABLE_HARD_STOP_SCENARIO_ID
+
+
+class InfrastructureUnavailableError(RuntimeError):
+    """Raised after an infrastructure failure has been classified and alerted."""
+
+    def __init__(
+        self,
+        event: InfrastructureUnavailableEvent,
+        decision: GateDecision,
+        original: BaseException,
+    ) -> None:
+        super().__init__(_infra_summary(event.resource_key, original))
+        self.event = event
+        self.decision = decision
+        self.original = original
+
+
+def classify_infrastructure_failure(
+    phase: PhaseEnum,
+    event: InfrastructureUnavailableEvent,
+    policy: GatePolicyProfile,
+) -> GateDecision:
+    """Classify a core infrastructure outage as a hard run failure."""
+
+    if event.phase is not phase:
+        msg = (
+            "infrastructure failure event phase does not match classifier phase: "
+            f"event={event.phase.value} phase={phase.value}"
+        )
+        raise ValueError(msg)
+    if event.failure_class is not FailureClass.INFRA:
+        msg = "infrastructure failure events must use failure_class=infra"
+        raise ValueError(msg)
+    if event.scenario_id != INFRA_UNAVAILABLE_HARD_STOP_SCENARIO_ID:
+        msg = (
+            "infrastructure failure events must use scenario_id="
+            f"{INFRA_UNAVAILABLE_HARD_STOP_SCENARIO_ID!r}"
+        )
+        raise ValueError(msg)
+
+    decision = classify_gate_result(phase, event, policy)
+    if (
+        decision.failure_class is not FailureClass.INFRA
+        or decision.action is not GateAction.FAIL_RUN
+    ):
+        msg = (
+            "infra_unavailable_hard_stop must map to "
+            "failure_class=infra and action=fail_run"
+        )
+        raise ValueError(msg)
+
+    return decision
+
+
+def guard_infrastructure_resource(
+    resource_key: str,
+    resource: object,
+    *,
+    phase: PhaseEnum,
+    policy_path: str,
+) -> object:
+    """Return a Dagster resource that alerts and fails on infra unavailability."""
+
+    if resource_key not in CORE_INFRASTRUCTURE_RESOURCE_KEYS:
+        return resource
+
+    from dagster import ResourceDefinition
+
+    def _resource_fn(context: object) -> Iterable[object]:
+        finalizers: tuple[Callable[[], None], ...] = ()
+        try:
+            value, finalizers = _initialize_resource(resource, context)
+        except InfrastructureUnavailableError:
+            raise
+        except Exception as exc:
+            _raise_infrastructure_unavailable(
+                resource_key=resource_key,
+                phase=phase,
+                policy_path=policy_path,
+                context=context,
+                exc=exc,
+            )
+
+        try:
+            yield _GuardedInfrastructureValue(
+                resource_key=resource_key,
+                value=value,
+                phase=phase,
+                policy_path=policy_path,
+                context=context,
+            )
+        finally:
+            _run_finalizers(finalizers)
+
+    return ResourceDefinition(
+        resource_fn=_resource_fn,
+        description=f"Guarded infrastructure resource for {resource_key}.",
+    )
+
+
+class _GuardedInfrastructureValue:
+    __slots__ = ("_context", "_phase", "_policy_path", "_resource_key", "_value")
+
+    def __init__(
+        self,
+        *,
+        resource_key: str,
+        value: object,
+        phase: PhaseEnum,
+        policy_path: str,
+        context: object,
+    ) -> None:
+        self._resource_key = resource_key
+        self._value = value
+        self._phase = phase
+        self._policy_path = policy_path
+        self._context = context
+
+    def __getattr__(self, name: str) -> object:
+        try:
+            attribute = getattr(self._value, name)
+        except InfrastructureUnavailableError:
+            raise
+        except Exception as exc:
+            _raise_infrastructure_unavailable(
+                resource_key=self._resource_key,
+                phase=self._phase,
+                policy_path=self._policy_path,
+                context=self._context,
+                exc=exc,
+            )
+
+        if callable(attribute) and name in _GUARDED_METHODS_BY_RESOURCE_KEY.get(
+            self._resource_key,
+            frozenset(),
+        ):
+            return _guard_method_call(
+                resource_key=self._resource_key,
+                phase=self._phase,
+                policy_path=self._policy_path,
+                context=self._context,
+                method=attribute,
+            )
+
+        return attribute
+
+
+def _guard_method_call(
+    *,
+    resource_key: str,
+    phase: PhaseEnum,
+    policy_path: str,
+    context: object,
+    method: Callable[..., object],
+) -> Callable[..., object]:
+    def _wrapped(*args: object, **kwargs: object) -> object:
+        try:
+            return method(*args, **kwargs)
+        except InfrastructureUnavailableError:
+            raise
+        except Exception as exc:
+            _raise_infrastructure_unavailable(
+                resource_key=resource_key,
+                phase=phase,
+                policy_path=policy_path,
+                context=context,
+                exc=exc,
+            )
+
+    return _wrapped
+
+
+def _initialize_resource(
+    resource: object,
+    context: object,
+) -> tuple[object, tuple[Callable[[], None], ...]]:
+    finalizers: list[Callable[[], None]] = []
+    setup_for_execution = getattr(resource, "setup_for_execution", None)
+    if callable(setup_for_execution):
+        setup_for_execution(context)
+
+    teardown_after_execution = getattr(resource, "teardown_after_execution", None)
+    if callable(teardown_after_execution):
+        finalizers.append(lambda: teardown_after_execution(context))
+
+    create_resource = getattr(resource, "create_resource", None)
+    if callable(create_resource):
+        return create_resource(context), tuple(finalizers)
+
+    resource_fn = getattr(resource, "resource_fn", None)
+    if callable(resource_fn):
+        created = resource_fn(context)
+        if isgenerator(created):
+            try:
+                value = next(created)
+            except StopIteration as exc:
+                raise RuntimeError("resource generator did not yield a value") from exc
+            finalizers.append(lambda: _close_resource_generator(created))
+            return value, tuple(finalizers)
+        return created, tuple(finalizers)
+
+    return resource, tuple(finalizers)
+
+
+def _close_resource_generator(generator: object) -> None:
+    try:
+        next(generator)  # type: ignore[arg-type]
+    except StopIteration:
+        return
+    raise RuntimeError("resource generator yielded more than once")
+
+
+def _run_finalizers(finalizers: Iterable[Callable[[], None]]) -> None:
+    for finalizer in reversed(tuple(finalizers)):
+        finalizer()
+
+
+def _raise_infrastructure_unavailable(
+    *,
+    resource_key: str,
+    phase: PhaseEnum,
+    policy_path: str,
+    context: object,
+    exc: BaseException,
+) -> NoReturn:
+    event = InfrastructureUnavailableEvent(
+        resource_key=resource_key,
+        phase=phase,
+        reason=_exception_summary(exc),
+    )
+    policy = load_gate_policy(policy_path)
+    decision = classify_infrastructure_failure(phase, event, policy)
+    dispatch_gate_decision_alert(
+        decision,
+        cycle_id=_cycle_id_from_context(context),
+        failed_node=resource_key,
+        summary=_infra_summary(resource_key, exc),
+        channels=policy.alert_channels,
+    )
+    raise InfrastructureUnavailableError(event, decision, exc) from exc
+
+
+def _infra_summary(resource_key: str, exc: BaseException) -> str:
+    return f"{resource_key} unavailable: {_exception_summary(exc)}"
+
+
+def _exception_summary(exc: BaseException) -> str:
+    message = str(exc)
+    if message:
+        return f"{type(exc).__name__}: {message}"
+    return type(exc).__name__
+
+
+def _cycle_id_from_context(context: object) -> str:
+    dagster_run = getattr(context, "dagster_run", None)
+    if dagster_run is None:
+        dagster_run = getattr(context, "run", None)
+    tags = getattr(dagster_run, "tags", {}) or {}
+    cycle_id = tags.get("cycle_id") if isinstance(tags, Mapping) else None
+    if isinstance(cycle_id, str) and cycle_id:
+        return cycle_id
+
+    run_id = getattr(context, "run_id", None)
+    return run_id if isinstance(run_id, str) and run_id else "unknown-infra-run"
+
+
+__all__ = [
+    "CORE_INFRASTRUCTURE_RESOURCE_KEYS",
+    "INFRASTRUCTURE_RESOURCE_PHASES",
+    "INFRA_UNAVAILABLE_HARD_STOP_SCENARIO_ID",
+    "InfrastructureUnavailableError",
+    "InfrastructureUnavailableEvent",
+    "classify_infrastructure_failure",
+    "guard_infrastructure_resource",
+]

--- a/tests/checks/test_classifier.py
+++ b/tests/checks/test_classifier.py
@@ -103,6 +103,20 @@ def test_classify_phase3_infra_repairs_manifest(gate_policy: Any) -> None:
     assert decision.action is GateAction.REPAIR_MANIFEST
 
 
+def test_classify_scenario_uses_applies_to_phase(gate_policy: Any) -> None:
+    decision = classify_gate_result(
+        PhaseEnum.PHASE1,
+        {
+            "failure_class": FailureClass.INFRA,
+            "scenario_id": "infra_unavailable_hard_stop",
+        },
+        gate_policy,
+    )
+
+    assert decision.phase is PhaseEnum.PHASE1
+    assert decision.action is GateAction.FAIL_RUN
+
+
 def test_unknown_policy_combination_raises(gate_policy: Any) -> None:
     with pytest.raises(
         UnknownGateFailure,

--- a/tests/integration/test_infra_hard_stop.py
+++ b/tests/integration/test_infra_hard_stop.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.integration.conftest import asset_materialization_keys
+
+_DOWNSTREAM_PUBLISH_ASSET_KEY = "phase2_downstream_publish"
+
+
+@pytest.mark.parametrize(
+    ("failing_resource_key", "blocked_asset_key"),
+    [
+        ("dbt", "graph_promotion"),
+        ("data_readiness", "graph_promotion"),
+        ("llm_health_probe", "graph_promotion"),
+        ("phase2_pool_failure_rate", _DOWNSTREAM_PUBLISH_ASSET_KEY),
+    ],
+)
+def test_daily_cycle_hard_stops_on_guarded_resource_init_failure(
+    dagster_module: object,
+    dagster_instance: object,
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    failing_resource_key: str,
+    blocked_asset_key: str,
+) -> None:
+    dagster = dagster_module
+    defs = _build_defs(
+        dagster,
+        monkeypatch=monkeypatch,
+        stub_policy_path=stub_policy_path,
+        failing_resource_key=failing_resource_key,
+    )
+    dagster.Definitions.validate_loadable(defs)
+
+    with caplog.at_level(logging.WARNING, logger="orchestrator.alerting.dispatcher"):
+        result = defs.get_job_def("daily_cycle_job").execute_in_process(
+            instance=dagster_instance,
+            raise_on_error=False,
+            tags={"cycle_id": "cycle-20260416"},
+        )
+
+    materialized_keys = asset_materialization_keys(result)
+    payload = _single_alert_for_resource(caplog.records, failing_resource_key)
+
+    assert result.success is False
+    assert dagster.AssetKey([blocked_asset_key]) not in materialized_keys
+    assert payload["phase"] in {"phase0", "phase2"}
+    assert payload["failure_class"] == "infra"
+    assert payload["action"] == "fail_run"
+    assert payload["failed_node"] == failing_resource_key
+    assert f"fake {failing_resource_key} unavailable" in str(payload["summary"])
+
+
+def _build_defs(
+    dagster: Any,
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_policy_path: str,
+    failing_resource_key: str,
+) -> object:
+    import orchestrator.definitions as definitions_module
+
+    if failing_resource_key == "dbt":
+        monkeypatch.setattr(
+            definitions_module,
+            "DbtCliResource",
+            _raising_dbt_resource_type(dagster),
+        )
+
+    return definitions_module.build_definitions(
+        module_factories=[
+            _fake_phase0_surface_provider(dagster, failing_resource_key),
+            _fake_phase1_provider(dagster),
+            _fake_phase2_provider(dagster, failing_resource_key),
+        ],
+        policy_path=stub_policy_path,
+    )
+
+
+def _raising_dbt_resource_type(dagster: Any) -> type:
+    class RaisingDbtResource(dagster.ConfigurableResource):
+        project_dir: str
+        profiles_dir: str
+
+        def create_resource(self, context: object) -> object:
+            raise RuntimeError("fake dbt unavailable")
+
+    return RaisingDbtResource
+
+
+def _fake_phase0_surface_provider(
+    dagster: Any,
+    failing_resource_key: str,
+) -> object:
+    from orchestrator.checks import DataReadinessSignal
+    from orchestrator.jobs.phase0_constants import (
+        PHASE0_CANDIDATE_FREEZE_ASSET_KEY,
+        PHASE0_GROUP_NAME,
+        PHASE0_READINESS_ASSET_KEY,
+    )
+    from orchestrator.sensors.data_readiness import DATA_READINESS_RESOURCE_KEY
+
+    class RaisingResource(dagster.ConfigurableResource):
+        resource_key: str
+
+        def create_resource(self, context: object) -> object:
+            raise RuntimeError(f"fake {self.resource_key} unavailable")
+
+    class FakeDataReadinessProvider:
+        def get_data_readiness_signal(self) -> DataReadinessSignal:
+            return DataReadinessSignal(ready=True, cycle_id="cycle-20260416")
+
+    class FakeDataReadinessResource(dagster.ConfigurableResource):
+        def create_resource(self, context: object) -> FakeDataReadinessProvider:
+            return FakeDataReadinessProvider()
+
+    class FakeLLMHealthResult:
+        healthy = True
+        summary = "provider ready"
+        provider = "fake-llm"
+
+    class FakeLLMHealthProbe:
+        def check_health(self) -> FakeLLMHealthResult:
+            return FakeLLMHealthResult()
+
+    class FakeLLMHealthProbeResource(dagster.ConfigurableResource):
+        def create_resource(self, context: object) -> FakeLLMHealthProbe:
+            return FakeLLMHealthProbe()
+
+    @dagster.asset(
+        name=PHASE0_CANDIDATE_FREEZE_ASSET_KEY,
+        group_name=PHASE0_GROUP_NAME,
+        deps=[dagster.AssetKey([PHASE0_READINESS_ASSET_KEY])],
+    )
+    def candidate_freeze(
+        data_readiness: dagster.ResourceParam[object],
+        dbt: dagster.ResourceParam[object],
+    ) -> str:
+        return "frozen"
+
+    class FakePhase0SurfaceProvider:
+        def get_assets(self) -> tuple[object, ...]:
+            return (candidate_freeze,)
+
+        def get_checks(self) -> tuple[object, ...]:
+            return ()
+
+        def get_resources(self) -> dict[str, object]:
+            data_readiness_resource: object
+            llm_health_probe_resource: object
+
+            if failing_resource_key == DATA_READINESS_RESOURCE_KEY:
+                data_readiness_resource = RaisingResource(
+                    resource_key=DATA_READINESS_RESOURCE_KEY,
+                )
+            else:
+                data_readiness_resource = FakeDataReadinessResource()
+
+            if failing_resource_key == "llm_health_probe":
+                llm_health_probe_resource = RaisingResource(
+                    resource_key="llm_health_probe",
+                )
+            else:
+                llm_health_probe_resource = FakeLLMHealthProbeResource()
+
+            return {
+                DATA_READINESS_RESOURCE_KEY: data_readiness_resource,
+                "llm_health_probe": llm_health_probe_resource,
+            }
+
+    return FakePhase0SurfaceProvider()
+
+
+def _fake_phase1_provider(dagster: Any) -> object:
+    from orchestrator.jobs.phase0_constants import (
+        PHASE0_CANDIDATE_FREEZE_ASSET_KEY,
+        PHASE0_READINESS_ASSET_KEY,
+    )
+    from orchestrator.jobs.phase1 import (
+        PHASE1_GRAPH_PROMOTION_ASSET_KEY,
+        PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
+        PHASE1_GROUP_NAME,
+    )
+
+    @dagster.asset(
+        name=PHASE1_GRAPH_PROMOTION_ASSET_KEY,
+        group_name=PHASE1_GROUP_NAME,
+        deps=[
+            dagster.AssetKey([PHASE0_READINESS_ASSET_KEY]),
+            dagster.AssetKey([PHASE0_CANDIDATE_FREEZE_ASSET_KEY]),
+        ],
+    )
+    def graph_promotion() -> str:
+        return "promoted"
+
+    @dagster.asset(
+        name=PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
+        group_name=PHASE1_GROUP_NAME,
+    )
+    def graph_snapshot(graph_promotion: str) -> str:
+        return f"snapshot:{graph_promotion}"
+
+    class FakePhase1Provider:
+        def get_assets(self) -> tuple[object, ...]:
+            return (graph_promotion, graph_snapshot)
+
+        def get_checks(self) -> tuple[object, ...]:
+            return ()
+
+        def get_resources(self) -> dict[str, object]:
+            return {}
+
+    return FakePhase1Provider()
+
+
+def _fake_phase2_provider(dagster: Any, failing_resource_key: str) -> object:
+    from orchestrator.checks import (
+        PHASE2_POOL_FAILURE_RATE_RESOURCE_KEY,
+        Phase2PoolFailureRateEvent,
+    )
+    from orchestrator.jobs.phase2 import PHASE2_GROUP_NAME, PHASE2_STAGE_KEYS
+
+    @dagster.asset(name=PHASE2_STAGE_KEYS[0], group_name=PHASE2_GROUP_NAME)
+    def phase2_l1(graph_snapshot: str) -> str:
+        return f"{graph_snapshot}:l1"
+
+    @dagster.asset(name=PHASE2_STAGE_KEYS[1], group_name=PHASE2_GROUP_NAME)
+    def phase2_l2(l1: str) -> str:
+        return f"{l1}:l2"
+
+    @dagster.asset(name=PHASE2_STAGE_KEYS[2], group_name=PHASE2_GROUP_NAME)
+    def phase2_l3(l2: str) -> str:
+        return f"{l2}:l3"
+
+    @dagster.asset(name=PHASE2_STAGE_KEYS[3], group_name=PHASE2_GROUP_NAME)
+    def phase2_l4(l3: str) -> str:
+        return f"{l3}:l4"
+
+    @dagster.asset(name=PHASE2_STAGE_KEYS[4], group_name=PHASE2_GROUP_NAME)
+    def phase2_l5(l4: str) -> str:
+        return f"{l4}:l5"
+
+    @dagster.asset(name=PHASE2_STAGE_KEYS[5], group_name=PHASE2_GROUP_NAME)
+    def phase2_l6(l5: str) -> str:
+        return f"{l5}:l6"
+
+    @dagster.asset(name=PHASE2_STAGE_KEYS[6], group_name=PHASE2_GROUP_NAME)
+    def phase2_l7(l6: str) -> str:
+        return f"{l6}:l7"
+
+    @dagster.asset(name=_DOWNSTREAM_PUBLISH_ASSET_KEY, group_name=PHASE2_GROUP_NAME)
+    def phase2_downstream_publish(l7: str) -> str:
+        return f"{l7}:published"
+
+    class RaisingResource(dagster.ConfigurableResource):
+        def create_resource(self, context: object) -> object:
+            raise RuntimeError(
+                f"fake {PHASE2_POOL_FAILURE_RATE_RESOURCE_KEY} unavailable",
+            )
+
+    class FakePhase2PoolFailureRateResource(dagster.ConfigurableResource):
+        def get_phase2_pool_failure_rate_event(
+            self,
+        ) -> Phase2PoolFailureRateEvent:
+            return Phase2PoolFailureRateEvent(
+                failed_count=0,
+                total_count=10,
+                failed_nodes=(),
+                reason="healthy fake pool",
+            )
+
+    phase2_assets = (
+        phase2_l1,
+        phase2_l2,
+        phase2_l3,
+        phase2_l4,
+        phase2_l5,
+        phase2_l6,
+        phase2_l7,
+        phase2_downstream_publish,
+    )
+
+    class FakePhase2Provider:
+        def get_assets(self) -> tuple[object, ...]:
+            return phase2_assets
+
+        def get_checks(self) -> tuple[object, ...]:
+            return ()
+
+        def get_resources(self) -> dict[str, object]:
+            if failing_resource_key == PHASE2_POOL_FAILURE_RATE_RESOURCE_KEY:
+                return {PHASE2_POOL_FAILURE_RATE_RESOURCE_KEY: RaisingResource()}
+            return {
+                PHASE2_POOL_FAILURE_RATE_RESOURCE_KEY: (
+                    FakePhase2PoolFailureRateResource()
+                ),
+            }
+
+    return FakePhase2Provider()
+
+
+def _single_alert_for_resource(
+    records: Iterable[logging.LogRecord],
+    resource_key: str,
+) -> dict[str, object]:
+    payloads = [
+        payload
+        for payload in _alert_payloads(records)
+        if payload.get("failed_node") == resource_key
+    ]
+    assert len(payloads) == 1
+    return payloads[0]
+
+
+def _alert_payloads(records: Iterable[logging.LogRecord]) -> list[dict[str, object]]:
+    payloads: list[dict[str, object]] = []
+    for record in records:
+        try:
+            payload = json.loads(record.message)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            payloads.append(payload)
+    return payloads

--- a/tests/integration/test_infra_hard_stop.py
+++ b/tests/integration/test_infra_hard_stop.py
@@ -60,6 +60,43 @@ def test_daily_cycle_hard_stops_on_guarded_resource_init_failure(
     assert f"fake {failing_resource_key} unavailable" in str(payload["summary"])
 
 
+def test_daily_cycle_alerts_when_gate_policy_resource_load_fails(
+    dagster_module: object,
+    dagster_instance: object,
+    tmp_dbt_project: Path,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dagster = dagster_module
+    missing_policy_path = tmp_path / "missing_gate_policy.yaml"
+    defs = _build_defs(
+        dagster,
+        monkeypatch=monkeypatch,
+        stub_policy_path=str(missing_policy_path),
+        failing_resource_key="none",
+    )
+    dagster.Definitions.validate_loadable(defs)
+
+    with caplog.at_level(logging.WARNING, logger="orchestrator.alerting.dispatcher"):
+        result = defs.get_job_def("daily_cycle_job").execute_in_process(
+            instance=dagster_instance,
+            raise_on_error=False,
+            tags={"cycle_id": "cycle-20260416"},
+        )
+
+    materialized_keys = asset_materialization_keys(result)
+    payload = _single_alert_for_resource(caplog.records, "gate_policy")
+
+    assert result.success is False
+    assert dagster.AssetKey(["graph_promotion"]) not in materialized_keys
+    assert payload["phase"] == "phase0"
+    assert payload["failure_class"] == "infra"
+    assert payload["action"] == "fail_run"
+    assert payload["failed_node"] == "gate_policy"
+    assert missing_policy_path.name in str(payload["summary"])
+
+
 def _build_defs(
     dagster: Any,
     *,

--- a/tests/resources/test_infra_gate.py
+++ b/tests/resources/test_infra_gate.py
@@ -8,13 +8,18 @@ import yaml
 
 from orchestrator.policy import GateAction, PhaseEnum, load_gate_policy
 
-pytest.importorskip("dagster", reason="dagster is not installed")
+_DAGSTER_IMPORT_ERROR: str | None = None
+try:
+    import dagster as _dagster  # noqa: F401
+except Exception as exc:
+    _DAGSTER_IMPORT_ERROR = f"dagster is not importable: {exc}"
 
-from orchestrator.resources import (  # noqa: E402
-    INFRA_UNAVAILABLE_HARD_STOP_SCENARIO_ID,
-    InfrastructureUnavailableEvent,
-    classify_infrastructure_failure,
+pytestmark = pytest.mark.skipif(
+    _DAGSTER_IMPORT_ERROR is not None,
+    reason=_DAGSTER_IMPORT_ERROR or "",
 )
+
+from orchestrator.checks import DataReadinessSignal
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -49,13 +54,14 @@ def test_classify_infrastructure_failure_hard_stops_each_phase(
     gate_policy: Any,
     phase: PhaseEnum,
 ) -> None:
-    event = InfrastructureUnavailableEvent(
+    infra = _infra_module()
+    event = infra.InfrastructureUnavailableEvent(
         resource_key="dbt",
         phase=phase,
         reason="postgres unavailable",
     )
 
-    decision = classify_infrastructure_failure(phase, event, gate_policy)
+    decision = infra.classify_infrastructure_failure(phase, event, gate_policy)
 
     assert decision.phase is phase
     assert decision.action is GateAction.FAIL_RUN
@@ -68,21 +74,22 @@ def test_classify_infrastructure_failure_hard_stops_each_phase(
 def test_classify_infrastructure_failure_rejects_policy_misconfiguration(
     tmp_path: Path,
 ) -> None:
+    infra = _infra_module()
     policy_data = _load_lite_policy_data()
     for entry in policy_data["phase_matrix"]:
-        if entry["scenario_id"] == INFRA_UNAVAILABLE_HARD_STOP_SCENARIO_ID:
+        if entry["scenario_id"] == infra.INFRA_UNAVAILABLE_HARD_STOP_SCENARIO_ID:
             entry["action"] = "repair_manifest"
             break
 
     policy = load_gate_policy(_write_policy(tmp_path, policy_data))
-    event = InfrastructureUnavailableEvent(
+    event = infra.InfrastructureUnavailableEvent(
         resource_key="dbt",
         phase=PhaseEnum.PHASE1,
         reason="neo4j unavailable",
     )
 
     with pytest.raises(ValueError, match="action=fail_run"):
-        classify_infrastructure_failure(PhaseEnum.PHASE1, event, policy)
+        infra.classify_infrastructure_failure(PhaseEnum.PHASE1, event, policy)
 
 
 def test_classify_infrastructure_failure_does_not_steal_manifest_repair(
@@ -102,3 +109,67 @@ def test_classify_infrastructure_failure_does_not_steal_manifest_repair(
     )
 
     assert decision.action is GateAction.REPAIR_MANIFEST
+
+
+@pytest.mark.parametrize(
+    "surface_name",
+    [
+        "get_readiness_signal",
+        "get_data_readiness",
+        "readiness_signal",
+    ],
+)
+def test_guarded_data_readiness_accepts_supported_signal_surfaces(
+    surface_name: str,
+) -> None:
+    signal = DataReadinessSignal(ready=True, cycle_id="cycle-20260416")
+    provider = _readiness_provider(surface_name, signal)
+    guarded = _infra_module()._GuardedInfrastructureValue(
+        resource_key="data_readiness",
+        value=provider,
+        phase=PhaseEnum.PHASE0,
+        policy_path=str(LITE_POLICY_PATH),
+        context=object(),
+    )
+
+    if callable(getattr(provider, surface_name, None)):
+        observed = getattr(guarded, surface_name)()
+    else:
+        observed = getattr(guarded, surface_name)
+
+    assert observed is signal
+    assert getattr(guarded, "missing_optional_signal", "fallback") == "fallback"
+    assert not hasattr(guarded, "missing_optional_signal")
+
+
+def _infra_module() -> Any:
+    import orchestrator.resources.infra as infra
+
+    return infra
+
+
+def _readiness_provider(
+    surface_name: str,
+    signal: DataReadinessSignal,
+) -> object:
+    if surface_name == "get_readiness_signal":
+        class GetReadinessSignalProvider:
+            def get_readiness_signal(self) -> DataReadinessSignal:
+                return signal
+
+        return GetReadinessSignalProvider()
+
+    if surface_name == "get_data_readiness":
+        class GetDataReadinessProvider:
+            def get_data_readiness(self) -> DataReadinessSignal:
+                return signal
+
+        return GetDataReadinessProvider()
+
+    if surface_name == "readiness_signal":
+        class ReadinessSignalProvider:
+            readiness_signal = signal
+
+        return ReadinessSignalProvider()
+
+    raise AssertionError(f"unsupported readiness surface: {surface_name}")

--- a/tests/resources/test_infra_gate.py
+++ b/tests/resources/test_infra_gate.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from orchestrator.policy import GateAction, PhaseEnum, load_gate_policy
+
+pytest.importorskip("dagster", reason="dagster is not installed")
+
+from orchestrator.resources import (  # noqa: E402
+    INFRA_UNAVAILABLE_HARD_STOP_SCENARIO_ID,
+    InfrastructureUnavailableEvent,
+    classify_infrastructure_failure,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LITE_POLICY_PATH = REPO_ROOT / "config" / "policy" / "gate_policy.lite.yaml"
+
+
+@pytest.fixture
+def gate_policy() -> Any:
+    return load_gate_policy(LITE_POLICY_PATH)
+
+
+def _load_lite_policy_data() -> dict[str, Any]:
+    return yaml.safe_load(LITE_POLICY_PATH.read_text(encoding="utf-8"))
+
+
+def _write_policy(tmp_path: Path, policy_data: dict[str, Any]) -> Path:
+    policy_path = tmp_path / "gate_policy.yaml"
+    policy_path.write_text(yaml.safe_dump(policy_data), encoding="utf-8")
+    return policy_path
+
+
+@pytest.mark.parametrize(
+    "phase",
+    [
+        PhaseEnum.PHASE0,
+        PhaseEnum.PHASE1,
+        PhaseEnum.PHASE2,
+        PhaseEnum.PHASE3,
+    ],
+)
+def test_classify_infrastructure_failure_hard_stops_each_phase(
+    gate_policy: Any,
+    phase: PhaseEnum,
+) -> None:
+    event = InfrastructureUnavailableEvent(
+        resource_key="dbt",
+        phase=phase,
+        reason="postgres unavailable",
+    )
+
+    decision = classify_infrastructure_failure(phase, event, gate_policy)
+
+    assert decision.phase is phase
+    assert decision.action is GateAction.FAIL_RUN
+    assert decision.failure_class.value == "infra"
+    assert decision.reason == (
+        "Core storage or graph infrastructure is unavailable; hard stop."
+    )
+
+
+def test_classify_infrastructure_failure_rejects_policy_misconfiguration(
+    tmp_path: Path,
+) -> None:
+    policy_data = _load_lite_policy_data()
+    for entry in policy_data["phase_matrix"]:
+        if entry["scenario_id"] == INFRA_UNAVAILABLE_HARD_STOP_SCENARIO_ID:
+            entry["action"] = "repair_manifest"
+            break
+
+    policy = load_gate_policy(_write_policy(tmp_path, policy_data))
+    event = InfrastructureUnavailableEvent(
+        resource_key="dbt",
+        phase=PhaseEnum.PHASE1,
+        reason="neo4j unavailable",
+    )
+
+    with pytest.raises(ValueError, match="action=fail_run"):
+        classify_infrastructure_failure(PhaseEnum.PHASE1, event, policy)
+
+
+def test_classify_infrastructure_failure_does_not_steal_manifest_repair(
+    gate_policy: Any,
+) -> None:
+    from orchestrator.checks.phase3 import (
+        ManifestWriteFailureEvent,
+        classify_manifest_write_failure,
+    )
+
+    decision = classify_manifest_write_failure(
+        ManifestWriteFailureEvent(
+            repair_node="repair_cycle_publish_manifest",
+            reason="manifest sink timed out",
+        ),
+        gate_policy,
+    )
+
+    assert decision.action is GateAction.REPAIR_MANIFEST


### PR DESCRIPTION
Closes #30

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `scripts/check_boundaries.py`, `src/orchestrator/alerting/dispatcher.py`, `src/orchestrator/checks/classifier.py`, `src/orchestrator/checks/dbt_events.py`, `src/orchestrator/checks/phase1.py`, `src/orchestrator/checks/phase2.py`, `src/orchestrator/checks/phase3.py`, `src/orchestrator/definitions.py`, `src/orchestrator/jobs/cycle.py`


---
### 1. 背景与目标
`docs/orchestrator.project-doc.md` §12.3 最后一行规定 PG / Iceberg / Neo4j 等基础设施不可用时，任意 phase 都必须硬停，不能继续进入后续发布路径。当前代码已有 `GatePolicyResource`、`build_resource_bundle()`、`DataReadinessSignal`、`llm_health_check`、Phase 1 failure hook 和 Phase 2/3 gate adapters，但基础设施初始化异常仍主要表现为普通 Dagster resource failure，缺少统一的 `GateDecision`、alert payload 和可测试的 hard-stop adapter。本 issue 的目标是把基础设施不可用归一化为 `FailureClass.INFRA + GateAction.FAIL_RUN`，并在 resource 初始化或 provider health check 失败时短路 daily cycle。

### 2. 所属模块
`src/orchestrator/resources/`、`src/orchestrator/checks/`、`src/orchestrator/definitions.py`、`tests/resources/`、`tests/integration/`。

### 3. 实现范围
- 新增 `src/orchestrator/resources/infra.py`：定义 `InfrastructureUnavailableEvent` dataclass，字段建议为 `failure_class: FailureClass = FailureClass.INFRA`、`resource_key: str`、`phase: PhaseEnum`、`reason: str`、`scenario_id: str = 'infra_unavailable_hard_stop'`。
- 实现 `classify_infrastructure_failure(phase: PhaseEnum, event: InfrastructureUnavailableEvent, policy: GatePolicyProfile) -> GateDecision`，复用 `orchestrator.checks.classifier.classify_gate_result()`，并要求返回 `GateAction.FAIL_RUN`，否则抛 `ValueError` 防止 policy 误配。
- 新增 `guard_infrastructure_resource(...)` 或等价 wrapper，覆盖 orchestrator 已知资源 key：`dbt`、`gate_policy`、`data_readiness`、`llm_health_probe`、`phase2_pool_failure_rate`，在 provider 初始化 / health check 抛异常时生成 `GateDecision` 并调用 `dispatch_gate_decision_alert()`。
- 修改 `src/orchestrator/definitions.py`：在把 `resource_bundle.resources` 合入 `Definitions(resources={...})` 前，对声明为核心基础设施的资源应用 guard；不要包装普通业务 asset 函数。
- 保持 `ResourceBundle` 只读边界：不得修改 `ResourceBundle.resources` 的 `MappingProxyType`，需要创建新的 resources dict 注入 Dagster。
- 新增测试：`tests/resources/test_infra_gate.py` 覆盖纯分类和 policy 误配；`tests/integration/test_infra_hard_stop.py` 用 fake `ConfigurableResource.create_resource()` 抛错验证 `daily_cycle_job.execute_in_process(..., raise_on_error=False)` 失败并产生 `fail_run` alert。

### 4. 不在本次范围
- 不实现真实 PG / Iceberg / Neo4j client，也不主动连接外部服务。
- 不把 provider 的业务健康检查