### PR TITLE
feat(#87): [milestone-3 review] P0: Scenario IDs are dropped before alerts and diagnostics

### DIFF
--- a/src/orchestrator/alerting/dispatcher.py
+++ b/src/orchestrator/alerting/dispatcher.py
@@ -97,6 +97,7 @@ def _dispatch_slack(payload: AlertPayload, webhook_url: str) -> None:
             "phase": payload.phase,
             "action": payload.action,
             "failure_class": payload.failure_class,
+            "scenario_id": payload.scenario_id,
             "summary": payload.summary,
             "runbook_url": payload.runbook_url,
         },

--- a/src/orchestrator/alerting/payload.py
+++ b/src/orchestrator/alerting/payload.py
@@ -10,4 +10,5 @@ class AlertPayload:
     action: str
     summary: str
     failure_class: str | None = None
+    scenario_id: str | None = None
     runbook_url: str | None = None

--- a/src/orchestrator/alerting/runbooks.py
+++ b/src/orchestrator/alerting/runbooks.py
@@ -49,13 +49,17 @@ def with_runbook_url(
     if payload.runbook_url:
         return payload
 
+    resolved_scenario_id = scenario_id
+    if resolved_scenario_id is None:
+        resolved_scenario_id = payload.scenario_id
+
     return replace(
         payload,
         runbook_url=runbook_url_for(
             payload.phase,
             payload.failure_class,
             payload.action,
-            scenario_id=scenario_id,
+            scenario_id=resolved_scenario_id,
         ),
     )
 

--- a/src/orchestrator/checks/asset_checks.py
+++ b/src/orchestrator/checks/asset_checks.py
@@ -179,6 +179,7 @@ def _llm_health_metadata(
             decision.failure_class.value if decision.failure_class else ""
         )
         metadata["action"] = decision.action.value
+        metadata["scenario_id"] = decision.scenario_id or ""
     return metadata
 
 

--- a/src/orchestrator/checks/classifier.py
+++ b/src/orchestrator/checks/classifier.py
@@ -44,6 +44,7 @@ def classify_gate_result(
                 failure_class=failure_class,
                 action=entry.action,
                 reason=entry.description,
+                scenario_id=entry.scenario_id,
             )
 
     msg = (
@@ -88,6 +89,7 @@ def _classify_scenario(
         failure_class=failure_class,
         action=entry.action,
         reason=entry.description,
+        scenario_id=entry.scenario_id,
     )
 
 

--- a/src/orchestrator/checks/dbt_events.py
+++ b/src/orchestrator/checks/dbt_events.py
@@ -299,6 +299,7 @@ def _gate_observation_metadata(
             else ""
         ),
         "reason": result.decision.reason or "",
+        "scenario_id": result.decision.scenario_id or "",
         "dbt_node_name": result.event.dbt_node_name or "",
         "failed_node": result.event.asset_key or "",
     }

--- a/src/orchestrator/checks/decision_handler.py
+++ b/src/orchestrator/checks/decision_handler.py
@@ -33,8 +33,10 @@ def dispatch_gate_decision_alert(
             action=decision.action.value,
             summary=summary,
             failure_class=failure_class,
+            scenario_id=decision.scenario_id,
             runbook_url=runbook_url,
         ),
+        scenario_id=decision.scenario_id,
     )
 
     dispatch_alert(

--- a/src/orchestrator/checks/models.py
+++ b/src/orchestrator/checks/models.py
@@ -16,6 +16,7 @@ class GateDecision:
     failure_class: FailureClass | None
     action: GateAction
     reason: str | None = None
+    scenario_id: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/orchestrator/checks/phase2.py
+++ b/src/orchestrator/checks/phase2.py
@@ -110,6 +110,7 @@ def inconclusive_metadata(
             decision.failure_class.value if decision.failure_class is not None else ""
         ),
         "action": decision.action.value,
+        "scenario_id": decision.scenario_id or "",
         "stock_id": event.stock_id,
         "failed_node": event.failed_node,
         "failure_rate": phase2_failure_rate(event.failed_count, event.total_count),
@@ -253,6 +254,7 @@ def _phase2_pool_failure_metadata(
             decision.failure_class.value if decision.failure_class is not None else ""
         ),
         "action": decision.action.value,
+        "scenario_id": decision.scenario_id or "",
         "failed_count": event.failed_count,
         "total_count": event.total_count,
         "failure_rate": phase2_failure_rate(event.failed_count, event.total_count),

--- a/src/orchestrator/diagnostics.py
+++ b/src/orchestrator/diagnostics.py
@@ -22,6 +22,7 @@ class GateDecisionDiagnostic:
     phase: str
     failure_class: str | None
     action: str
+    scenario_id: str | None
     failed_node: str | None
     summary: str | None
     runbook_url: str | None
@@ -35,6 +36,7 @@ class RerunPlanDiagnostic:
     requires_manual_ack: bool
     rerun_mode: str
     generated_at: str
+    scenario_id: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -109,6 +111,7 @@ def run_diagnostic_to_dict(summary: RunDiagnosticSummary) -> dict[str, object]:
                 "phase": decision.phase,
                 "failure_class": decision.failure_class,
                 "action": decision.action,
+                "scenario_id": decision.scenario_id,
                 "failed_node": decision.failed_node,
                 "summary": decision.summary,
                 "runbook_url": decision.runbook_url,
@@ -123,6 +126,7 @@ def run_diagnostic_to_dict(summary: RunDiagnosticSummary) -> dict[str, object]:
                 "requires_manual_ack": plan.requires_manual_ack,
                 "rerun_mode": plan.rerun_mode,
                 "generated_at": plan.generated_at,
+                "scenario_id": plan.scenario_id,
             }
             for plan in summary.rerun_plans
         ],
@@ -224,6 +228,7 @@ def _gate_decisions_for_runs(
                     decision.phase,
                     decision.failure_class,
                     decision.action,
+                    decision.scenario_id,
                     decision.failed_node,
                     decision.summary,
                 )
