### PR TITLE
feat(#32): Runbook 生成与 alert payload 关联

### DIFF
--- a/docs/RUNBOOK_P5.md
+++ b/docs/RUNBOOK_P5.md
@@ -1,0 +1,180 @@
+# P5 Gate Runbook
+
+本 runbook 面向 P5 影子运行值班处理。告警中的 `runbook_url` 使用仓库内相对路径和锚点，锚点由 `phase/failure_class/action` 组合生成。
+
+### 通用处理原则
+
+1. 先确认告警 payload 的 `cycle_id`、`phase`、`failed_node`、`failure_class`、`action`。
+2. 只在对应上游模块或运行环境中排查业务原因；`orchestrator` 只负责装配、分类、告警和 rerun/repair 请求。
+3. 处理后用本节给出的验证命令或对应测试确认路径恢复。
+
+<a id="phase0-data_quality-fail_run"></a>
+## phase0-data_quality-fail_run
+
+场景：`phase0_data_readiness_delayed`
+
+适用：Phase 0 数据 readiness 失败，市场数据延迟或不可用。
+
+处理路径：
+
+1. 查看 payload 的 `failed_node`，确认失败来自 data readiness provider。
+2. 到 `data-platform` 或上游数据源检查数据到达、水位、交易日配置。
+3. 数据恢复后重新触发日频 cycle，不在 `orchestrator` 中补写业务数据。
+
+验证：
+
+```bash
+python3 -m pytest tests/sensors/test_data_readiness.py tests/integration/test_phase0_failure_matrix.py -q
+```
+
+<a id="phase0-infra-fail_run"></a>
+## phase0-infra-fail_run
+
+场景：`phase0_llm_health_check_failed`
+
+适用：Phase 0 LLM health check 失败，需要在进入 Phase 1 前硬停。
+
+处理路径：
+
+1. 确认 `reasoner-runtime` health check 返回的 provider、错误摘要和凭据状态。
+2. 修复 provider 配置、网络出口或限流问题。
+3. health check 通过后重新触发 cycle。
+
+验证：
+
+```bash
+python3 -m pytest tests/checks/test_llm_health_check.py -q
+```
+
+<a id="phase0-task_level-partial_rerun"></a>
+## phase0-task_level-partial_rerun
+
+场景：`phase0_dbt_test_failed`
+
+适用：Phase 0 dbt test 失败，Gate action 为 `partial_rerun`。
+
+处理路径：
+
+1. 查看 alert summary 中的 dbt test 名称、asset key、rerun request 写入状态。
+2. 修复 dbt model 或上游输入后，使用生成的 rerun request 选择最小 asset selection。
+3. 不扩大 rerun 到整个 phase，除非 request 生成失败且人工确认需要更大范围。
+
+验证：
+
+```bash
+python3 -m pytest tests/checks/test_dbt_events.py -q
+```
+
+<a id="phase1-publish-fail_run"></a>
+## phase1-publish-fail_run
+
+场景：`phase1_graph_promotion_snapshot_failed`
+
+适用：Phase 1 graph promotion 或 snapshot 失败，保留上一版 ready graph。
+
+处理路径：
+
+1. 确认失败节点是 graph promotion 或 snapshot asset。
+2. 到 `graph-engine` 检查纯检查函数输出和 graph artifact 完整性。
+3. 修复后重新执行 Phase 1；不要在编排层复制 graph 业务逻辑。
+
+验证：
+
+```bash
+python3 -m pytest tests/checks/test_phase1_gate.py tests/integration/test_phase1_graph_gate.py -q
+```
+
+<a id="phase2-task_level-mark_inconclusive"></a>
+## phase2-task_level-mark_inconclusive
+
+场景：`phase2_single_stock_task_failed`
+
+适用：Phase 2 单股票任务失败但未超过容忍阈值，标记为 `mark_inconclusive` 并继续其他股票。
+
+处理路径：
+
+1. 记录 payload 中的股票、失败节点和 failure rate。
+2. 在 `main-core` 检查单股票任务输入、LLM 响应和输出校验。
+3. 仅对受影响股票做后续补跑或人工审阅；不要阻塞整个 pool，除非 pool gate 后续失败。
+
+验证：
+
+```bash
+python3 -m pytest tests/checks/test_phase2_single_stock_gate.py tests/integration/test_phase2_inconclusive_path.py -q
+```
+
+<a id="phase2-data_quality-fail_run"></a>
+## phase2-data_quality-fail_run
+
+场景：`phase2_pool_failure_rate_exceeded`
+
+适用：Phase 2 pool failure rate 超过 policy 阈值，整轮失败并告警。
+
+处理路径：
+
+1. 查看 payload 的 `failed_node` 列表和 summary 中的失败比例。
+2. 到 `main-core` 检查 pool 级输入、任务分布和失败类别。
+3. 修复后重新触发 cycle 或按事故处理流程重跑 Phase 2。
+
+验证：
+
+```bash
+python3 -m pytest tests/checks/test_phase2_pool_gate.py tests/integration/test_phase2_pool_failure_gate.py -q
+```
+
+<a id="phase3-publish-fail_run"></a>
+## phase3-publish-fail_run
+
+场景：`phase3_formal_commit_failed`
+
+适用：Phase 3 formal table commit 失败，manifest 写入前硬停。
+
+处理路径：
+
+1. 确认失败发生在 formal objects commit，而不是 manifest repair 路径。
+2. 到 `main-core` 发布入口检查事务、目标表 schema、权限和幂等状态。
+3. commit 成功前不要手工写 manifest。
+
+验证：
+
+```bash
+python3 -m pytest tests/checks/test_phase3_publish_gate.py tests/integration/test_phase3_publish_wiring.py -q
+```
+
+<a id="phase3-infra-repair_manifest"></a>
+## phase3-infra-repair_manifest
+
+场景：`phase3_manifest_write_failed`
+
+适用：Phase 3 manifest 写入失败，Gate action 为 `repair_manifest`。
+
+处理路径：
+
+1. 确认 payload 的 `failed_node` 是 `cycle_publish_manifest`。
+2. 使用 repair-only rerun request，只选择注册的 manifest repair asset。
+3. repair 成功后核对 manifest 内容指向已提交的 formal objects，不重新提交业务表。
+
+验证：
+
+```bash
+python3 -m pytest tests/checks/test_phase3_manifest_repair.py tests/integration/test_phase3_manifest_repair_flow.py -q
+```
+
+<a id="phase2-infra-fail_run"></a>
+## phase2-infra-fail_run
+
+场景：`infra_unavailable_hard_stop`
+
+适用：核心存储、Dagster instance、graph backend 或其他基础设施不可用。矩阵入口记录为 `phase2/infra/fail_run`，但 `applies_to_phases` 覆盖 Phase 0 到 Phase 3。
+
+处理路径：
+
+1. 确认 payload 中的 phase 和 failed node，判断是存储、实例连接、graph backend 还是资源装配失败。
+2. 修复基础设施或 assembly 提供的环境配置。
+3. 基础设施恢复后重新触发受影响 cycle；不要在业务模块中绕过 gate。
+
+验证：
+
+```bash
+python3 -m pytest tests/resources/test_bundle.py tests/policy/test_gate_matrix_coverage.py -q
+```

--- a/src/orchestrator/alerting/__init__.py
+++ b/src/orchestrator/alerting/__init__.py
@@ -1,4 +1,11 @@
 from orchestrator.alerting.dispatcher import AlertDispatchResult, dispatch_alert
 from orchestrator.alerting.payload import AlertPayload
+from orchestrator.alerting.runbooks import runbook_url_for, with_runbook_url
 
-__all__ = ["AlertDispatchResult", "AlertPayload", "dispatch_alert"]
+__all__ = [
+    "AlertDispatchResult",
+    "AlertPayload",
+    "dispatch_alert",
+    "runbook_url_for",
+    "with_runbook_url",
+]

--- a/src/orchestrator/alerting/runbooks.py
+++ b/src/orchestrator/alerting/runbooks.py
@@ -1,0 +1,82 @@
+"""Runbook URL helpers for gate decision alerts."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Final
+
+from orchestrator.alerting.payload import AlertPayload
+
+RUNBOOK_P5_PATH: Final = "docs/RUNBOOK_P5.md"
+
+_SCENARIO_RUNBOOK_ANCHORS: Final[dict[str, str]] = {
+    "phase0_data_readiness_delayed": "phase0-data_quality-fail_run",
+    "phase0_llm_health_check_failed": "phase0-infra-fail_run",
+    "phase0_dbt_test_failed": "phase0-task_level-partial_rerun",
+    "phase1_graph_promotion_snapshot_failed": "phase1-publish-fail_run",
+    "phase2_single_stock_task_failed": "phase2-task_level-mark_inconclusive",
+    "phase2_pool_failure_rate_exceeded": "phase2-data_quality-fail_run",
+    "phase3_formal_commit_failed": "phase3-publish-fail_run",
+    "phase3_manifest_write_failed": "phase3-infra-repair_manifest",
+    "infra_unavailable_hard_stop": "phase2-infra-fail_run",
+}
+
+
+def runbook_url_for(
+    phase: str,
+    failure_class: str | None,
+    action: str,
+    *,
+    scenario_id: str | None = None,
+) -> str:
+    """Return the repository-relative P5 runbook URL for a gate outcome."""
+
+    if scenario_id is not None:
+        scenario_anchor = _SCENARIO_RUNBOOK_ANCHORS.get(scenario_id.strip())
+        if scenario_anchor is not None:
+            return _runbook_url(scenario_anchor)
+
+    return _runbook_url(_anchor_for(phase, failure_class, action))
+
+
+def with_runbook_url(
+    payload: AlertPayload,
+    *,
+    scenario_id: str | None = None,
+) -> AlertPayload:
+    """Return an alert payload with a runbook URL filled when absent."""
+
+    if payload.runbook_url:
+        return payload
+
+    return replace(
+        payload,
+        runbook_url=runbook_url_for(
+            payload.phase,
+            payload.failure_class,
+            payload.action,
+            scenario_id=scenario_id,
+        ),
+    )
+
+
+def _anchor_for(phase: str, failure_class: str | None, action: str) -> str:
+    failure_anchor = _normalize_part(failure_class) if failure_class else "unknown"
+    return "-".join(
+        (
+            _normalize_part(phase),
+            failure_anchor,
+            _normalize_part(action),
+        ),
+    )
+
+
+def _normalize_part(value: str) -> str:
+    return value.strip().lower().replace(" ", "_")
+
+
+def _runbook_url(anchor: str) -> str:
+    return f"{RUNBOOK_P5_PATH}#{anchor}"
+
+
+__all__ = ["runbook_url_for", "with_runbook_url"]

--- a/src/orchestrator/checks/decision_handler.py
+++ b/src/orchestrator/checks/decision_handler.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
-from orchestrator.alerting import AlertPayload, dispatch_alert
+from orchestrator.alerting import AlertPayload, dispatch_alert, with_runbook_url
 from orchestrator.checks.models import GateDecision
 from orchestrator.policy import GateAction
 
@@ -16,13 +16,15 @@ def dispatch_gate_decision_alert(
     failed_node: str | None,
     summary: str,
     channels: Iterable[str],
+    runbook_url: str | None = None,
 ) -> None:
     """Dispatch an alert for non-continue gate decisions."""
 
     if decision.action is GateAction.CONTINUE:
         return
 
-    dispatch_alert(
+    failure_class = decision.failure_class.value if decision.failure_class else None
+    payload = with_runbook_url(
         AlertPayload(
             cycle_id=cycle_id,
             phase=decision.phase.value,
@@ -30,10 +32,13 @@ def dispatch_gate_decision_alert(
             failed_node=failed_node,
             action=decision.action.value,
             summary=summary,
-            failure_class=(
-                decision.failure_class.value if decision.failure_class else None
-            ),
+            failure_class=failure_class,
+            runbook_url=runbook_url,
         ),
+    )
+
+    dispatch_alert(
+        payload,
         channels=channels,
     )
 

--- a/tests/alerting/test_runbooks.py
+++ b/tests/alerting/test_runbooks.py
@@ -1,0 +1,90 @@
+import re
+from pathlib import Path
+
+from orchestrator.alerting import AlertPayload, runbook_url_for, with_runbook_url
+from orchestrator.policy import load_gate_policy
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LITE_POLICY_PATH = REPO_ROOT / "config" / "policy" / "gate_policy.lite.yaml"
+RUNBOOK_PATH = REPO_ROOT / "docs" / "RUNBOOK_P5.md"
+RUNBOOK_RELATIVE_PATH = "docs/RUNBOOK_P5.md"
+
+
+def test_runbook_url_for_default_phase_failure_action_anchor() -> None:
+    assert (
+        runbook_url_for("phase2", "data_quality", "fail_run")
+        == "docs/RUNBOOK_P5.md#phase2-data_quality-fail_run"
+    )
+    assert (
+        runbook_url_for("phase3", "infra", "repair_manifest")
+        == "docs/RUNBOOK_P5.md#phase3-infra-repair_manifest"
+    )
+
+
+def test_runbook_url_for_matrix_scenarios_points_to_existing_anchor() -> None:
+    profile = load_gate_policy(LITE_POLICY_PATH)
+    anchors = _runbook_anchors()
+
+    for entry in profile.phase_matrix:
+        url = runbook_url_for(
+            entry.phase.value,
+            entry.failure_class.value,
+            entry.action.value,
+            scenario_id=entry.scenario_id,
+        )
+        path, _separator, anchor = url.partition("#")
+
+        assert path == RUNBOOK_RELATIVE_PATH
+        assert anchor in anchors
+
+
+def test_runbook_url_for_scenario_id_can_target_generic_infra_anchor() -> None:
+    assert (
+        runbook_url_for(
+            "phase0",
+            "infra",
+            "fail_run",
+            scenario_id="infra_unavailable_hard_stop",
+        )
+        == "docs/RUNBOOK_P5.md#phase2-infra-fail_run"
+    )
+
+
+def test_with_runbook_url_fills_missing_url_without_mutating_payload() -> None:
+    payload = AlertPayload(
+        cycle_id="c1",
+        phase="phase2",
+        status="failed",
+        failed_node="phase2_stock_AAPL",
+        action="fail_run",
+        summary="pool failed",
+        failure_class="data_quality",
+    )
+
+    enriched = with_runbook_url(payload)
+
+    assert payload.runbook_url is None
+    assert enriched.runbook_url == (
+        "docs/RUNBOOK_P5.md#phase2-data_quality-fail_run"
+    )
+
+
+def test_with_runbook_url_preserves_explicit_url() -> None:
+    payload = AlertPayload(
+        cycle_id="c1",
+        phase="phase2",
+        status="failed",
+        failed_node="phase2_stock_AAPL",
+        action="fail_run",
+        summary="pool failed",
+        failure_class="data_quality",
+        runbook_url="docs/custom.md#anchor",
+    )
+
+    assert with_runbook_url(payload) is payload
+
+
+def _runbook_anchors() -> set[str]:
+    text = RUNBOOK_PATH.read_text(encoding="utf-8")
+    return set(re.findall(r'<a id="([^"]+)"></a>', text))

--- a/tests/checks/test_dbt_events.py
+++ b/tests/checks/test_dbt_events.py
@@ -255,6 +255,9 @@ def test_stream_dbt_events_handles_failed_check_with_alert_and_request(
     assert alert["failed_node"] == "heartbeat"
     assert alert["action"] == "partial_rerun"
     assert alert["failure_class"] == "task_level"
+    assert alert["runbook_url"] == (
+        "docs/RUNBOOK_P5.md#phase0-task_level-partial_rerun"
+    )
 
 
 def test_rerun_request_write_failure_still_alerts_and_observes(

--- a/tests/checks/test_decision_handler.py
+++ b/tests/checks/test_decision_handler.py
@@ -36,17 +36,50 @@ def test_dispatch_gate_decision_alert_logs_fail_run_payload(
         "action": "fail_run",
         "summary": "not ready",
         "failure_class": "data_quality",
-        "runbook_url": None,
+        "runbook_url": "docs/RUNBOOK_P5.md#phase0-data_quality-fail_run",
     }
 
 
-def test_dispatch_gate_decision_alert_logs_repair_manifest_payload(
+@pytest.mark.parametrize(
+    ("phase", "failure_class", "action", "expected_runbook_url"),
+    [
+        (
+            PhaseEnum.PHASE0,
+            FailureClass.DATA_QUALITY,
+            GateAction.FAIL_RUN,
+            "docs/RUNBOOK_P5.md#phase0-data_quality-fail_run",
+        ),
+        (
+            PhaseEnum.PHASE0,
+            FailureClass.TASK_LEVEL,
+            GateAction.PARTIAL_RERUN,
+            "docs/RUNBOOK_P5.md#phase0-task_level-partial_rerun",
+        ),
+        (
+            PhaseEnum.PHASE2,
+            FailureClass.TASK_LEVEL,
+            GateAction.MARK_INCONCLUSIVE,
+            "docs/RUNBOOK_P5.md#phase2-task_level-mark_inconclusive",
+        ),
+        (
+            PhaseEnum.PHASE3,
+            FailureClass.INFRA,
+            GateAction.REPAIR_MANIFEST,
+            "docs/RUNBOOK_P5.md#phase3-infra-repair_manifest",
+        ),
+    ],
+)
+def test_dispatch_gate_decision_alert_fills_runbook_for_non_continue_actions(
+    phase: PhaseEnum,
+    failure_class: FailureClass,
+    action: GateAction,
+    expected_runbook_url: str,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     decision = GateDecision(
-        phase=PhaseEnum.PHASE3,
-        failure_class=FailureClass.INFRA,
-        action=GateAction.REPAIR_MANIFEST,
+        phase=phase,
+        failure_class=failure_class,
+        action=action,
         reason="policy row",
     )
 
@@ -55,17 +88,43 @@ def test_dispatch_gate_decision_alert_logs_repair_manifest_payload(
             decision,
             cycle_id="cycle-1",
             failed_node="phase3_manifest",
-            summary="manifest write failed",
+            summary="gate failed",
             channels=("logging",),
         )
 
     payload = json.loads(caplog.records[-1].message)
 
-    assert payload["phase"] == "phase3"
+    assert payload["phase"] == phase.value
     assert payload["status"] == "failed"
-    assert payload["action"] == "repair_manifest"
-    assert payload["failure_class"] == "infra"
+    assert payload["action"] == action.value
+    assert payload["failure_class"] == failure_class.value
     assert payload["failed_node"] == "phase3_manifest"
+    assert payload["runbook_url"] == expected_runbook_url
+
+
+def test_dispatch_gate_decision_alert_preserves_explicit_runbook_url(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    decision = GateDecision(
+        phase=PhaseEnum.PHASE2,
+        failure_class=FailureClass.DATA_QUALITY,
+        action=GateAction.FAIL_RUN,
+        reason="policy row",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        dispatch_gate_decision_alert(
+            decision,
+            cycle_id="cycle-1",
+            failed_node="phase2_pool",
+            summary="pool failed",
+            channels=("logging",),
+            runbook_url="docs/custom.md#pool",
+        )
+
+    payload = json.loads(caplog.records[-1].message)
+
+    assert payload["runbook_url"] == "docs/custom.md#pool"
 
 
 def test_dispatch_gate_decision_alert_skips_continue(

--- a/tests/checks/test_phase2_pool_gate.py
+++ b/tests/checks/test_phase2_pool_gate.py
@@ -165,6 +165,9 @@ def test_dispatch_phase2_pool_failure_alert_logs_shared_payload(
     assert payload["summary"] == (
         "Phase 2 pool failure rate 0.4 (4/10): fake pool failures"
     )
+    assert payload["runbook_url"] == (
+        "docs/RUNBOOK_P5.md#phase2-data_quality-fail_run"
+    )
 
 
 def test_dispatch_phase2_pool_failure_alert_skips_continue(

--- a/tests/checks/test_phase3_manifest_repair.py
+++ b/tests/checks/test_phase3_manifest_repair.py
@@ -116,3 +116,6 @@ def test_manifest_write_failure_alert_payload_contains_repair_action(
     assert payload["failure_class"] == "infra"
     assert payload["action"] == "repair_manifest"
     assert payload["failed_node"] == PHASE3_MANIFEST_ASSET_KEY
+    assert payload["runbook_url"] == (
+        "docs/RUNBOOK_P5.md#phase3-infra-repair_manifest"
+    )

--- a/tests/integration/test_phase2_pool_failure_gate.py
+++ b/tests/integration/test_phase2_pool_failure_gate.py
@@ -64,7 +64,7 @@ def test_daily_cycle_phase2_pool_failure_rate_gate_fails_and_alerts(
             "action": "fail_run",
             "summary": "Phase 2 pool failure rate 0.4 (4/10): fake pool failures",
             "failure_class": "data_quality",
-            "runbook_url": None,
+            "runbook_url": "docs/RUNBOOK_P5.md#phase2-data_quality-fail_run",
         },
     ]
 


### PR DESCRIPTION
Closes #32

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `scripts/check_boundaries.py`, `src/orchestrator/alerting/dispatcher.py`, `src/orchestrator/checks/dbt_events.py`, `src/orchestrator/checks/phase1.py`, `src/orchestrator/checks/phase2.py`, `src/orchestrator/checks/phase3.py`, `src/orchestrator/jobs/cycle.py`, `src/orchestrator/resources/infra.py`, `src/orchestrator/sensors/manual_rerun.py`


---
### 1. 背景与目标
`docs/orchestrator.project-doc.md` §13.3 把 runbook / alert payload 定义为值班人面向的运行诊断产物；当前 `AlertPayload` 已有 `runbook_url: str | None = None` 字段，但 `dispatch_gate_decision_alert()` 从未填充，测试里也一直断言为 `None`。P5 影子运行需要 alert 直接指向对应 phase / failure_class / action 的处理说明，而不是让值班人从 `docs/RUNBOOK_P1A.md` 手动搜索。本 issue 的目标是新增 P5 runbook 文档和 payload enrichment，让所有非-continue GateDecision 默认带可预测 runbook anchor。

### 2. 所属模块
`src/orchestrator/alerting/`、`src/orchestrator/checks/decision_handler.py`、`docs/`、`tests/alerting/`、`tests/checks/`。

### 3. 实现范围
- 新增 `docs/RUNBOOK_P5.md`：按 #29 的 9 个 `scenario_id` 或 `phase/failure_class/action` 组合提供锚点，覆盖 Phase 0 数据延迟、LLM hard stop、dbt partial rerun、Phase 1 graph failure、Phase 2 inconclusive、Phase 2 pool fail、Phase 3 formal commit fail、Phase 3 manifest repair、generic infra hard stop。
- 新增 `src/orchestrator/alerting/runbooks.py`：实现 `runbook_url_for(phase: str, failure_class: str | None, action: str, *, scenario_id: str | None = None) -> str`，默认返回仓库内相对路径加锚点，例如 `docs/RUNBOOK_P5.md#phase2-data_quality-fail_run`。
- 修改 `src/orchestrator/checks/decision_handler.py`：构造 `AlertPayload` 时，如果调用方没有显式 runbook，则通过 `runbook_url_for(decision.phase.value, failure_class, decision.action.value)` 填入。
- 可选扩展 `AlertPayload`：如需要支持 #29 的 `scenario_id`，新增 `scenario_id: str | None = None` 必须同步更新 `tests/alerting/test_dispatcher.py::test_alert_payload_field_set_matches_runbook_payload`。
- 更新 Phase 2 专用 `dispatch_phase2_pool_failure_alert()` 和 dbt gate handling，确保它们继续通过 `dispatch_gate_decision_alert()` 或同一 enrichment helper 下发，不绕过 runbook 填充。
- 新增 `tests/alerting/test_runbooks.py`，并更新 `tests/checks/test_decision_handler.py`、`tests/checks/test_phase3_manifest_repair.py`、`tests/checks/test_phase2_pool_gate.py` 的 payload 断言。

### 4. 不在本次范围
- 不实现外部文档站点发布；`runbook_url` 先使用仓库内相对路径。
- 不写自动修复脚本，runbook 只描述操作路径和验证命令。
- 不改变 `GateDecision` dataclass 字段，除非 #29 已引入 scenario-level lookup 且需要透传。
- 不实现多语言 runbook。

### 5. 关键交付物
- `docs/RUNBOOK_P5.md`，包含 9 个稳定 anchor，anchor 命名必须可由代码纯