### PR TITLE
feat(#88): [milestone-3 review] P0: Infrastructure hard stop does not cover declared core infrastructure

### DIFF
--- a/src/orchestrator/resources/__init__.py
+++ b/src/orchestrator/resources/__init__.py
@@ -2,11 +2,15 @@ from orchestrator.resources.bundle import ResourceBundle, build_resource_bundle
 from orchestrator.resources.infra import (
     CORE_INFRASTRUCTURE_RESOURCE_KEYS,
     INFRASTRUCTURE_RESOURCE_PHASES,
+    INFRASTRUCTURE_RESOURCE_REGISTRY,
     INFRA_UNAVAILABLE_HARD_STOP_SCENARIO_ID,
     InfrastructureUnavailableError,
     InfrastructureUnavailableEvent,
+    InfrastructureResourceRegistryEntry,
+    PROVIDER_RESOURCE_CONSTRUCTION_KEY,
     classify_infrastructure_failure,
     guard_infrastructure_resource,
+    guard_provider_resource_construction,
 )
 from orchestrator.resources.providers import AssetFactoryProvider, PureCheckProvider
 
@@ -14,12 +18,16 @@ __all__ = [
     "AssetFactoryProvider",
     "CORE_INFRASTRUCTURE_RESOURCE_KEYS",
     "INFRASTRUCTURE_RESOURCE_PHASES",
+    "INFRASTRUCTURE_RESOURCE_REGISTRY",
     "INFRA_UNAVAILABLE_HARD_STOP_SCENARIO_ID",
     "InfrastructureUnavailableError",
     "InfrastructureUnavailableEvent",
+    "InfrastructureResourceRegistryEntry",
+    "PROVIDER_RESOURCE_CONSTRUCTION_KEY",
     "PureCheckProvider",
     "ResourceBundle",
     "build_resource_bundle",
     "classify_infrastructure_failure",
     "guard_infrastructure_resource",
+    "guard_provider_resource_construction",
 ]

--- a/src/orchestrator/resources/bundle.py
+++ b/src/orchestrator/resources/bundle.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from dagster import ResourceDefinition
 
+from orchestrator.resources.infra import guard_provider_resource_construction
 from orchestrator.resources.providers import AssetFactoryProvider
 
 
@@ -36,7 +37,7 @@ def build_resource_bundle(
     module_factories: Iterable[AssetFactoryProvider],
 ) -> ResourceBundle:
     module_factory_list = tuple(module_factories)
-    resources = _collect_resource_definitions(module_factory_list)
+    resources = _collect_resource_definitions(module_factory_list, env_config)
     return _resource_bundle_from(
         env_config=env_config,
         module_factories=module_factory_list,
@@ -46,11 +47,16 @@ def build_resource_bundle(
 
 def _collect_resource_definitions(
     module_factories: Iterable[AssetFactoryProvider],
+    env_config: Mapping[str, Any] | str | None,
 ) -> dict[str, ResourceDefinition]:
     resources: dict[str, ResourceDefinition] = {}
 
     for module_factory in module_factories:
-        for key, resource in module_factory.get_resources().items():
+        provider_resources = guard_provider_resource_construction(
+            module_factory,
+            env_config=env_config,
+        )
+        for key, resource in provider_resources.items():
             if key in resources:
                 raise ValueError(f"duplicate resource key: {key}")
             resources[key] = resource

--- a/src/orchestrator/resources/infra.py
+++ b/src/orchestrator/resources/infra.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
-from inspect import isgenerator
+from inspect import Parameter, isgenerator, signature
 from types import MappingProxyType
-from typing import NoReturn
+from typing import Any, NoReturn
 
 from orchestrator.checks.classifier import classify_gate_result
 from orchestrator.checks.decision_handler import dispatch_gate_decision_alert
@@ -24,22 +24,49 @@ _INFRA_HARD_STOP_REASON = (
     "Core storage or graph infrastructure is unavailable; hard stop."
 )
 _FALLBACK_ALERT_CHANNELS = ("logging",)
-CORE_INFRASTRUCTURE_RESOURCE_KEYS = frozenset(
-    {
-        "dbt",
-        "gate_policy",
-        "data_readiness",
-        "llm_health_probe",
-        "phase2_pool_failure_rate",
-    },
+PROVIDER_RESOURCE_CONSTRUCTION_KEY = "provider_resource_construction"
+_GUARDED_RESOURCE_ATTR = "_orchestrator_infrastructure_guard_key"
+
+
+@dataclass(frozen=True, slots=True)
+class InfrastructureResourceRegistryEntry:
+    """Hard-stop metadata for one infrastructure resource key."""
+
+    key: str
+    phase: PhaseEnum
+
+
+_INFRASTRUCTURE_RESOURCE_REGISTRY_ENTRIES = (
+    InfrastructureResourceRegistryEntry("dbt", PhaseEnum.PHASE0),
+    InfrastructureResourceRegistryEntry("gate_policy", PhaseEnum.PHASE0),
+    InfrastructureResourceRegistryEntry("data_readiness", PhaseEnum.PHASE0),
+    InfrastructureResourceRegistryEntry("llm_health_probe", PhaseEnum.PHASE0),
+    InfrastructureResourceRegistryEntry("postgres", PhaseEnum.PHASE0),
+    InfrastructureResourceRegistryEntry("postgresql", PhaseEnum.PHASE0),
+    InfrastructureResourceRegistryEntry("postgres_engine", PhaseEnum.PHASE0),
+    InfrastructureResourceRegistryEntry("pg_engine", PhaseEnum.PHASE0),
+    InfrastructureResourceRegistryEntry("dagster_instance_storage", PhaseEnum.PHASE0),
+    InfrastructureResourceRegistryEntry("iceberg_catalog", PhaseEnum.PHASE0),
+    InfrastructureResourceRegistryEntry("neo4j", PhaseEnum.PHASE1),
+    InfrastructureResourceRegistryEntry("neo4j_driver", PhaseEnum.PHASE1),
+    InfrastructureResourceRegistryEntry("graph_backend", PhaseEnum.PHASE1),
+    InfrastructureResourceRegistryEntry("phase2_pool_failure_rate", PhaseEnum.PHASE2),
+    InfrastructureResourceRegistryEntry(
+        PROVIDER_RESOURCE_CONSTRUCTION_KEY,
+        PhaseEnum.PHASE0,
+    ),
 )
+INFRASTRUCTURE_RESOURCE_REGISTRY: Mapping[
+    str,
+    InfrastructureResourceRegistryEntry,
+] = MappingProxyType(
+    {entry.key: entry for entry in _INFRASTRUCTURE_RESOURCE_REGISTRY_ENTRIES},
+)
+CORE_INFRASTRUCTURE_RESOURCE_KEYS = frozenset(INFRASTRUCTURE_RESOURCE_REGISTRY)
 INFRASTRUCTURE_RESOURCE_PHASES: Mapping[str, PhaseEnum] = MappingProxyType(
     {
-        "dbt": PhaseEnum.PHASE0,
-        "gate_policy": PhaseEnum.PHASE0,
-        "data_readiness": PhaseEnum.PHASE0,
-        "llm_health_probe": PhaseEnum.PHASE0,
-        "phase2_pool_failure_rate": PhaseEnum.PHASE2,
+        key: entry.phase
+        for key, entry in INFRASTRUCTURE_RESOURCE_REGISTRY.items()
     },
 )
 _GUARDED_METHODS_BY_RESOURCE_KEY: Mapping[str, frozenset[str]] = MappingProxyType(
@@ -133,6 +160,8 @@ def guard_infrastructure_resource(
 
     if resource_key not in CORE_INFRASTRUCTURE_RESOURCE_KEYS:
         return resource
+    if getattr(resource, _GUARDED_RESOURCE_ATTR, None) == resource_key:
+        return resource
 
     from dagster import ResourceDefinition
 
@@ -162,10 +191,44 @@ def guard_infrastructure_resource(
         finally:
             _run_finalizers(finalizers)
 
-    return ResourceDefinition(
+    guarded_resource = ResourceDefinition(
         resource_fn=_resource_fn,
+        config_schema=getattr(resource, "config_schema", None),
         description=f"Guarded infrastructure resource for {resource_key}.",
+        required_resource_keys=getattr(resource, "required_resource_keys", None),
+        version=getattr(resource, "version", None),
     )
+    setattr(guarded_resource, _GUARDED_RESOURCE_ATTR, resource_key)
+    return guarded_resource
+
+
+def guard_provider_resource_construction(
+    module_factory: object,
+    *,
+    env_config: Mapping[str, Any] | str | None,
+) -> Mapping[str, object]:
+    """Collect provider resources through the same infra hard-stop path."""
+
+    get_resources = getattr(module_factory, "get_resources")
+    if not callable(get_resources):
+        msg = "module factory get_resources attribute is not callable"
+        raise TypeError(msg)
+
+    try:
+        resources = get_resources()
+    except InfrastructureUnavailableError:
+        raise
+    except Exception as exc:
+        resource_key = _provider_failure_resource_key(module_factory)
+        _raise_infrastructure_unavailable(
+            resource_key=resource_key,
+            phase=_phase_for_resource_key(resource_key),
+            policy_path=_policy_path_from_env_config(env_config),
+            context=_BundleAssemblyContext(module_factory),
+            exc=exc,
+        )
+
+    return resources
 
 
 class _GuardedInfrastructureValue:
@@ -261,7 +324,7 @@ def _initialize_resource(
 
     resource_fn = getattr(resource, "resource_fn", None)
     if callable(resource_fn):
-        created = resource_fn(context)
+        created = _call_with_optional_context(resource_fn, context)
         if isgenerator(created):
             try:
                 value = next(created)
@@ -272,6 +335,34 @@ def _initialize_resource(
         return created, tuple(finalizers)
 
     return resource, tuple(finalizers)
+
+
+def _call_with_optional_context(
+    resource_fn: Callable[..., object],
+    context: object,
+) -> object:
+    if _has_at_least_one_parameter(resource_fn):
+        return resource_fn(context)
+    return resource_fn()
+
+
+def _has_at_least_one_parameter(callable_obj: Callable[..., object]) -> bool:
+    try:
+        parameters = signature(callable_obj).parameters.values()
+    except (TypeError, ValueError):
+        return True
+
+    return any(
+        parameter.kind
+        in {
+            Parameter.POSITIONAL_ONLY,
+            Parameter.POSITIONAL_OR_KEYWORD,
+            Parameter.VAR_POSITIONAL,
+            Parameter.KEYWORD_ONLY,
+            Parameter.VAR_KEYWORD,
+        }
+        for parameter in parameters
+    )
 
 
 def _close_resource_generator(generator: object) -> None:
@@ -319,6 +410,54 @@ def _raise_infrastructure_unavailable(
     raise InfrastructureUnavailableError(event, decision, exc) from exc
 
 
+@dataclass(frozen=True, slots=True)
+class _BundleAssemblyContext:
+    module_factory: object
+    run_id: str = "resource-bundle-assembly"
+
+
+def _provider_failure_resource_key(module_factory: object) -> str:
+    for attr_name in (
+        "infrastructure_resource_key",
+        "infra_resource_key",
+        "resource_key",
+    ):
+        declared = getattr(module_factory, attr_name, None)
+        if isinstance(declared, str) and declared in CORE_INFRASTRUCTURE_RESOURCE_KEYS:
+            return declared
+
+    for attr_name in ("infrastructure_resource_keys", "infra_resource_keys"):
+        declared_keys = getattr(module_factory, attr_name, None)
+        if isinstance(declared_keys, str):
+            declared_keys = (declared_keys,)
+        if declared_keys is None:
+            continue
+        try:
+            iterator = iter(declared_keys)
+        except TypeError:
+            continue
+        for declared in iterator:
+            if isinstance(declared, str) and declared in CORE_INFRASTRUCTURE_RESOURCE_KEYS:
+                return declared
+
+    return PROVIDER_RESOURCE_CONSTRUCTION_KEY
+
+
+def _phase_for_resource_key(resource_key: str) -> PhaseEnum:
+    return INFRASTRUCTURE_RESOURCE_PHASES.get(resource_key, PhaseEnum.PHASE0)
+
+
+def _policy_path_from_env_config(env_config: Mapping[str, Any] | str | None) -> str:
+    if isinstance(env_config, str):
+        return env_config
+    if isinstance(env_config, Mapping):
+        for key in ("policy_path", "gate_policy_path", "config_ref"):
+            value = env_config.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return ""
+
+
 def _fallback_infrastructure_decision(phase: PhaseEnum) -> GateDecision:
     return GateDecision(
         phase=phase,
@@ -355,9 +494,13 @@ def _cycle_id_from_context(context: object) -> str:
 __all__ = [
     "CORE_INFRASTRUCTURE_RESOURCE_KEYS",
     "INFRASTRUCTURE_RESOURCE_PHASES",
+    "INFRASTRUCTURE_RESOURCE_REGISTRY",
     "INFRA_UNAVAILABLE_HARD_STOP_SCENARIO_ID",
     "InfrastructureUnavailableError",
     "InfrastructureUnavailableEvent",
+    "InfrastructureResourceRegistryEntry",
+    "PROVIDER_RESOURCE_CONSTRUCTION_KEY",
     "classify_infrastructure_failure",
     "guard_infrastructure_resource",
+    "guard_provider_resource_construction",
 ]

--- a/tests/integration/test_infra_hard_stop.py
+++ b/tests/integration/test_infra_hard_stop.py
@@ -19,6 +19,9 @@ _DOWNSTREAM_PUBLISH_ASSET_KEY = "phase2_downstream_publish"
         ("dbt", "graph_promotion"),
         ("data_readiness", "graph_promotion"),
         ("llm_health_probe", "graph_promotion"),
+        ("postgres_engine", "graph_promotion"),
+        ("iceberg_catalog", "graph_promotion"),
+        ("neo4j_driver", "graph_promotion"),
         ("phase2_pool_failure_rate", _DOWNSTREAM_PUBLISH_ASSET_KEY),
     ],
 )
@@ -53,7 +56,7 @@ def test_daily_cycle_hard_stops_on_guarded_resource_init_failure(
 
     assert result.success is False
     assert dagster.AssetKey([blocked_asset_key]) not in materialized_keys
-    assert payload["phase"] in {"phase0", "phase2"}
+    assert payload["phase"] in {"phase0", "phase1", "phase2"}
     assert payload["failure_class"] == "infra"
     assert payload["action"] == "fail_run"
     assert payload["failed_node"] == failing_resource_key
@@ -97,6 +100,39 @@ def test_daily_cycle_alerts_when_gate_policy_resource_load_fails(
     assert missing_policy_path.name in str(payload["summary"])
 
 
+def test_build_definitions_alerts_when_provider_get_resources_fails(
+    dagster_module: object,
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import orchestrator.definitions as definitions_module
+    from orchestrator.resources import InfrastructureUnavailableError
+
+    class BrokenGraphProvider:
+        infrastructure_resource_key = "neo4j_driver"
+
+        def get_resources(self) -> dict[str, object]:
+            raise RuntimeError("fake neo4j driver construction failed")
+
+    with caplog.at_level(logging.WARNING, logger="orchestrator.alerting.dispatcher"):
+        with pytest.raises(InfrastructureUnavailableError) as error:
+            definitions_module.build_definitions(
+                module_factories=[BrokenGraphProvider()],
+                policy_path=stub_policy_path,
+            )
+
+    payload = _single_alert_for_resource(caplog.records, "neo4j_driver")
+
+    assert error.value.event.resource_key == "neo4j_driver"
+    assert error.value.decision.action.value == "fail_run"
+    assert payload["phase"] == "phase1"
+    assert payload["failure_class"] == "infra"
+    assert payload["action"] == "fail_run"
+    assert payload["failed_node"] == "neo4j_driver"
+    assert "fake neo4j driver construction failed" in payload["summary"]
+
+
 def _build_defs(
     dagster: Any,
     *,
@@ -116,7 +152,7 @@ def _build_defs(
     return definitions_module.build_definitions(
         module_factories=[
             _fake_phase0_surface_provider(dagster, failing_resource_key),
-            _fake_phase1_provider(dagster),
+            _fake_phase1_provider(dagster, failing_resource_key),
             _fake_phase2_provider(dagster, failing_resource_key),
         ],
         policy_path=stub_policy_path,
@@ -173,6 +209,12 @@ def _fake_phase0_surface_provider(
         def create_resource(self, context: object) -> FakeLLMHealthProbe:
             return FakeLLMHealthProbe()
 
+    class FakeCoreResource(dagster.ConfigurableResource):
+        resource_key: str
+
+        def create_resource(self, context: object) -> dict[str, str]:
+            return {"resource_key": self.resource_key}
+
     @dagster.asset(
         name=PHASE0_CANDIDATE_FREEZE_ASSET_KEY,
         group_name=PHASE0_GROUP_NAME,
@@ -181,6 +223,8 @@ def _fake_phase0_surface_provider(
     def candidate_freeze(
         data_readiness: dagster.ResourceParam[object],
         dbt: dagster.ResourceParam[object],
+        postgres_engine: dagster.ResourceParam[object],
+        iceberg_catalog: dagster.ResourceParam[object],
     ) -> str:
         return "frozen"
 
@@ -209,15 +253,25 @@ def _fake_phase0_surface_provider(
             else:
                 llm_health_probe_resource = FakeLLMHealthProbeResource()
 
-            return {
+            resources: dict[str, object] = {
                 DATA_READINESS_RESOURCE_KEY: data_readiness_resource,
                 "llm_health_probe": llm_health_probe_resource,
             }
+            for resource_key in ("postgres_engine", "iceberg_catalog"):
+                if failing_resource_key == resource_key:
+                    resources[resource_key] = RaisingResource(
+                        resource_key=resource_key,
+                    )
+                else:
+                    resources[resource_key] = FakeCoreResource(
+                        resource_key=resource_key,
+                    )
+            return resources
 
     return FakePhase0SurfaceProvider()
 
 
-def _fake_phase1_provider(dagster: Any) -> object:
+def _fake_phase1_provider(dagster: Any, failing_resource_key: str) -> object:
     from orchestrator.jobs.phase0_constants import (
         PHASE0_CANDIDATE_FREEZE_ASSET_KEY,
         PHASE0_READINESS_ASSET_KEY,
@@ -236,7 +290,7 @@ def _fake_phase1_provider(dagster: Any) -> object:
             dagster.AssetKey([PHASE0_CANDIDATE_FREEZE_ASSET_KEY]),
         ],
     )
-    def graph_promotion() -> str:
+    def graph_promotion(neo4j_driver: dagster.ResourceParam[object]) -> str:
         return "promoted"
 
     @dagster.asset(
@@ -246,6 +300,14 @@ def _fake_phase1_provider(dagster: Any) -> object:
     def graph_snapshot(graph_promotion: str) -> str:
         return f"snapshot:{graph_promotion}"
 
+    class RaisingResource(dagster.ConfigurableResource):
+        def create_resource(self, context: object) -> object:
+            raise RuntimeError("fake neo4j_driver unavailable")
+
+    class FakeNeo4jDriverResource(dagster.ConfigurableResource):
+        def create_resource(self, context: object) -> dict[str, str]:
+            return {"resource_key": "neo4j_driver"}
+
     class FakePhase1Provider:
         def get_assets(self) -> tuple[object, ...]:
             return (graph_promotion, graph_snapshot)
@@ -254,7 +316,9 @@ def _fake_phase1_provider(dagster: Any) -> object:
             return ()
 
         def get_resources(self) -> dict[str, object]:
-            return {}
+            if failing_resource_key == "neo4j_driver":
+                return {"neo4j_driver": RaisingResource()}
+            return {"neo4j_driver": FakeNeo4jDriverResource()}
 
     return FakePhase1Provider()
 

--- a/tests/resources/test_bundle.py
+++ b/tests/resources/test_bundle.py
@@ -1,10 +1,16 @@
+import json
+import logging
 from dataclasses import FrozenInstanceError, fields, replace
 from datetime import datetime, timezone
 from inspect import signature
+from pathlib import Path
 from types import MappingProxyType
 from typing import Any
 
 import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LITE_POLICY_PATH = REPO_ROOT / "config" / "policy" / "gate_policy.lite.yaml"
 
 
 @pytest.fixture
@@ -147,3 +153,89 @@ def test_read_only_resource_bundle_rejects_metadata_shadowing_bypass(
         bundle.extra = "mutated"
     with pytest.raises(FrozenInstanceError):
         bundle.config_ref = "mutated"
+
+
+def test_build_resource_bundle_hard_stops_provider_resource_construction_failure(
+    resource_exports: dict[str, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from orchestrator.resources import InfrastructureUnavailableError
+
+    build_resource_bundle = resource_exports["build_resource_bundle"]
+
+    class IcebergProvider:
+        infrastructure_resource_key = "iceberg_catalog"
+
+        def get_resources(self) -> dict[str, object]:
+            raise RuntimeError("fake iceberg catalog unavailable")
+
+    with caplog.at_level(logging.WARNING, logger="orchestrator.alerting.dispatcher"):
+        with pytest.raises(InfrastructureUnavailableError) as error:
+            build_resource_bundle(str(LITE_POLICY_PATH), [IcebergProvider()])
+
+    payload = _single_alert_for_resource(caplog.records, "iceberg_catalog")
+
+    assert error.value.event.resource_key == "iceberg_catalog"
+    assert error.value.decision.action.value == "fail_run"
+    assert payload["phase"] == "phase0"
+    assert payload["failure_class"] == "infra"
+    assert payload["action"] == "fail_run"
+    assert payload["failed_node"] == "iceberg_catalog"
+    assert "fake iceberg catalog unavailable" in payload["summary"]
+
+
+def test_build_resource_bundle_hard_stops_generic_get_resources_failure(
+    resource_exports: dict[str, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from orchestrator.resources import (
+        InfrastructureUnavailableError,
+        PROVIDER_RESOURCE_CONSTRUCTION_KEY,
+    )
+
+    build_resource_bundle = resource_exports["build_resource_bundle"]
+
+    class BrokenProvider:
+        def get_resources(self) -> dict[str, object]:
+            raise RuntimeError("provider get_resources exploded")
+
+    with caplog.at_level(logging.WARNING, logger="orchestrator.alerting.dispatcher"):
+        with pytest.raises(InfrastructureUnavailableError) as error:
+            build_resource_bundle(str(LITE_POLICY_PATH), [BrokenProvider()])
+
+    payload = _single_alert_for_resource(
+        caplog.records,
+        PROVIDER_RESOURCE_CONSTRUCTION_KEY,
+    )
+
+    assert error.value.event.resource_key == PROVIDER_RESOURCE_CONSTRUCTION_KEY
+    assert payload["phase"] == "phase0"
+    assert payload["failure_class"] == "infra"
+    assert payload["action"] == "fail_run"
+    assert payload["failed_node"] == PROVIDER_RESOURCE_CONSTRUCTION_KEY
+    assert "provider get_resources exploded" in payload["summary"]
+
+
+def _single_alert_for_resource(
+    records: list[logging.LogRecord],
+    resource_key: str,
+) -> dict[str, object]:
+    payloads = [
+        payload
+        for payload in _alert_payloads(records)
+        if payload.get("failed_node") == resource_key
+    ]
+    assert len(payloads) == 1
+    return payloads[0]
+
+
+def _alert_payloads(records: list[logging.LogRecord]) -> list[dict[str, object]]:
+    payloads: list[dict[str, object]] = []
+    for record in records:
+        try:
+            payload = json.loads(record.message)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            payloads.append(payload)
+    return payloads

--- a/tests/resources/test_infra_gate.py
+++ b/tests/resources/test_infra_gate.py
@@ -111,6 +111,22 @@ def test_classify_infrastructure_failure_does_not_steal_manifest_repair(
     assert decision.action is GateAction.REPAIR_MANIFEST
 
 
+def test_infrastructure_registry_includes_core_storage_and_graph_backends() -> None:
+    infra = _infra_module()
+
+    assert {
+        "postgres_engine",
+        "iceberg_catalog",
+        "neo4j_driver",
+    } <= infra.CORE_INFRASTRUCTURE_RESOURCE_KEYS
+    assert infra.INFRASTRUCTURE_RESOURCE_PHASES["postgres_engine"] is PhaseEnum.PHASE0
+    assert infra.INFRASTRUCTURE_RESOURCE_PHASES["iceberg_catalog"] is PhaseEnum.PHASE0
+    assert infra.INFRASTRUCTURE_RESOURCE_PHASES["neo4j_driver"] is PhaseEnum.PHASE1
+    assert set(infra.INFRASTRUCTURE_RESOURCE_REGISTRY) == set(
+        infra.CORE_INFRASTRUCTURE_RESOURCE_KEYS,
+    )
+
+
 @pytest.mark.parametrize(
     "surface_name",
     [
@@ -140,6 +156,42 @@ def test_guarded_data_readiness_accepts_supported_signal_surfaces(
     assert observed is signal
     assert getattr(guarded, "missing_optional_signal", "fallback") == "fallback"
     assert not hasattr(guarded, "missing_optional_signal")
+
+
+def test_guarded_no_arg_resource_definition_initializes_normally() -> None:
+    dagster = pytest.importorskip("dagster", reason="dagster is not installed")
+    infra = _infra_module()
+
+    @dagster.resource
+    def no_arg_resource() -> str:
+        return "ok"
+
+    value, finalizers = infra._initialize_resource(no_arg_resource, object())
+
+    assert value == "ok"
+    assert finalizers == ()
+
+
+def test_guarded_resource_definition_preserves_dagster_metadata() -> None:
+    dagster = pytest.importorskip("dagster", reason="dagster is not installed")
+    infra = _infra_module()
+
+    @dagster.resource(
+        required_resource_keys={"postgres_engine"},
+        config_schema={"catalog_name": str},
+    )
+    def iceberg_catalog(context: object) -> str:
+        return str(context.resource_config["catalog_name"])
+
+    guarded = infra.guard_infrastructure_resource(
+        "iceberg_catalog",
+        iceberg_catalog,
+        phase=PhaseEnum.PHASE0,
+        policy_path=str(LITE_POLICY_PATH),
+    )
+
+    assert guarded.required_resource_keys == {"postgres_engine"}
+    assert guarded.config_schema is iceberg_catalog.config_schema
 
 
 def _infra_module() -> Any:


### PR DESCRIPTION
Closes #88

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `scripts/check_boundaries.py`, `src/orchestrator/alerting/dispatcher.py`, `src/orchestrator/alerting/runbooks.py`, `src/orchestrator/checks/dbt_events.py`, `src/orchestrator/checks/phase1.py`, `src/orchestrator/checks/phase2.py`, `src/orchestrator/checks/phase3.py`, `src/orchestrator/diagnostics.py`, `src/orchestrator/jobs/cycle.py`


---
## 背景与目标
Milestone review for milestone-3 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The hard-stop adapter guards only dbt, gate_policy, data_readiness, llm_health_probe, and phase2_pool_failure_rate. The issue explicitly calls out PG/Iceberg/Neo4j-style core infrastructure, but those resources are not represented in CORE_INFRASTRUCTURE_RESOURCE_KEYS or INFRASTRUCTURE_RESOURCE_PHASES. Also, build_definitions calls build_resource_bundle before wrapping resources, so failures while assembling provider resources still bypass GateDecision classification and alerting entirely.

## 实现范围
- 修改文件: `src/orchestrator/resources/infra.py`
- Define a single infrastructure resource registry shared with assembly/resource_bundle, including the actual storage and graph backend resource keys. Guard provider resource construction as well as Dagster runtime initialization, and add integration tests for PG/Iceberg/Neo4j-equivalent resource keys plus build_resource_bundle/get_resources failures.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/orchestrator/.venv/bin/python -m pytest
```
