### PR TITLE
feat(#34): 影子运行观测与运行诊断脚本

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
 ]
 
 [project.scripts]
+orchestrator = "orchestrator.cli.main:main"
 orchestrator-rerun = "orchestrator.cli.rerun:main"
 
 [tool.setuptools.packages.find]

--- a/src/orchestrator/cli/diag.py
+++ b/src/orchestrator/cli/diag.py
@@ -1,0 +1,77 @@
+"""Run diagnostic CLI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+
+from orchestrator.diagnostics import (
+    RunDiagnosticNotFound,
+    collect_run_diagnostic,
+    run_diagnostic_to_dict,
+)
+from orchestrator.rerun_request import DEFAULT_REQUEST_DIR
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Collect read-only diagnostics for an orchestrator run."""
+
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "run":
+        return _run(args)
+
+    parser.print_help(sys.stderr)
+    return 2
+
+
+def _run(args: argparse.Namespace) -> int:
+    try:
+        summary = collect_run_diagnostic(
+            args.cycle_id,
+            request_dir=args.request_dir,
+        )
+    except RunDiagnosticNotFound as exc:
+        print(str(exc), file=sys.stderr)
+        return 3
+    except Exception as exc:
+        print(f"failed to collect run diagnostic: {exc}", file=sys.stderr)
+        return 2
+
+    payload = run_diagnostic_to_dict(summary)
+    indent = None if args.json else 2
+    print(json.dumps(payload, indent=indent, sort_keys=True))
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="orchestrator diag",
+        description="Collect read-only orchestrator run diagnostics.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = subparsers.add_parser(
+        "run",
+        help="summarize Dagster runs, gate decisions, and rerun requests",
+    )
+    run_parser.add_argument("cycle_id")
+    run_parser.add_argument(
+        "--request-dir",
+        default=DEFAULT_REQUEST_DIR,
+        help=f"directory for rerun request JSON files (default: {DEFAULT_REQUEST_DIR})",
+    )
+    run_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit compact JSON output",
+    )
+
+    return parser
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/orchestrator/cli/main.py
+++ b/src/orchestrator/cli/main.py
@@ -1,0 +1,36 @@
+"""Top-level orchestrator CLI dispatcher."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Dispatch orchestrator CLI subcommands."""
+
+    parser = _build_parser()
+    args, remaining = parser.parse_known_args(argv)
+
+    if args.command == "diag":
+        from orchestrator.cli import diag
+
+        return diag.main(remaining)
+
+    parser.print_help(sys.stderr)
+    return 2
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="orchestrator",
+        description="Orchestrator operational commands.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("diag", help="collect run diagnostics")
+    return parser
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/orchestrator/diagnostics.py
+++ b/src/orchestrator/diagnostics.py
@@ -1,0 +1,673 @@
+"""Read-only run diagnostics assembled from Dagster logs and rerun requests."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from orchestrator.alerting import runbook_url_for
+from orchestrator.rerun_request import DEFAULT_REQUEST_DIR
+
+
+class RunDiagnosticNotFound(LookupError):
+    """Raised when no Dagster run can be found for a cycle id."""
+
+
+@dataclass(frozen=True, slots=True)
+class GateDecisionDiagnostic:
+    run_id: str | None
+    phase: str
+    failure_class: str | None
+    action: str
+    failed_node: str | None
+    summary: str | None
+    runbook_url: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class RerunPlanDiagnostic:
+    run_id: str
+    failed_node: str
+    rerun_selection: tuple[str, ...]
+    requires_manual_ack: bool
+    rerun_mode: str
+    generated_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class _RunRecordDiagnostic:
+    run_id: str
+    job_name: str | None
+    status: str | None
+    tags: Mapping[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class RunDiagnosticSummary:
+    cycle_id: str
+    runs: tuple[_RunRecordDiagnostic, ...]
+    gate_decisions: tuple[GateDecisionDiagnostic, ...]
+    rerun_plans: tuple[RerunPlanDiagnostic, ...]
+    generated_at: str
+
+
+def collect_run_diagnostic(
+    cycle_id: str,
+    *,
+    instance: object | None = None,
+    request_dir: str | Path = DEFAULT_REQUEST_DIR,
+) -> RunDiagnosticSummary:
+    """Collect a JSON-serializable diagnostic summary for one cycle id."""
+
+    normalized_cycle_id = cycle_id.strip()
+    if not normalized_cycle_id:
+        raise ValueError("cycle_id is required")
+
+    if instance is None:
+        instance = _default_dagster_instance()
+
+    raw_runs = _runs_for_cycle(instance, normalized_cycle_id)
+    if not raw_runs:
+        raise RunDiagnosticNotFound(
+            f"no Dagster runs found for cycle_id={normalized_cycle_id}",
+        )
+
+    run_records = tuple(_run_record_diagnostic(run) for run in raw_runs)
+    run_ids = frozenset(run.run_id for run in run_records)
+    gate_decisions = _gate_decisions_for_runs(instance, raw_runs)
+    rerun_plans = _rerun_plans_from_request_dir(request_dir, run_ids)
+
+    return RunDiagnosticSummary(
+        cycle_id=normalized_cycle_id,
+        runs=run_records,
+        gate_decisions=gate_decisions,
+        rerun_plans=rerun_plans,
+        generated_at=_now_iso(),
+    )
+
+
+def run_diagnostic_to_dict(summary: RunDiagnosticSummary) -> dict[str, object]:
+    """Serialize a run diagnostic summary using only JSON-native containers."""
+
+    return {
+        "cycle_id": summary.cycle_id,
+        "runs": [
+            {
+                "run_id": run.run_id,
+                "job_name": run.job_name,
+                "status": run.status,
+                "tags": _json_safe(dict(run.tags)),
+            }
+            for run in summary.runs
+        ],
+        "gate_decisions": [
+            {
+                "run_id": decision.run_id,
+                "phase": decision.phase,
+                "failure_class": decision.failure_class,
+                "action": decision.action,
+                "failed_node": decision.failed_node,
+                "summary": decision.summary,
+                "runbook_url": decision.runbook_url,
+            }
+            for decision in summary.gate_decisions
+        ],
+        "rerun_plans": [
+            {
+                "run_id": plan.run_id,
+                "failed_node": plan.failed_node,
+                "rerun_selection": list(plan.rerun_selection),
+                "requires_manual_ack": plan.requires_manual_ack,
+                "rerun_mode": plan.rerun_mode,
+                "generated_at": plan.generated_at,
+            }
+            for plan in summary.rerun_plans
+        ],
+        "generated_at": summary.generated_at,
+    }
+
+
+def _default_dagster_instance() -> object:
+    try:
+        from dagster import DagsterInstance
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "dagster is required when no diagnostic instance is supplied",
+        ) from exc
+
+    return DagsterInstance.get()
+
+
+def _runs_for_cycle(instance: object, cycle_id: str) -> tuple[object, ...]:
+    runs = _query_runs(instance, cycle_id)
+    return tuple(
+        run
+        for run in runs
+        if _run_tags(_dagster_run(run)).get("cycle_id") == cycle_id
+    )
+
+
+def _query_runs(instance: object, cycle_id: str) -> tuple[object, ...]:
+    filters = _runs_filter(cycle_id)
+    for method_name in ("get_runs", "get_run_records"):
+        method = getattr(instance, method_name, None)
+        if not callable(method):
+            continue
+
+        if filters is not None:
+            for keyword in ("filters", "run_filter"):
+                try:
+                    return _as_tuple(method(**{keyword: filters}))
+                except TypeError:
+                    continue
+
+        try:
+            return _as_tuple(method())
+        except TypeError:
+            continue
+
+    return ()
+
+
+def _runs_filter(cycle_id: str) -> object | None:
+    try:
+        from dagster import RunsFilter
+    except Exception:
+        return None
+
+    try:
+        return RunsFilter(tags={"cycle_id": cycle_id})
+    except TypeError:
+        return None
+
+
+def _run_record_diagnostic(raw_run: object) -> _RunRecordDiagnostic:
+    run = _dagster_run(raw_run)
+    run_id = _required_string(_mapping_or_attr(run, "run_id"), "run_id")
+    return _RunRecordDiagnostic(
+        run_id=run_id,
+        job_name=_optional_string(
+            _first_present_attr(run, ("job_name", "pipeline_name")),
+        ),
+        status=_status_string(_mapping_or_attr(run, "status")),
+        tags=_json_safe_mapping(_run_tags(run)),
+    )
+
+
+def _dagster_run(raw_run: object) -> object:
+    return _mapping_or_attr(raw_run, "dagster_run") or raw_run
+
+
+def _run_tags(run: object) -> Mapping[str, object]:
+    tags = _mapping_or_attr(run, "tags")
+    return tags if isinstance(tags, Mapping) else {}
+
+
+def _gate_decisions_for_runs(
+    instance: object,
+    raw_runs: Sequence[object],
+) -> tuple[GateDecisionDiagnostic, ...]:
+    decisions: list[GateDecisionDiagnostic] = []
+    seen: set[tuple[object, ...]] = set()
+
+    for raw_run in raw_runs:
+        run = _dagster_run(raw_run)
+        run_id = _required_string(_mapping_or_attr(run, "run_id"), "run_id")
+        run_tags = _run_tags(run)
+        for record in _event_records_for_run(instance, run_id):
+            for decision in _gate_decisions_from_record(record, run_id, run_tags):
+                key = (
+                    decision.run_id,
+                    decision.phase,
+                    decision.failure_class,
+                    decision.action,
+                    decision.failed_node,
+                    decision.summary,
+                )
+                if key in seen:
+                    continue
+                seen.add(key)
+                decisions.append(decision)
+
+    return tuple(decisions)
+
+
+def _event_records_for_run(instance: object, run_id: str) -> tuple[object, ...]:
+    all_logs = getattr(instance, "all_logs", None)
+    if callable(all_logs):
+        return _as_tuple(all_logs(run_id))
+
+    get_records_for_run = getattr(instance, "get_records_for_run", None)
+    if callable(get_records_for_run):
+        try:
+            return _records_from_connection(
+                get_records_for_run(run_id, ascending=True),
+            )
+        except TypeError:
+            return _records_from_connection(get_records_for_run(run_id))
+
+    return ()
+
+
+def _records_from_connection(value: object) -> tuple[object, ...]:
+    records = _mapping_or_attr(value, "records")
+    if records is not None:
+        return _as_tuple(records)
+    return _as_tuple(value)
+
+
+def _gate_decisions_from_record(
+    record: object,
+    fallback_run_id: str,
+    run_tags: Mapping[str, object],
+) -> tuple[GateDecisionDiagnostic, ...]:
+    entry = _event_log_entry(record)
+    event = _dagster_event(entry)
+    run_id = (
+        _optional_string(_mapping_or_attr(entry, "run_id"))
+        or _optional_string(_mapping_or_attr(record, "run_id"))
+        or fallback_run_id
+    )
+
+    decisions: list[GateDecisionDiagnostic] = []
+    for owner in _gate_metadata_owners(event):
+        metadata = _metadata(owner)
+        action = _optional_string(metadata.get("action"))
+        if not action:
+            continue
+
+        failure_class = _optional_string(metadata.get("failure_class"))
+        failed_node = _failed_node(metadata, owner, event)
+        phase = (
+            _optional_string(metadata.get("phase"))
+            or _optional_string(run_tags.get("phase"))
+            or _infer_phase(failed_node, owner, event)
+        )
+        summary = _summary(metadata, owner, entry, phase=phase, action=action)
+        runbook_url = _diagnostic_runbook_url(
+            metadata,
+            phase=phase,
+            failure_class=failure_class,
+            action=action,
+        )
+
+        decisions.append(
+            GateDecisionDiagnostic(
+                run_id=run_id,
+                phase=phase,
+                failure_class=failure_class,
+                action=action,
+                failed_node=failed_node,
+                summary=summary,
+                runbook_url=runbook_url,
+            ),
+        )
+
+    return tuple(decisions)
+
+
+def _event_log_entry(record: object) -> object:
+    return (
+        _mapping_or_attr(record, "event_log_entry")
+        or _mapping_or_attr(record, "event_log_entry_data")
+        or record
+    )
+
+
+def _dagster_event(entry: object) -> object:
+    return _mapping_or_attr(entry, "dagster_event") or entry
+
+
+def _gate_metadata_owners(event: object) -> tuple[object, ...]:
+    owners: list[object] = []
+    event_specific_data = _mapping_or_attr(event, "event_specific_data")
+
+    for candidate in (
+        _mapping_or_attr(event_specific_data, "asset_observation"),
+        _mapping_or_attr(event_specific_data, "observation"),
+        _mapping_or_attr(event, "asset_observation"),
+        _mapping_or_attr(event, "observation"),
+    ):
+        if candidate is not None:
+            owners.append(candidate)
+
+    for candidate in (
+        _mapping_or_attr(event_specific_data, "asset_check_evaluation"),
+        _mapping_or_attr(event_specific_data, "evaluation"),
+        _mapping_or_attr(event, "asset_check_evaluation"),
+        _mapping_or_attr(event, "evaluation"),
+    ):
+        if candidate is not None:
+            owners.append(candidate)
+
+    if _has_metadata(event_specific_data):
+        owners.append(event_specific_data)
+    if _has_metadata(event):
+        owners.append(event)
+
+    return tuple(owner for owner in owners if _metadata(owner))
+
+
+def _metadata(owner: object) -> dict[str, object]:
+    raw_metadata = _mapping_or_attr(owner, "metadata")
+    if not isinstance(raw_metadata, Mapping):
+        return {}
+    return {
+        str(key): _metadata_value(value)
+        for key, value in raw_metadata.items()
+    }
+
+
+def _metadata_value(value: object) -> object:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Mapping):
+        return {
+            str(key): _metadata_value(nested_value)
+            for key, nested_value in value.items()
+        }
+    if isinstance(value, Sequence) and not isinstance(
+        value,
+        (str, bytes, bytearray),
+    ):
+        return [_metadata_value(item) for item in value]
+
+    to_user_string = getattr(value, "to_user_string", None)
+    if callable(to_user_string):
+        return to_user_string()
+
+    for attribute_name in ("value", "text", "data", "path", "url", "md_str"):
+        attribute_value = getattr(value, attribute_name, None)
+        if attribute_value is not None:
+            return _metadata_value(attribute_value)
+
+    return str(value)
+
+
+def _failed_node(
+    metadata: Mapping[str, object],
+    owner: object,
+    event: object,
+) -> str | None:
+    for key in ("failed_node", "failed_nodes", "asset_key", "dbt_node_name"):
+        value = _optional_string(metadata.get(key))
+        if value:
+            return value
+
+    check_name = _check_name(owner)
+    if check_name:
+        return check_name
+
+    for candidate in (
+        _mapping_or_attr(owner, "asset_key"),
+        _mapping_or_attr(event, "asset_key"),
+    ):
+        asset_key = _asset_key_string(candidate)
+        if asset_key:
+            return asset_key
+
+    return None
+
+
+def _check_name(owner: object) -> str | None:
+    check_name = _optional_string(_mapping_or_attr(owner, "check_name"))
+    if check_name:
+        return check_name
+
+    check_key = _mapping_or_attr(owner, "check_key")
+    return _optional_string(_mapping_or_attr(check_key, "name"))
+
+
+def _asset_key_string(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value or None
+    if isinstance(value, Sequence) and not isinstance(
+        value,
+        (str, bytes, bytearray),
+    ):
+        parts = [str(part) for part in value if str(part)]
+        return "/".join(parts) if parts else None
+
+    to_user_string = getattr(value, "to_user_string", None)
+    if callable(to_user_string):
+        return _optional_string(to_user_string())
+
+    path = getattr(value, "path", None)
+    if isinstance(path, Sequence) and not isinstance(path, (str, bytes, bytearray)):
+        parts = [str(part) for part in path if str(part)]
+        return "/".join(parts) if parts else None
+
+    return _optional_string(str(value))
+
+
+def _infer_phase(failed_node: str | None, owner: object, event: object) -> str:
+    candidates = [
+        failed_node,
+        _check_name(owner),
+        _asset_key_string(_mapping_or_attr(owner, "asset_key")),
+        _asset_key_string(_mapping_or_attr(event, "asset_key")),
+    ]
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        lowered = candidate.lower()
+        for phase in ("phase0", "phase1", "phase2", "phase3"):
+            if phase in lowered:
+                return phase
+        if "llm_health" in lowered or "dbt" in lowered:
+            return "phase0"
+        if "graph_" in lowered:
+            return "phase1"
+        if "formal" in lowered or "manifest" in lowered:
+            return "phase3"
+    return "unknown"
+
+
+def _summary(
+    metadata: Mapping[str, object],
+    owner: object,
+    entry: object,
+    *,
+    phase: str,
+    action: str,
+) -> str | None:
+    for key in ("summary", "reason", "message", "error", "description"):
+        value = _optional_string(metadata.get(key))
+        if value:
+            return value
+
+    for value in (
+        _mapping_or_attr(owner, "description"),
+        _mapping_or_attr(entry, "message"),
+        _mapping_or_attr(entry, "user_message"),
+    ):
+        summary = _optional_string(value)
+        if summary:
+            return summary
+
+    return f"{phase} gate decision: {action}"
+
+
+def _diagnostic_runbook_url(
+    metadata: Mapping[str, object],
+    *,
+    phase: str,
+    failure_class: str | None,
+    action: str,
+) -> str | None:
+    explicit = _optional_string(metadata.get("runbook_url"))
+    if explicit:
+        return explicit
+    if action == "continue" or phase == "unknown":
+        return None
+    return runbook_url_for(phase, failure_class, action)
+
+
+def _rerun_plans_from_request_dir(
+    request_dir: str | Path,
+    run_ids: frozenset[str],
+) -> tuple[RerunPlanDiagnostic, ...]:
+    path = Path(request_dir)
+    if not path.exists() or not path.is_dir():
+        return ()
+
+    plans: list[RerunPlanDiagnostic] = []
+    for request_path in sorted(path.glob("*.json")):
+        plan = _rerun_plan_from_request_path(request_path)
+        if plan is None or plan.run_id not in run_ids:
+            continue
+        plans.append(plan)
+    return tuple(plans)
+
+
+def _rerun_plan_from_request_path(path: Path) -> RerunPlanDiagnostic | None:
+    try:
+        raw_payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+    if not isinstance(raw_payload, Mapping):
+        return None
+
+    try:
+        return RerunPlanDiagnostic(
+            run_id=_required_string(raw_payload.get("run_id"), "run_id"),
+            failed_node=_required_string(
+                raw_payload.get("failed_node"),
+                "failed_node",
+            ),
+            rerun_selection=_required_string_tuple(
+                raw_payload.get("rerun_selection"),
+                "rerun_selection",
+            ),
+            requires_manual_ack=_required_bool(
+                raw_payload.get("requires_manual_ack"),
+                "requires_manual_ack",
+            ),
+            rerun_mode=_required_string(raw_payload.get("rerun_mode"), "rerun_mode"),
+            generated_at=_required_string(
+                raw_payload.get("generated_at"),
+                "generated_at",
+            ),
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def _mapping_or_attr(value: object, key: str) -> object | None:
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        return value.get(key)
+    return getattr(value, key, None)
+
+
+def _first_present_attr(value: object, keys: Iterable[str]) -> object | None:
+    for key in keys:
+        candidate = _mapping_or_attr(value, key)
+        if candidate is not None:
+            return candidate
+    return None
+
+
+def _has_metadata(value: object) -> bool:
+    raw_metadata = _mapping_or_attr(value, "metadata")
+    return isinstance(raw_metadata, Mapping) and bool(raw_metadata)
+
+
+def _optional_string(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, (int, float)):
+        return str(value)
+    return str(value).strip() or None
+
+
+def _required_string(value: object, key: str) -> str:
+    string_value = _optional_string(value)
+    if string_value is None:
+        raise ValueError(f"{key} is required")
+    return string_value
+
+
+def _required_string_tuple(value: object, key: str) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise TypeError(f"{key} must be a string sequence")
+    output = tuple(_required_string(item, key) for item in value)
+    if not output:
+        raise ValueError(f"{key} must not be empty")
+    return output
+
+
+def _required_bool(value: object, key: str) -> bool:
+    if not isinstance(value, bool):
+        raise TypeError(f"{key} must be a boolean")
+    return value
+
+
+def _status_string(status: object) -> str | None:
+    if status is None:
+        return None
+    value = getattr(status, "value", None)
+    if isinstance(value, str):
+        return value
+    name = getattr(status, "name", None)
+    if isinstance(name, str):
+        return name
+    return str(status)
+
+
+def _json_safe_mapping(mapping: Mapping[str, object]) -> Mapping[str, object]:
+    return {str(key): _json_safe(value) for key, value in mapping.items()}
+
+
+def _json_safe(value: object) -> object:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(nested) for key, nested in value.items()}
+    if isinstance(value, Sequence) and not isinstance(
+        value,
+        (str, bytes, bytearray),
+    ):
+        return [_json_safe(item) for item in value]
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        return isoformat()
+    return str(value)
+
+
+def _as_tuple(value: object) -> tuple[object, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, tuple):
+        return value
+    if isinstance(value, list):
+        return tuple(value)
+    if isinstance(value, Iterable) and not isinstance(value, (str, bytes, bytearray)):
+        return tuple(value)
+    return (value,)
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+__all__ = [
+    "GateDecisionDiagnostic",
+    "RerunPlanDiagnostic",
+    "RunDiagnosticNotFound",
+    "RunDiagnosticSummary",
+    "collect_run_diagnostic",
+    "run_diagnostic_to_dict",
+]

--- a/tests/cli/test_diag.py
+++ b/tests/cli/test_diag.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from orchestrator.diagnostics import (
+    RunDiagnosticNotFound,
+    RunDiagnosticSummary,
+    collect_run_diagnostic,
+    run_diagnostic_to_dict,
+)
+
+
+class _FakeInstance:
+    def __init__(self, runs: list[object], logs: dict[str, list[object]]) -> None:
+        self._runs = runs
+        self._logs = logs
+
+    def get_runs(self, filters: object | None = None) -> list[object]:
+        return self._runs
+
+    def all_logs(self, run_id: str) -> list[object]:
+        return self._logs.get(run_id, [])
+
+
+class _MetadataText:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+def test_collect_run_diagnostic_serializes_gate_metadata_and_rerun_request(
+    tmp_path: Path,
+) -> None:
+    cycle_id = "cycle-20260416"
+    run = _fake_run("run-1", cycle_id)
+    observation = SimpleNamespace(
+        asset_key="heartbeat",
+        description="dbt test failure gate decision",
+        metadata={
+            "phase": "phase0",
+            "action": "partial_rerun",
+            "failure_class": "task_level",
+            "failed_node": "heartbeat",
+            "reason": _MetadataText("dbt test failed"),
+        },
+    )
+    evaluation = SimpleNamespace(
+        check_name="llm_health_check",
+        metadata={
+            "action": "fail_run",
+            "failure_class": "infra",
+            "summary": "provider unavailable",
+        },
+    )
+    instance = _FakeInstance(
+        [run],
+        {
+            "run-1": [
+                _fake_observation_record("run-1", observation),
+                _fake_check_record("run-1", evaluation),
+            ],
+        },
+    )
+    _write_request(
+        tmp_path / "dbt.json",
+        run_id="run-1",
+        failed_node="heartbeat",
+        rerun_selection=["heartbeat"],
+        rerun_mode="asset_only",
+        requires_manual_ack=False,
+    )
+    _write_request(
+        tmp_path / "other-run.json",
+        run_id="run-other",
+        failed_node="heartbeat",
+        rerun_selection=["heartbeat"],
+        rerun_mode="asset_only",
+        requires_manual_ack=False,
+    )
+
+    summary = collect_run_diagnostic(
+        cycle_id,
+        instance=instance,
+        request_dir=tmp_path,
+    )
+    payload = run_diagnostic_to_dict(summary)
+
+    assert set(payload) == {
+        "cycle_id",
+        "runs",
+        "gate_decisions",
+        "rerun_plans",
+        "generated_at",
+    }
+    assert payload["cycle_id"] == cycle_id
+    assert payload["runs"] == [
+        {
+            "run_id": "run-1",
+            "job_name": "daily_cycle_job",
+            "status": "FAILURE",
+            "tags": {"cycle_id": cycle_id},
+        },
+    ]
+    assert payload["gate_decisions"] == [
+        {
+            "run_id": "run-1",
+            "phase": "phase0",
+            "failure_class": "task_level",
+            "action": "partial_rerun",
+            "failed_node": "heartbeat",
+            "summary": "dbt test failed",
+            "runbook_url": "docs/RUNBOOK_P5.md#phase0-task_level-partial_rerun",
+        },
+        {
+            "run_id": "run-1",
+            "phase": "phase0",
+            "failure_class": "infra",
+            "action": "fail_run",
+            "failed_node": "llm_health_check",
+            "summary": "provider unavailable",
+            "runbook_url": "docs/RUNBOOK_P5.md#phase0-infra-fail_run",
+        },
+    ]
+    assert payload["rerun_plans"] == [
+        {
+            "run_id": "run-1",
+            "failed_node": "heartbeat",
+            "rerun_selection": ["heartbeat"],
+            "requires_manual_ack": False,
+            "rerun_mode": "asset_only",
+            "generated_at": "2026-04-16T00:00:00+00:00",
+        },
+    ]
+
+
+def test_collect_run_diagnostic_keeps_repair_request_manual_ack(
+    tmp_path: Path,
+) -> None:
+    instance = _FakeInstance([_fake_run("run-1", "cycle-20260416")], {"run-1": []})
+    _write_request(
+        tmp_path / "repair.json",
+        run_id="run-1",
+        failed_node="cycle_publish_manifest",
+        rerun_selection=["repair_cycle_publish_manifest"],
+        rerun_mode="repair_only",
+        requires_manual_ack=True,
+    )
+
+    payload = run_diagnostic_to_dict(
+        collect_run_diagnostic(
+            "cycle-20260416",
+            instance=instance,
+            request_dir=tmp_path,
+        ),
+    )
+
+    assert payload["rerun_plans"] == [
+        {
+            "run_id": "run-1",
+            "failed_node": "cycle_publish_manifest",
+            "rerun_selection": ["repair_cycle_publish_manifest"],
+            "requires_manual_ack": True,
+            "rerun_mode": "repair_only",
+            "generated_at": "2026-04-16T00:00:00+00:00",
+        },
+    ]
+    assert "formal_objects_commit" not in payload["rerun_plans"][0]["rerun_selection"]
+
+
+def test_collect_run_diagnostic_raises_when_cycle_has_no_matching_run() -> None:
+    instance = _FakeInstance([_fake_run("run-1", "cycle-other")], {"run-1": []})
+
+    with pytest.raises(RunDiagnosticNotFound, match="cycle-20260416"):
+        collect_run_diagnostic("cycle-20260416", instance=instance)
+
+
+def test_diag_cli_run_outputs_json(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    from orchestrator.cli import diag
+
+    summary = RunDiagnosticSummary(
+        cycle_id="cycle-20260416",
+        runs=(),
+        gate_decisions=(),
+        rerun_plans=(),
+        generated_at="2026-04-16T00:00:00+00:00",
+    )
+    monkeypatch.setattr(
+        diag,
+        "collect_run_diagnostic",
+        lambda cycle_id, *, request_dir: summary,
+    )
+
+    exit_code = diag.main(
+        [
+            "run",
+            "cycle-20260416",
+            "--json",
+            "--request-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["cycle_id"] == "cycle-20260416"
+    assert payload["runs"] == []
+    assert payload["gate_decisions"] == []
+    assert payload["rerun_plans"] == []
+    assert payload["generated_at"] == "2026-04-16T00:00:00+00:00"
+
+
+def test_diag_cli_no_matching_run_returns_three(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from orchestrator.cli import diag
+
+    def _raise_not_found(cycle_id: str, *, request_dir: object) -> object:
+        raise RunDiagnosticNotFound(f"no run for {cycle_id}")
+
+    monkeypatch.setattr(diag, "collect_run_diagnostic", _raise_not_found)
+
+    exit_code = diag.main(["run", "cycle-20260416", "--json"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 3
+    assert "cycle-20260416" in captured.err
+
+
+def test_top_level_cli_dispatches_diag(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from orchestrator.cli import diag
+    from orchestrator.cli import main as cli_main
+
+    summary = RunDiagnosticSummary(
+        cycle_id="cycle-20260416",
+        runs=(),
+        gate_decisions=(),
+        rerun_plans=(),
+        generated_at="2026-04-16T00:00:00+00:00",
+    )
+    monkeypatch.setattr(
+        diag,
+        "collect_run_diagnostic",
+        lambda cycle_id, *, request_dir: summary,
+    )
+
+    exit_code = cli_main.main(["diag", "run", "cycle-20260416", "--json"])
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out)["cycle_id"] == "cycle-20260416"
+
+
+def _fake_run(run_id: str, cycle_id: str) -> object:
+    return SimpleNamespace(
+        run_id=run_id,
+        job_name="daily_cycle_job",
+        status=SimpleNamespace(value="FAILURE"),
+        tags={"cycle_id": cycle_id},
+    )
+
+
+def _fake_observation_record(run_id: str, observation: object) -> object:
+    return SimpleNamespace(
+        run_id=run_id,
+        dagster_event=SimpleNamespace(
+            event_type_value="ASSET_OBSERVATION",
+            event_specific_data=SimpleNamespace(asset_observation=observation),
+        ),
+        message="fallback observation message",
+    )
+
+
+def _fake_check_record(run_id: str, evaluation: object) -> object:
+    return SimpleNamespace(
+        run_id=run_id,
+        dagster_event=SimpleNamespace(
+            event_type_value="ASSET_CHECK_EVALUATION",
+            event_specific_data=SimpleNamespace(asset_check_evaluation=evaluation),
+        ),
+        message="fallback check message",
+    )
+
+
+def _write_request(
+    path: Path,
+    *,
+    run_id: str,
+    failed_node: str,
+    rerun_selection: list[str],
+    rerun_mode: str,
+    requires_manual_ack: bool,
+) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "run_id": run_id,
+                "failed_node": failed_node,
+                "rerun_selection": rerun_selection,
+                "requires_manual_ack": requires_manual_ack,
+                "rerun_mode": rerun_mode,
+                "generated_at": "2026-04-16T00:00:00+00:00",
+            },
+        ),
+        encoding="utf-8",
+    )

--- a/tests/integration/test_diag_run.py
+++ b/tests/integration/test_diag_run.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from orchestrator.diagnostics import collect_run_diagnostic, run_diagnostic_to_dict
+
+
+class _FakeDagsterLikeInstance:
+    def __init__(self, run_record: object, records: list[object]) -> None:
+        self._run_record = run_record
+        self._records = records
+
+    def get_run_records(self, filters: object | None = None) -> list[object]:
+        return [self._run_record]
+
+    def get_records_for_run(self, run_id: str, ascending: bool = True) -> object:
+        return SimpleNamespace(records=self._records)
+
+
+def test_diag_run_collects_event_log_and_manual_request_json(
+    tmp_path: Path,
+) -> None:
+    cycle_id = "cycle-20260416"
+    run = SimpleNamespace(
+        run_id="run-1",
+        job_name="daily_cycle_job",
+        status=SimpleNamespace(name="FAILURE"),
+        tags={"cycle_id": cycle_id},
+    )
+    evaluation = SimpleNamespace(
+        check_name="phase2_single_stock_tolerance",
+        metadata={
+            "phase": "phase2",
+            "failure_class": "task_level",
+            "action": "mark_inconclusive",
+            "failed_node": "phase2_llm_score_AAPL",
+            "reason": "single-stock failure remains within tolerance",
+        },
+    )
+    event_log_entry = SimpleNamespace(
+        run_id="run-1",
+        dagster_event=SimpleNamespace(
+            event_type_value="ASSET_CHECK_EVALUATION",
+            event_specific_data=SimpleNamespace(asset_check_evaluation=evaluation),
+        ),
+        message="asset check evaluated",
+    )
+    instance = _FakeDagsterLikeInstance(
+        SimpleNamespace(dagster_run=run),
+        [SimpleNamespace(event_log_entry=event_log_entry)],
+    )
+    request_path = tmp_path / "run-1-dbt.json"
+    request_path.write_text(
+        json.dumps(
+            {
+                "run_id": "run-1",
+                "failed_node": "dbt.phase0.heartbeat",
+                "rerun_selection": ["dbt.phase0.heartbeat"],
+                "requires_manual_ack": False,
+                "rerun_mode": "asset_only",
+                "generated_at": "2026-04-16T00:00:00+00:00",
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    summary = collect_run_diagnostic(
+        cycle_id,
+        instance=instance,
+        request_dir=tmp_path,
+    )
+    payload = run_diagnostic_to_dict(summary)
+
+    assert payload["cycle_id"] == cycle_id
+    assert payload["runs"][0]["run_id"] == "run-1"
+    assert payload["gate_decisions"] == [
+        {
+            "run_id": "run-1",
+            "phase": "phase2",
+            "failure_class": "task_level",
+            "action": "mark_inconclusive",
+            "failed_node": "phase2_llm_score_AAPL",
+            "summary": "single-stock failure remains within tolerance",
+            "runbook_url": "docs/RUNBOOK_P5.md#phase2-task_level-mark_inconclusive",
+        },
+    ]
+    assert payload["rerun_plans"][0]["rerun_mode"] == "asset_only"
+    assert payload["rerun_plans"][0]["rerun_selection"] == ["dbt.phase0.heartbeat"]


### PR DESCRIPTION
Closes #34

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `scripts/check_boundaries.py`, `src/orchestrator/alerting/dispatcher.py`, `src/orchestrator/alerting/runbooks.py`, `src/orchestrator/checks/dbt_events.py`, `src/orchestrator/checks/phase1.py`, `src/orchestrator/checks/phase2.py`, `src/orchestrator/checks/phase3.py`, `src/orchestrator/jobs/cycle.py`, `src/orchestrator/resources/infra.py`


---
### 1. 背景与目标
`docs/orchestrator.project-doc.md` §13.3 和 §21 阶段 3 要求影子运行具备 run summary、GateDecision 列表、rerun plan 建议等可观测入口。当前仓库已有 `orchestrator-rerun` CLI（`src/orchestrator/cli/rerun.py`）、manual rerun request 文件（`src/orchestrator/rerun_request.py`）和多处 Dagster AssetObservation/AssetCheck metadata，但没有面向值班人的 `orchestrator diag run <cycle_id>`。本 issue 的目标是新增诊断 CLI，从 Dagster instance event log 和本地 rerun request 目录汇总 JSON 诊断报告。

### 2. 所属模块
`src/orchestrator/cli/`、`src/orchestrator/diagnostics.py`（新文件）、`pyproject.toml`、`tests/cli/`、`tests/integration/`。

### 3. 实现范围
- 新增 `src/orchestrator/diagnostics.py`：定义只读 dataclass `GateDecisionDiagnostic`、`RerunPlanDiagnostic`、`RunDiagnosticSummary`，并实现纯序列化 helper。
- 实现 `collect_run_diagnostic(cycle_id: str, *, instance: object | None = None, request_dir: str | Path = DEFAULT_REQUEST_DIR) -> RunDiagnosticSummary`：默认使用 `dagster.DagsterInstance.get()`，按 run tags `cycle_id` 查找 run，再读取 event records。
- 从现有 metadata 约定提取 gate 信息：dbt AssetObservation 的 `action` / `failure_class` / `failed_node`，AssetCheck evaluation metadata 中的 `action` / `failure_class`，以及 fallback summary。
- 从 `DEFAULT_REQUEST_DIR` 或 `--request-dir` 读取 manual rerun JSON，复用 `orchestrator.rerun_request.request_from_plan()` 的字段名。
- 新增 `src/orchestrator/cli/diag.py`：实现 `main(argv: Sequence[str] | None = None) -> int`，支持命令 `run <cycle_id>`、`--request-dir`、`--json`。
- 新增 `src/orchestrator/cli/main.py`：分发 `orchestrator diag ...`；在 `pyproject.toml [project.scripts]` 加 `orchestrator = 'orchestrator.cli.main:main'`，保留现有 `orchestrator-rerun`。

### 4. 不在本次范围
- 不实现 TUI、HTML 报表或长期存储。
- 不直接查询 PostgreSQL 表；通过 Dagster public instance/event APIs 或测试 fake instance 读取。
- 不自动触发 rerun；CLI 只读诊断并给出 request 文件中已有的建议。
- 不把 alert dispatcher 的日志反解析为唯一事实来源；event log / request JSON 优先。

### 5. 关键交付物
- `@dataclass(frozen=True, slots=True) class GateDecisionDiagnostic`，字段至少包含 `run_id: str | None`、`phase: str`、`failure_class: str | None`、`action: str`、`failed_node: str | None`、`summary: str | None`、`runb