@@ -280,6 +285,7 @@ def _gate_decisions_from_record(
             continue
 
         failure_class = _optional_string(metadata.get("failure_class"))
+        scenario_id = _optional_string(metadata.get("scenario_id"))
         failed_node = _failed_node(metadata, owner, event)
         phase = (
             _optional_string(metadata.get("phase"))
@@ -292,6 +298,7 @@ def _gate_decisions_from_record(
             phase=phase,
             failure_class=failure_class,
             action=action,
+            scenario_id=scenario_id,
         )
 
         decisions.append(
@@ -300,6 +307,7 @@ def _gate_decisions_from_record(
                 phase=phase,
                 failure_class=failure_class,
                 action=action,
+                scenario_id=scenario_id,
                 failed_node=failed_node,
                 summary=summary,
                 runbook_url=runbook_url,
@@ -499,13 +507,14 @@ def _diagnostic_runbook_url(
     phase: str,
     failure_class: str | None,
     action: str,
+    scenario_id: str | None,
 ) -> str | None:
     explicit = _optional_string(metadata.get("runbook_url"))
     if explicit:
         return explicit
     if action == "continue" or phase == "unknown":
         return None
-    return runbook_url_for(phase, failure_class, action)
+    return runbook_url_for(phase, failure_class, action, scenario_id=scenario_id)
 
 
 def _rerun_plans_from_request_dir(
@@ -554,6 +563,7 @@ def _rerun_plan_from_request_path(path: Path) -> RerunPlanDiagnostic | None:
                 raw_payload.get("generated_at"),
                 "generated_at",
             ),
+            scenario_id=_optional_string(raw_payload.get("scenario_id")),
         )
     except (TypeError, ValueError):
         return None

--- a/src/orchestrator/rerun.py
+++ b/src/orchestrator/rerun.py
@@ -28,6 +28,7 @@ class PartialRerunPlan:
     requires_manual_ack: bool
     generated_at: datetime
     rerun_mode: RerunMode
+    scenario_id: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -93,6 +94,7 @@ def compute_partial_rerun_plan(
         requires_manual_ack=rerun_mode != "asset_only",
         generated_at=datetime.now(timezone.utc),
         rerun_mode=rerun_mode,
+        scenario_id=entry.scenario_id,
     )
 
 

--- a/src/orchestrator/rerun_request.py
+++ b/src/orchestrator/rerun_request.py
@@ -15,7 +15,7 @@ DEFAULT_REQUEST_DIR: Final[str] = ".orchestrator/rerun_requests"
 
 
 def request_from_plan(plan: PartialRerunPlan) -> dict[str, Any]:
-    return {
+    payload = {
         "run_id": plan.run_id,
         "failed_node": plan.failed_node,
         "rerun_selection": list(plan.rerun_selection),
@@ -23,6 +23,9 @@ def request_from_plan(plan: PartialRerunPlan) -> dict[str, Any]:
         "rerun_mode": plan.rerun_mode,
         "generated_at": plan.generated_at.isoformat(),
     }
+    if plan.scenario_id is not None:
+        payload["scenario_id"] = plan.scenario_id
+    return payload
 
 
 def request_filename(run_id: str, failed_node: str) -> str:

--- a/src/orchestrator/resources/infra.py
+++ b/src/orchestrator/resources/infra.py
@@ -325,6 +325,7 @@ def _fallback_infrastructure_decision(phase: PhaseEnum) -> GateDecision:
         failure_class=FailureClass.INFRA,
         action=GateAction.FAIL_RUN,
         reason=_INFRA_HARD_STOP_REASON,
+        scenario_id=INFRA_UNAVAILABLE_HARD_STOP_SCENARIO_ID,
     )
 
 

--- a/src/orchestrator/sensors/manual_rerun.py
+++ b/src/orchestrator/sensors/manual_rerun.py
@@ -140,14 +140,25 @@ def _validate_request(
             f"invalid manual rerun request {request_name}: generated_at is required",
         )
 
-    return {
+    validated = {
         "run_id": run_id,
         "failed_node": failed_node,
         "rerun_selection": list(rerun_selection),
         "requires_manual_ack": requires_manual_ack,
         "rerun_mode": rerun_mode,
         "generated_at": generated_at,
-    }, None
+    }
+    scenario_id = payload.get("scenario_id")
+    if scenario_id is not None:
+        if not _is_non_empty_str(scenario_id):
+            return (
+                None,
+                f"invalid manual rerun request {request_name}: "
+                "scenario_id must be a non-empty string when provided",
+            )
+        validated["scenario_id"] = scenario_id.strip()
+
+    return validated, None
 
 
 def _validate_repair_only_selection(
@@ -193,6 +204,9 @@ def _build_run_request(payload: dict[str, Any]) -> RunRequest:
         "failed_node": payload["failed_node"],
         "rerun_mode": payload["rerun_mode"],
     }
+    scenario_id = payload.get("scenario_id")
+    if isinstance(scenario_id, str) and scenario_id:
+        tags["scenario_id"] = scenario_id
     run_key = (
         "manual-rerun:"
         f"{payload['run_id']}:"

--- a/tests/alerting/test_dispatcher.py
+++ b/tests/alerting/test_dispatcher.py
@@ -48,6 +48,7 @@ def payload() -> AlertPayload:
         action="fail_run",
         summary="test",
         failure_class="infra",
+        scenario_id="phase0_llm_health_check_failed",
         runbook_url="https://runbooks.example/c1",
     )
 
@@ -131,6 +132,7 @@ def test_dispatch_alert_slack_channel_posts_minimal_payload(
     assert body["phase"] == payload.phase
     assert body["action"] == payload.action
     assert body["failure_class"] == payload.failure_class
+    assert body["scenario_id"] == payload.scenario_id
     assert body["summary"] == payload.summary
     assert body["runbook_url"] == payload.runbook_url
 
@@ -246,6 +248,7 @@ def test_alert_payload_optional_fields_allow_none() -> None:
 
     assert payload.failed_node is None
     assert payload.failure_class is None
+    assert payload.scenario_id is None
     assert payload.runbook_url is None
 
 
@@ -260,6 +263,7 @@ def test_alert_payload_field_set_matches_runbook_payload() -> None:
         "action",
         "summary",
         "failure_class",
+        "scenario_id",
         "runbook_url",
     }
 

--- a/tests/alerting/test_runbooks.py
+++ b/tests/alerting/test_runbooks.py
@@ -70,6 +70,23 @@ def test_with_runbook_url_fills_missing_url_without_mutating_payload() -> None:
     )
 
 
+def test_with_runbook_url_uses_payload_scenario_id() -> None:
+    payload = AlertPayload(
+        cycle_id="c1",
+        phase="phase1",
+        status="failed",
+        failed_node="graph_store",
+        action="fail_run",
+        summary="infra unavailable",
+        failure_class="infra",
+        scenario_id="infra_unavailable_hard_stop",
+    )
+
+    enriched = with_runbook_url(payload)
+
+    assert enriched.runbook_url == "docs/RUNBOOK_P5.md#phase2-infra-fail_run"
+
+
 def test_with_runbook_url_preserves_explicit_url() -> None:
     payload = AlertPayload(
         cycle_id="c1",

--- a/tests/checks/test_classifier.py
+++ b/tests/checks/test_classifier.py
@@ -43,6 +43,7 @@ def test_gate_decision_fields_match_runtime_model() -> None:
         "failure_class",
         "action",
         "reason",
+        "scenario_id",
     ]
 
 
@@ -74,6 +75,7 @@ def test_classify_phase0_infra_fails_run(gate_policy: Any) -> None:
     assert decision.phase is PhaseEnum.PHASE0
     assert decision.failure_class is FailureClass.INFRA
     assert decision.action is GateAction.FAIL_RUN
+    assert decision.scenario_id == "phase0_llm_health_check_failed"
     assert decision.reason == "LLM health check failed; stop before Phase 1."
 
 
@@ -87,6 +89,7 @@ def test_classify_phase2_task_level_marks_inconclusive(gate_policy: Any) -> None
     assert decision.phase is PhaseEnum.PHASE2
     assert decision.failure_class is FailureClass.TASK_LEVEL
     assert decision.action is GateAction.MARK_INCONCLUSIVE
+    assert decision.scenario_id == "phase2_single_stock_task_failed"
     assert (
         decision.reason
         == "A single-stock LLM task failed within tolerance; continue the pool."
@@ -101,6 +104,7 @@ def test_classify_phase3_infra_repairs_manifest(gate_policy: Any) -> None:
     )
 
     assert decision.action is GateAction.REPAIR_MANIFEST
+    assert decision.scenario_id == "phase3_manifest_write_failed"
 
 
 def test_classify_scenario_uses_applies_to_phase(gate_policy: Any) -> None:
@@ -115,6 +119,7 @@ def test_classify_scenario_uses_applies_to_phase(gate_policy: Any) -> None:
 
     assert decision.phase is PhaseEnum.PHASE1
     assert decision.action is GateAction.FAIL_RUN
+    assert decision.scenario_id == "infra_unavailable_hard_stop"
 
 
 def test_unknown_policy_combination_raises(gate_policy: Any) -> None:

--- a/tests/checks/test_dbt_events.py
+++ b/tests/checks/test_dbt_events.py
@@ -109,6 +109,7 @@ def test_classify_dbt_test_failure_from_node_name(gate_policy: Any) -> None:
     assert decision.phase is PhaseEnum.PHASE0
     assert decision.failure_class is FailureClass.TASK_LEVEL
     assert decision.action is GateAction.PARTIAL_RERUN
+    assert decision.scenario_id == "phase0_dbt_test_failed"
     assert (
         decision.reason
         == "dbt test failed; rerun the repaired asset group after the fix."
@@ -139,6 +140,7 @@ def test_plan_dbt_test_partial_rerun_uses_validated_event_asset_key(
     assert plan.rerun_selection == ("dbt_phase0_assets",)
     assert plan.requires_manual_ack is False
     assert plan.rerun_mode == "asset_only"
+    assert plan.scenario_id == "phase0_dbt_test_failed"
     assert "phase0_readiness_ping" not in plan.rerun_selection
     assert "candidate_freeze" not in plan.rerun_selection
 
@@ -246,15 +248,21 @@ def test_stream_dbt_events_handles_failed_check_with_alert_and_request(
     assert _observation_asset_key(observation) == "heartbeat"
     assert _observation_metadata_value(observation, "action") == "partial_rerun"
     assert _observation_metadata_value(observation, "failure_class") == "task_level"
+    assert (
+        _observation_metadata_value(observation, "scenario_id")
+        == "phase0_dbt_test_failed"
+    )
     assert _observation_metadata_value(observation, "failed_node") == "heartbeat"
     assert request["run_id"] == "run-dbt"
     assert request["failed_node"] == "heartbeat"
     assert request["rerun_selection"] == ["heartbeat"]
     assert request["rerun_mode"] == "asset_only"
+    assert request["scenario_id"] == "phase0_dbt_test_failed"
     assert alert["cycle_id"] == "cycle-dbt"
     assert alert["failed_node"] == "heartbeat"
     assert alert["action"] == "partial_rerun"
     assert alert["failure_class"] == "task_level"
+    assert alert["scenario_id"] == "phase0_dbt_test_failed"
     assert alert["runbook_url"] == (
         "docs/RUNBOOK_P5.md#phase0-task_level-partial_rerun"
     )

--- a/tests/checks/test_decision_handler.py
+++ b/tests/checks/test_decision_handler.py
@@ -36,6 +36,7 @@ def test_dispatch_gate_decision_alert_logs_fail_run_payload(
         "action": "fail_run",
         "summary": "not ready",
         "failure_class": "data_quality",
+        "scenario_id": None,
         "runbook_url": "docs/RUNBOOK_P5.md#phase0-data_quality-fail_run",
     }
 
@@ -100,6 +101,32 @@ def test_dispatch_gate_decision_alert_fills_runbook_for_non_continue_actions(
     assert payload["failure_class"] == failure_class.value
     assert payload["failed_node"] == "phase3_manifest"
     assert payload["runbook_url"] == expected_runbook_url
+
+
+def test_dispatch_gate_decision_alert_uses_scenario_runbook_mapping(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    decision = GateDecision(
+        phase=PhaseEnum.PHASE1,
+        failure_class=FailureClass.INFRA,
+        action=GateAction.FAIL_RUN,
+        reason="infra hard stop",
+        scenario_id="infra_unavailable_hard_stop",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        dispatch_gate_decision_alert(
+            decision,
+            cycle_id="cycle-1",
+            failed_node="graph_store",
+            summary="graph store unavailable",
+            channels=("logging",),
+        )
+
+    payload = json.loads(caplog.records[-1].message)
+
+    assert payload["scenario_id"] == "infra_unavailable_hard_stop"
+    assert payload["runbook_url"] == "docs/RUNBOOK_P5.md#phase2-infra-fail_run"
 
 
 def test_dispatch_gate_decision_alert_preserves_explicit_runbook_url(

--- a/tests/checks/test_llm_health_check.py
+++ b/tests/checks/test_llm_health_check.py
@@ -94,6 +94,7 @@ def test_llm_health_check_fails_phase0_infra_with_fail_run_action(
     assert result.passed is False
     assert result.metadata["failure_class"] == "infra"
     assert result.metadata["action"] == "fail_run"
+    assert result.metadata["scenario_id"] == "phase0_llm_health_check_failed"
     assert result.metadata["provider"] == "fake-llm"
     assert result.metadata["summary"] == "probe failed"
 
@@ -124,6 +125,7 @@ def test_llm_health_check_dispatches_fail_run_alert(
     assert payload["failed_node"] == "llm_health_check"
     assert payload["action"] == "fail_run"
     assert payload["failure_class"] == "infra"
+    assert payload["scenario_id"] == "phase0_llm_health_check_failed"
     assert payload["summary"] == "LLM health check failed; stop before Phase 1."
 
 
@@ -148,8 +150,10 @@ def test_llm_health_check_probe_exception_is_policy_classified(
     assert result.metadata["summary"] == "llm health probe failed: probe timeout"
     assert result.metadata["failure_class"] == "infra"
     assert result.metadata["action"] == "fail_run"
+    assert result.metadata["scenario_id"] == "phase0_llm_health_check_failed"
     assert payload["failure_class"] == "infra"
     assert payload["action"] == "fail_run"
+    assert payload["scenario_id"] == "phase0_llm_health_check_failed"
 
 
 def test_llm_health_check_is_dagster_asset_check_definition() -> None:

--- a/tests/checks/test_phase1_gate.py
+++ b/tests/checks/test_phase1_gate.py
@@ -48,6 +48,7 @@ def test_classify_graph_promotion_failure_uses_phase1_publish_policy(
     assert decision.phase is PhaseEnum.PHASE1
     assert decision.failure_class is FailureClass.PUBLISH
     assert decision.action is GateAction.FAIL_RUN
+    assert decision.scenario_id == "phase1_graph_promotion_snapshot_failed"
     assert (
         decision.reason
         == "Graph promotion or snapshot failed; retain the previous ready graph."

--- a/tests/checks/test_phase2_pool_gate.py
+++ b/tests/checks/test_phase2_pool_gate.py
@@ -64,6 +64,7 @@ def test_classify_phase2_pool_failure_rate_threshold(
     assert decision.failure_class is FailureClass.DATA_QUALITY
     assert decision.action is expected_action
     if expected_action is GateAction.FAIL_RUN:
+        assert decision.scenario_id == "phase2_pool_failure_rate_exceeded"
         assert (
             decision.reason
             == "Pool failure rate exceeded threshold; fail the run and alert."
@@ -161,6 +162,7 @@ def test_dispatch_phase2_pool_failure_alert_logs_shared_payload(
     assert payload["phase"] == "phase2"
     assert payload["failure_class"] == "data_quality"
     assert payload["action"] == "fail_run"
+    assert payload["scenario_id"] == "phase2_pool_failure_rate_exceeded"
     assert payload["failed_node"] == "phase2_stock_AAPL, phase2_stock_MSFT"
     assert payload["summary"] == (
         "Phase 2 pool failure rate 0.4 (4/10): fake pool failures"

--- a/tests/checks/test_phase2_single_stock_gate.py
+++ b/tests/checks/test_phase2_single_stock_gate.py
@@ -73,6 +73,7 @@ def test_classify_phase2_single_stock_failure_marks_inconclusive(
     assert decision.phase is PhaseEnum.PHASE2
     assert decision.failure_class is FailureClass.TASK_LEVEL
     assert decision.action is GateAction.MARK_INCONCLUSIVE
+    assert decision.scenario_id == "phase2_single_stock_task_failed"
     assert (
         decision.reason
         == "A single-stock LLM task failed within tolerance; continue the pool."
@@ -172,6 +173,7 @@ def test_inconclusive_metadata_contains_asset_check_fields(gate_policy: Any) -> 
         "phase": "phase2",
         "failure_class": "task_level",
         "action": "mark_inconclusive",
+        "scenario_id": "phase2_single_stock_task_failed",
         "stock_id": "AAPL",
         "failed_node": "phase2_llm_score_AAPL",
         "failure_rate": 0.1,

--- a/tests/checks/test_phase3_manifest_repair.py
+++ b/tests/checks/test_phase3_manifest_repair.py
@@ -54,6 +54,7 @@ def test_classify_manifest_write_failure_repairs_manifest(
     assert decision.phase is PhaseEnum.PHASE3
     assert decision.failure_class is FailureClass.INFRA
     assert decision.action is GateAction.REPAIR_MANIFEST
+    assert decision.scenario_id == "phase3_manifest_write_failed"
     assert (
         decision.reason
         == "Manifest write failed; alert and expose repair-only rerun."
@@ -75,6 +76,7 @@ def test_plan_manifest_repair_rerun_selects_only_repair_asset(
     assert plan.rerun_selection == (REPAIR_MANIFEST_ASSET_KEY,)
     assert plan.rerun_mode == "repair_only"
     assert plan.requires_manual_ack is True
+    assert plan.scenario_id == "phase3_manifest_write_failed"
     assert PHASE3_FORMAL_COMMIT_ASSET_KEY not in plan.rerun_selection
     assert PHASE3_MANIFEST_ASSET_KEY not in plan.rerun_selection
     assert request["rerun_selection"] == [REPAIR_MANIFEST_ASSET_KEY]
@@ -115,6 +117,7 @@ def test_manifest_write_failure_alert_payload_contains_repair_action(
     assert payload["phase"] == "phase3"
     assert payload["failure_class"] == "infra"
     assert payload["action"] == "repair_manifest"
+    assert payload["scenario_id"] == "phase3_manifest_write_failed"
     assert payload["failed_node"] == PHASE3_MANIFEST_ASSET_KEY
     assert payload["runbook_url"] == (
         "docs/RUNBOOK_P5.md#phase3-infra-repair_manifest"

--- a/tests/checks/test_phase3_publish_gate.py
+++ b/tests/checks/test_phase3_publish_gate.py
@@ -46,6 +46,7 @@ def test_classify_formal_commit_failure_uses_phase3_publish_policy(
     assert decision.phase is PhaseEnum.PHASE3
     assert decision.failure_class is FailureClass.PUBLISH
     assert decision.action is GateAction.FAIL_RUN
+    assert decision.scenario_id == "phase3_formal_commit_failed"
     assert (
         decision.reason
         == "Formal table commit failed; fail Phase 3 before writing manifest."

--- a/tests/cli/test_diag.py
+++ b/tests/cli/test_diag.py
@@ -43,6 +43,7 @@ def test_collect_run_diagnostic_serializes_gate_metadata_and_rerun_request(
             "phase": "phase0",
             "action": "partial_rerun",
             "failure_class": "task_level",
+            "scenario_id": "phase0_dbt_test_failed",
             "failed_node": "heartbeat",
             "reason": _MetadataText("dbt test failed"),
         },
@@ -52,6 +53,7 @@ def test_collect_run_diagnostic_serializes_gate_metadata_and_rerun_request(
         metadata={
             "action": "fail_run",
             "failure_class": "infra",
+            "scenario_id": "phase0_llm_health_check_failed",
             "summary": "provider unavailable",
         },
     )
@@ -71,6 +73,7 @@ def test_collect_run_diagnostic_serializes_gate_metadata_and_rerun_request(
         rerun_selection=["heartbeat"],
         rerun_mode="asset_only",
         requires_manual_ack=False,
+        scenario_id="phase0_dbt_test_failed",
     )
     _write_request(
         tmp_path / "other-run.json",
@@ -110,6 +113,7 @@ def test_collect_run_diagnostic_serializes_gate_metadata_and_rerun_request(
             "phase": "phase0",
             "failure_class": "task_level",
             "action": "partial_rerun",
+            "scenario_id": "phase0_dbt_test_failed",
             "failed_node": "heartbeat",
             "summary": "dbt test failed",
             "runbook_url": "docs/RUNBOOK_P5.md#phase0-task_level-partial_rerun",
@@ -119,6 +123,7 @@ def test_collect_run_diagnostic_serializes_gate_metadata_and_rerun_request(
             "phase": "phase0",
             "failure_class": "infra",
             "action": "fail_run",
+            "scenario_id": "phase0_llm_health_check_failed",
             "failed_node": "llm_health_check",
             "summary": "provider unavailable",
             "runbook_url": "docs/RUNBOOK_P5.md#phase0-infra-fail_run",
@@ -132,6 +137,7 @@ def test_collect_run_diagnostic_serializes_gate_metadata_and_rerun_request(
             "requires_manual_ack": False,
             "rerun_mode": "asset_only",
             "generated_at": "2026-04-16T00:00:00+00:00",
+            "scenario_id": "phase0_dbt_test_failed",
         },
     ]
 
@@ -165,6 +171,7 @@ def test_collect_run_diagnostic_keeps_repair_request_manual_ack(
             "requires_manual_ack": True,
             "rerun_mode": "repair_only",
             "generated_at": "2026-04-16T00:00:00+00:00",
+            "scenario_id": None,
         },
     ]
     assert "formal_objects_commit" not in payload["rerun_plans"][0]["rerun_selection"]
@@ -299,17 +306,16 @@ def _write_request(
     rerun_selection: list[str],
     rerun_mode: str,
     requires_manual_ack: bool,
+    scenario_id: str | None = None,
 ) -> None:
-    path.write_text(
-        json.dumps(
-            {
-                "run_id": run_id,
-                "failed_node": failed_node,
-                "rerun_selection": rerun_selection,
-                "requires_manual_ack": requires_manual_ack,
-                "rerun_mode": rerun_mode,
-                "generated_at": "2026-04-16T00:00:00+00:00",
-            },
-        ),
-        encoding="utf-8",
-    )
+    payload = {
+        "run_id": run_id,
+        "failed_node": failed_node,
+        "rerun_selection": rerun_selection,
+        "requires_manual_ack": requires_manual_ack,
+        "rerun_mode": rerun_mode,
+        "generated_at": "2026-04-16T00:00:00+00:00",
+    }
+    if scenario_id is not None:
+        payload["scenario_id"] = scenario_id
+    path.write_text(json.dumps(payload), encoding="utf-8")

--- a/tests/integration/failure_injection.py
+++ b/tests/integration/failure_injection.py
@@ -931,6 +931,7 @@ def _run_phase3_formal_commit_failure(
                 "phase": decision.phase.value,
                 "failure_class": decision.failure_class.value,
                 "action": decision.action.value,
+                "scenario_id": decision.scenario_id or "",
                 "failed_node": event.failed_node,
                 "table_name": event.table_name or "",
             },

--- a/tests/integration/test_diag_run.py
+++ b/tests/integration/test_diag_run.py
@@ -35,6 +35,7 @@ def test_diag_run_collects_event_log_and_manual_request_json(
             "phase": "phase2",
             "failure_class": "task_level",
             "action": "mark_inconclusive",
+            "scenario_id": "phase2_single_stock_task_failed",
             "failed_node": "phase2_llm_score_AAPL",
             "reason": "single-stock failure remains within tolerance",
         },
@@ -58,10 +59,11 @@ def test_diag_run_collects_event_log_and_manual_request_json(
                 "run_id": "run-1",
                 "failed_node": "dbt.phase0.heartbeat",
                 "rerun_selection": ["dbt.phase0.heartbeat"],
-                "requires_manual_ack": False,
-                "rerun_mode": "asset_only",
-                "generated_at": "2026-04-16T00:00:00+00:00",
-            },
+            "requires_manual_ack": False,
+            "rerun_mode": "asset_only",
+            "generated_at": "2026-04-16T00:00:00+00:00",
+            "scenario_id": "phase0_dbt_test_failed",
+        },
         ),
         encoding="utf-8",
     )
@@ -81,6 +83,7 @@ def test_diag_run_collects_event_log_and_manual_request_json(
             "phase": "phase2",
             "failure_class": "task_level",
             "action": "mark_inconclusive",
+            "scenario_id": "phase2_single_stock_task_failed",
             "failed_node": "phase2_llm_score_AAPL",
             "summary": "single-stock failure remains within tolerance",
             "runbook_url": "docs/RUNBOOK_P5.md#phase2-task_level-mark_inconclusive",
@@ -88,3 +91,4 @@ def test_diag_run_collects_event_log_and_manual_request_json(
     ]
     assert payload["rerun_plans"][0]["rerun_mode"] == "asset_only"
     assert payload["rerun_plans"][0]["rerun_selection"] == ["dbt.phase0.heartbeat"]
+    assert payload["rerun_plans"][0]["scenario_id"] == "phase0_dbt_test_failed"

--- a/tests/integration/test_gate_matrix_failure_injection.py
+++ b/tests/integration/test_gate_matrix_failure_injection.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 
+import sys
+from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
-from orchestrator.policy import REQUIRED_GATE_MATRIX_SCENARIOS
+from orchestrator.alerting import runbook_url_for
+from orchestrator.checks import dispatch_gate_decision_alert
+from orchestrator.policy import (
+    FailureClass,
+    REQUIRED_GATE_MATRIX_SCENARIOS,
+    load_gate_policy,
+)
 from tests.integration.conftest import metadata_value
 from tests.integration.failure_injection import (
     PHASE2_DOWNSTREAM_PUBLISH_ASSET_KEY,
@@ -14,9 +23,12 @@ from tests.integration.failure_injection import (
     PHASE3_MANIFEST_ASSET_KEY,
     REPAIR_MANIFEST_ASSET_KEY,
     FailureInjectionCase,
+    alert_payloads,
     asset_selection_strings,
     gate_matrix_failure_cases,
 )
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 @pytest.fixture(
@@ -92,9 +104,14 @@ def _assert_required_alert_payload(
     assert alert["phase"] == case.phase
     assert alert["action"] == case.expected_action
     assert alert["failure_class"] == case.expected_failure_class
+    assert alert["scenario_id"] == case.scenario_id
     assert alert["failed_node"] == expected_failed_node
-    assert isinstance(alert["runbook_url"], str)
-    assert alert["runbook_url"]
+    assert alert["runbook_url"] == runbook_url_for(
+        case.phase,
+        case.expected_failure_class,
+        case.expected_action,
+        scenario_id=case.scenario_id,
+    )
 
 
 def _assert_materialization_expectations(
@@ -127,6 +144,10 @@ def _assert_scenario_specifics(
         assert getattr(evaluation, "passed", None) is False
         assert metadata_value(evaluation, "action") == "fail_run"
         assert metadata_value(evaluation, "failure_class") == "infra"
+        assert (
+            metadata_value(evaluation, "scenario_id")
+            == "phase0_llm_health_check_failed"
+        )
         return
 
     if scenario_id == "phase0_dbt_test_failed":
@@ -144,6 +165,10 @@ def _assert_scenario_specifics(
         assert outcome.success is True
         assert getattr(evaluation, "passed", None) is False
         assert metadata_value(evaluation, "action") == "mark_inconclusive"
+        assert (
+            metadata_value(evaluation, "scenario_id")
+            == "phase2_single_stock_task_failed"
+        )
         assert metadata_value(evaluation, "stock_id") == "AAPL"
         assert metadata_value(evaluation, "failure_rate") == 0.1
         return
@@ -152,6 +177,10 @@ def _assert_scenario_specifics(
         evaluation = outcome.evaluations[0]
         assert getattr(evaluation, "passed", None) is False
         assert metadata_value(evaluation, "action") == "fail_run"
+        assert (
+            metadata_value(evaluation, "scenario_id")
+            == "phase2_pool_failure_rate_exceeded"
+        )
         assert metadata_value(evaluation, "failure_rate") == 0.4
         assert dagster.AssetKey([PHASE2_STAGE_KEYS[-1]]) in outcome.materialized_keys
         assert dagster.AssetKey([PHASE2_DOWNSTREAM_PUBLISH_ASSET_KEY]) not in (
@@ -163,6 +192,7 @@ def _assert_scenario_specifics(
         evaluation = outcome.evaluations[0]
         assert getattr(evaluation, "passed", None) is False
         assert metadata_value(evaluation, "action") == "fail_run"
+        assert metadata_value(evaluation, "scenario_id") == "phase3_formal_commit_failed"
         assert dagster.AssetKey([PHASE3_FORMAL_COMMIT_ASSET_KEY]) in (
             outcome.materialized_keys
         )
@@ -191,10 +221,12 @@ def _assert_dbt_failure_request(outcome: object) -> None:
 
     assert metadata_value(gate_observation, "action") == "partial_rerun"
     assert metadata_value(gate_observation, "failure_class") == "task_level"
+    assert metadata_value(gate_observation, "scenario_id") == "phase0_dbt_test_failed"
     assert metadata_value(gate_observation, "failed_node") == outcome.failed_node
     assert request == expected_request
     assert request["rerun_selection"] == [outcome.failed_node]
     assert request["rerun_mode"] == "asset_only"
+    assert request["scenario_id"] == "phase0_dbt_test_failed"
 
 
 def _assert_manifest_repair_request(dagster: object, outcome: object) -> None:
@@ -205,6 +237,7 @@ def _assert_manifest_repair_request(dagster: object, outcome: object) -> None:
     assert request["failed_node"] == PHASE3_MANIFEST_ASSET_KEY
     assert request["rerun_selection"] == [REPAIR_MANIFEST_ASSET_KEY]
     assert request["rerun_mode"] == "repair_only"
+    assert request["scenario_id"] == "phase3_manifest_write_failed"
     assert request["requires_manual_ack"] is True
     assert PHASE3_FORMAL_COMMIT_ASSET_KEY not in request["rerun_selection"]
     assert isinstance(outcome.run_request, dagster.RunRequest)
@@ -224,6 +257,63 @@ def _single_alert_for_failed_node(
     ]
     assert len(matches) == 1
     return matches[0]
+
+
+def test_infra_unavailable_alerts_use_scenario_runbook_for_each_applies_phase(
+    stub_policy_path: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    infra = _load_infra_module()
+    policy = load_gate_policy(stub_policy_path)
+    entry = next(
+        entry
+        for entry in policy.phase_matrix
+        if entry.scenario_id == infra.INFRA_UNAVAILABLE_HARD_STOP_SCENARIO_ID
+    )
+
+    assert entry.applies_to_phases is not None
+    for phase in entry.applies_to_phases:
+        caplog.clear()
+        decision = infra.classify_infrastructure_failure(
+            phase,
+            infra.InfrastructureUnavailableEvent(
+                resource_key=f"{phase.value}_core_store",
+                phase=phase,
+                reason="unavailable",
+            ),
+            policy,
+        )
+
+        dispatch_gate_decision_alert(
+            decision,
+            cycle_id="cycle-20260416",
+            failed_node=f"{phase.value}_core_store",
+            summary="core store unavailable",
+            channels=("logging",),
+        )
+
+        alert = _single_alert_for_failed_node(
+            tuple(alert_payloads(caplog.records)),
+            f"{phase.value}_core_store",
+        )
+        assert alert["phase"] == phase.value
+        assert alert["action"] == "fail_run"
+        assert alert["failure_class"] == FailureClass.INFRA.value
+        assert alert["scenario_id"] == infra.INFRA_UNAVAILABLE_HARD_STOP_SCENARIO_ID
+        assert alert["runbook_url"] == "docs/RUNBOOK_P5.md#phase2-infra-fail_run"
+
+
+def _load_infra_module() -> ModuleType:
+    spec = spec_from_file_location(
+        "_orchestrator_test_infra",
+        REPO_ROOT / "src/orchestrator/resources/infra.py",
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("could not load orchestrator resources infra module")
+    module = module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def _single_rerun_request(outcome: object) -> dict[str, object]:

--- a/tests/integration/test_infra_hard_stop.py
+++ b/tests/integration/test_infra_hard_stop.py
@@ -56,6 +56,8 @@ def test_daily_cycle_hard_stops_on_guarded_resource_init_failure(
     assert payload["phase"] in {"phase0", "phase2"}
     assert payload["failure_class"] == "infra"
     assert payload["action"] == "fail_run"
+    assert payload["scenario_id"] == "infra_unavailable_hard_stop"
+    assert payload["runbook_url"] == "docs/RUNBOOK_P5.md#phase2-infra-fail_run"
     assert payload["failed_node"] == failing_resource_key
     assert f"fake {failing_resource_key} unavailable" in str(payload["summary"])
 
@@ -93,6 +95,8 @@ def test_daily_cycle_alerts_when_gate_policy_resource_load_fails(
     assert payload["phase"] == "phase0"
     assert payload["failure_class"] == "infra"
     assert payload["action"] == "fail_run"
+    assert payload["scenario_id"] == "infra_unavailable_hard_stop"
+    assert payload["runbook_url"] == "docs/RUNBOOK_P5.md#phase2-infra-fail_run"
     assert payload["failed_node"] == "gate_policy"
     assert missing_policy_path.name in str(payload["summary"])
 

--- a/tests/integration/test_phase0_failure_matrix.py
+++ b/tests/integration/test_phase0_failure_matrix.py
@@ -83,11 +83,13 @@ def test_readiness_not_ready_fails_phase0_alerts_and_skips(
     assert decision.phase is PhaseEnum.PHASE0
     assert decision.failure_class is FailureClass.DATA_QUALITY
     assert decision.action is GateAction.FAIL_RUN
+    assert decision.scenario_id == "phase0_data_readiness_delayed"
     assert alert["cycle_id"] == "cycle-20260416"
     assert alert["phase"] == "phase0"
     assert alert["failed_node"] == "phase0_readiness_ping"
     assert alert["action"] == "fail_run"
     assert alert["failure_class"] == "data_quality"
+    assert alert["scenario_id"] == "phase0_data_readiness_delayed"
 
 
 def test_llm_health_failure_emits_failed_check_and_blocks_downstream_phase(
@@ -136,6 +138,10 @@ def test_llm_health_failure_emits_failed_check_and_blocks_downstream_phase(
     assert getattr(llm_evaluation, "passed", None) is False
     assert metadata_value(llm_evaluation, "action") == "fail_run"
     assert metadata_value(llm_evaluation, "failure_class") == "infra"
+    assert (
+        metadata_value(llm_evaluation, "scenario_id")
+        == "phase0_llm_health_check_failed"
+    )
     assert dagster.AssetKey(["phase1_trigger_marker"]) not in asset_materialization_keys(
         result,
     )
@@ -173,6 +179,7 @@ def test_dbt_test_failure_matrix_plans_only_failed_dbt_asset_group(
     assert plan.rerun_selection == (failed_asset_key.to_user_string(),)
     assert plan.requires_manual_ack is False
     assert plan.rerun_mode == "asset_only"
+    assert plan.scenario_id == "phase0_dbt_test_failed"
     assert "dbt_phase0_assets" not in plan.rerun_selection
     assert "phase0_readiness_ping" not in plan.rerun_selection
     assert "candidate_freeze" not in plan.rerun_selection
@@ -245,14 +252,17 @@ def test_dbt_test_failure_dagster_run_emits_gate_alert_observation_and_request(
     assert result.success is False
     assert metadata_value(gate_observation, "action") == "partial_rerun"
     assert metadata_value(gate_observation, "failure_class") == "task_level"
+    assert metadata_value(gate_observation, "scenario_id") == "phase0_dbt_test_failed"
     assert metadata_value(gate_observation, "failed_node") == failed_node
     assert request["run_id"] == result.run_id
     assert request["failed_node"] == failed_node
     assert request["rerun_selection"] == [failed_node]
     assert request["rerun_mode"] == "asset_only"
+    assert request["scenario_id"] == "phase0_dbt_test_failed"
     assert alert["failed_node"] == failed_node
     assert alert["action"] == "partial_rerun"
     assert alert["failure_class"] == "task_level"
+    assert alert["scenario_id"] == "phase0_dbt_test_failed"
 
 
 def test_manual_rerun_request_sensor_minimal_happy_path(

--- a/tests/integration/test_phase1_graph_gate.py
+++ b/tests/integration/test_phase1_graph_gate.py
@@ -101,6 +101,7 @@ def test_phase1_snapshot_failure_alerts_and_does_not_advance_ready_graph(
     assert alert["failed_node"] == "graph_snapshot"
     assert alert["action"] == "fail_run"
     assert alert["failure_class"] == "publish"
+    assert alert["scenario_id"] == "phase1_graph_promotion_snapshot_failed"
     assert "snapshot writer failed after promoted" in str(alert["summary"])
 
 

--- a/tests/integration/test_phase2_inconclusive_path.py
+++ b/tests/integration/test_phase2_inconclusive_path.py
@@ -118,6 +118,10 @@ def test_phase2_single_stock_inconclusive_check_does_not_block_daily_cycle(
     assert dagster.AssetKey(["phase2_stock_MSFT"]) in materialized_keys
     assert getattr(evaluation, "passed", None) is False
     assert metadata_value(evaluation, "action") == "mark_inconclusive"
+    assert (
+        metadata_value(evaluation, "scenario_id")
+        == "phase2_single_stock_task_failed"
+    )
     assert metadata_value(evaluation, "stock_id") == "AAPL"
     assert metadata_value(evaluation, "failure_rate") == 0.1
 

--- a/tests/integration/test_phase2_pool_failure_gate.py
+++ b/tests/integration/test_phase2_pool_failure_gate.py
@@ -64,6 +64,7 @@ def test_daily_cycle_phase2_pool_failure_rate_gate_fails_and_alerts(
             "action": "fail_run",
             "summary": "Phase 2 pool failure rate 0.4 (4/10): fake pool failures",
             "failure_class": "data_quality",
+            "scenario_id": "phase2_pool_failure_rate_exceeded",
             "runbook_url": "docs/RUNBOOK_P5.md#phase2-data_quality-fail_run",
         },
     ]

--- a/tests/integration/test_phase3_manifest_repair_flow.py
+++ b/tests/integration/test_phase3_manifest_repair_flow.py
@@ -137,12 +137,14 @@ def test_daily_cycle_manifest_failure_hook_writes_repair_only_request(
     assert request["rerun_selection"] == [repair_node]
     assert request["rerun_mode"] == "repair_only"
     assert request["requires_manual_ack"] is True
+    assert request["scenario_id"] == "phase3_manifest_write_failed"
 
     assert alert["cycle_id"] == cycle_id
     assert alert["phase"] == "phase3"
     assert alert["failed_node"] == PHASE3_MANIFEST_ASSET_KEY
     assert alert["action"] == "repair_manifest"
     assert alert["failure_class"] == "infra"
+    assert alert["scenario_id"] == "phase3_manifest_write_failed"
     assert str(request_files[0]) in str(alert["summary"])
     assert "fake manifest write failed" in str(alert["summary"])
 
@@ -154,6 +156,7 @@ def test_daily_cycle_manifest_failure_hook_writes_repair_only_request(
         "rerun_of": result.run_id,
         "failed_node": PHASE3_MANIFEST_ASSET_KEY,
         "rerun_mode": "repair_only",
+        "scenario_id": "phase3_manifest_write_failed",
     }
     assert _asset_selection_strings(run_request.asset_selection) == [repair_node]
 

--- a/tests/resources/test_infra_gate.py
+++ b/tests/resources/test_infra_gate.py
@@ -66,6 +66,7 @@ def test_classify_infrastructure_failure_hard_stops_each_phase(
     assert decision.phase is phase
     assert decision.action is GateAction.FAIL_RUN
     assert decision.failure_class.value == "infra"
+    assert decision.scenario_id == infra.INFRA_UNAVAILABLE_HARD_STOP_SCENARIO_ID
     assert decision.reason == (
         "Core storage or graph infrastructure is unavailable; hard stop."
     )

--- a/tests/test_rerun.py
+++ b/tests/test_rerun.py
@@ -71,6 +71,7 @@ def test_partial_rerun_plan_fields_match_runtime_model() -> None:
         "requires_manual_ack",
         "generated_at",
         "rerun_mode",
+        "scenario_id",
     ]
 
 
@@ -98,6 +99,7 @@ def test_plan_partial_rerun_facade_remains_importable_and_frozen() -> None:
     assert plan.rerun_selection == ("phase0_readiness_ping",)
     assert plan.requires_manual_ack is False
     assert plan.rerun_mode == "asset_only"
+    assert plan.scenario_id is None
     assert plan.generated_at.tzinfo is not None
     with pytest.raises(FrozenInstanceError):
         plan.failed_node = "other"
@@ -132,6 +134,7 @@ def test_asset_only_returns_failed_node_without_manual_ack() -> None:
     assert plan.rerun_selection == ("phase2_score_AAPL",)
     assert plan.requires_manual_ack is False
     assert plan.rerun_mode == "asset_only"
+    assert plan.scenario_id == "test_phase2_task_level_partial_rerun_asset_only"
 
 
 def test_phase_only_returns_same_phase_downstream_closure() -> None:


### PR DESCRIPTION
Closes #87

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `scripts/check_boundaries.py`, `src/orchestrator/alerting/dispatcher.py`, `src/orchestrator/alerting/runbooks.py`, `src/orchestrator/checks/dbt_events.py`, `src/orchestrator/checks/phase1.py`, `src/orchestrator/checks/phase2.py`, `src/orchestrator/checks/phase3.py`, `src/orchestrator/diagnostics.py`, `src/orchestrator/jobs/cycle.py`


---
## 背景与目标
Milestone review for milestone-3 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The frozen gate matrix is scenario-based, and runbooks define scenario-specific anchors, but _classify_scenario returns a GateDecision containing only phase/failure_class/action. dispatch_gate_decision_alert then calls with_runbook_url without scenario_id, and diagnostics has no scenario_id field to recover it later. This means actual alerts do not use the scenario mapping added in runbooks.py. In particular, infra_unavailable_hard_stop for phase0/phase1/phase3 will fall back to phase/action anchors, causing phase0 to point at the LLM health runbook and phase1/phase3 to produce anchors that do not exist.

## 实现范围
- 修改文件: `src/orchestrator/checks/decision_handler.py`
- Add scenario_id to GateDecision or an adjacent GateDecisionContext, propagate it from classify_gate_result through specialized classifiers, alert payloads, event metadata, rerun request metadata, and diagnostics. Pass scenario_id into with_runbook_url. Add integration tests that assert the exact runbook_url and scenario_id for every required matrix scenario, including each infra_unavailable_hard_stop applies_to_phases value.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/orchestrator/.venv/bin/python -m pytest
```
