### PR TITLE
feat(#36): orchestrator.temporal workflow 骨架

### DIFF
--- a/src/orchestrator/jobs/__init__.py
+++ b/src/orchestrator/jobs/__init__.py
@@ -1,29 +1,64 @@
 """Dagster job and asset group exports."""
 
-from orchestrator.jobs.audit import (
-    AUDIT_EVAL_GROUP_NAME,
-    RETROSPECTIVE_HOOK_ASSET_KEY,
-)
-from orchestrator.jobs.cycle import build_daily_cycle_jobs, daily_cycle_job
-from orchestrator.jobs.phase0 import (
-    PHASE0_CANDIDATE_FREEZE_ASSET_KEY,
-    PHASE0_GROUP_NAME,
-    PHASE0_READINESS_ASSET_KEY,
-    PHASE0_REQUIRED_ASSET_KEYS,
-    dbt_phase0_assets,
-    phase0_readiness_ping,
-)
-from orchestrator.jobs.phase1 import (
-    PHASE1_GRAPH_PROMOTION_ASSET_KEY,
-    PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
-    PHASE1_GROUP_NAME,
-)
-from orchestrator.jobs.phase2 import PHASE2_GROUP_NAME, PHASE2_STAGE_KEYS
-from orchestrator.jobs.phase3 import (
-    PHASE3_FORMAL_COMMIT_ASSET_KEY,
-    PHASE3_GROUP_NAME,
-    PHASE3_MANIFEST_ASSET_KEY,
-)
+_PUBLIC_JOB_IMPORTS = {
+    "AUDIT_EVAL_GROUP_NAME": ("orchestrator.jobs.audit", "AUDIT_EVAL_GROUP_NAME"),
+    "RETROSPECTIVE_HOOK_ASSET_KEY": (
+        "orchestrator.jobs.audit",
+        "RETROSPECTIVE_HOOK_ASSET_KEY",
+    ),
+    "build_daily_cycle_jobs": (
+        "orchestrator.jobs.cycle",
+        "build_daily_cycle_jobs",
+    ),
+    "daily_cycle_job": ("orchestrator.jobs.cycle", "daily_cycle_job"),
+    "PHASE0_CANDIDATE_FREEZE_ASSET_KEY": (
+        "orchestrator.jobs.phase0",
+        "PHASE0_CANDIDATE_FREEZE_ASSET_KEY",
+    ),
+    "PHASE0_GROUP_NAME": ("orchestrator.jobs.phase0", "PHASE0_GROUP_NAME"),
+    "PHASE0_READINESS_ASSET_KEY": (
+        "orchestrator.jobs.phase0",
+        "PHASE0_READINESS_ASSET_KEY",
+    ),
+    "PHASE0_REQUIRED_ASSET_KEYS": (
+        "orchestrator.jobs.phase0",
+        "PHASE0_REQUIRED_ASSET_KEYS",
+    ),
+    "dbt_phase0_assets": ("orchestrator.jobs.phase0", "dbt_phase0_assets"),
+    "phase0_readiness_ping": (
+        "orchestrator.jobs.phase0",
+        "phase0_readiness_ping",
+    ),
+    "PHASE1_GRAPH_PROMOTION_ASSET_KEY": (
+        "orchestrator.jobs.phase1",
+        "PHASE1_GRAPH_PROMOTION_ASSET_KEY",
+    ),
+    "PHASE1_GRAPH_SNAPSHOT_ASSET_KEY": (
+        "orchestrator.jobs.phase1",
+        "PHASE1_GRAPH_SNAPSHOT_ASSET_KEY",
+    ),
+    "PHASE1_GROUP_NAME": ("orchestrator.jobs.phase1", "PHASE1_GROUP_NAME"),
+    "PHASE2_GROUP_NAME": ("orchestrator.jobs.phase2", "PHASE2_GROUP_NAME"),
+    "PHASE2_STAGE_KEYS": ("orchestrator.jobs.phase2", "PHASE2_STAGE_KEYS"),
+    "PHASE3_FORMAL_COMMIT_ASSET_KEY": (
+        "orchestrator.jobs.phase3",
+        "PHASE3_FORMAL_COMMIT_ASSET_KEY",
+    ),
+    "PHASE3_GROUP_NAME": ("orchestrator.jobs.phase3", "PHASE3_GROUP_NAME"),
+    "PHASE3_MANIFEST_ASSET_KEY": (
+        "orchestrator.jobs.phase3",
+        "PHASE3_MANIFEST_ASSET_KEY",
+    ),
+}
+
+
+def __getattr__(name: str) -> object:
+    if name in _PUBLIC_JOB_IMPORTS:
+        from importlib import import_module
+
+        module_name, attribute_name = _PUBLIC_JOB_IMPORTS[name]
+        return getattr(import_module(module_name), attribute_name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 __all__ = [
     "AUDIT_EVAL_GROUP_NAME",

--- a/src/orchestrator/temporal/__init__.py
+++ b/src/orchestrator/temporal/__init__.py
@@ -1,1 +1,27 @@
+"""Pure Python facade for the optional Phase 1-3 Temporal workflow."""
 
+from orchestrator.temporal.models import (
+    TemporalCycleRequest,
+    TemporalCycleResult,
+    TemporalPhaseResult,
+    TemporalPhaseSpec,
+    TemporalWorkflowStatus,
+)
+from orchestrator.temporal.phase_specs import default_phase1_3_specs
+from orchestrator.temporal.workflow import (
+    TemporalPhaseExecutor,
+    phase_result_should_continue,
+    run_phase1_3_temporal_workflow,
+)
+
+__all__ = [
+    "TemporalCycleRequest",
+    "TemporalCycleResult",
+    "TemporalPhaseExecutor",
+    "TemporalPhaseResult",
+    "TemporalPhaseSpec",
+    "TemporalWorkflowStatus",
+    "default_phase1_3_specs",
+    "phase_result_should_continue",
+    "run_phase1_3_temporal_workflow",
+]

--- a/src/orchestrator/temporal/models.py
+++ b/src/orchestrator/temporal/models.py
@@ -1,0 +1,104 @@
+"""Pure Python models for the optional Phase 1-3 Temporal workflow."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Literal, TypeAlias
+
+from orchestrator.checks.models import GateDecision
+from orchestrator.policy import PhaseEnum
+
+
+TemporalWorkflowStatus: TypeAlias = Literal[
+    "pending",
+    "running",
+    "succeeded",
+    "failed",
+    "skipped",
+    "repair_required",
+]
+
+_EMPTY_MAPPING: Mapping[str, object] = MappingProxyType({})
+_EMPTY_TAGS: Mapping[str, str] = MappingProxyType({})
+
+
+@dataclass(frozen=True, slots=True)
+class TemporalPhaseSpec:
+    """A phase execution boundary passed to a Temporal phase executor."""
+
+    phase: PhaseEnum
+    asset_selection: tuple[str, ...]
+    gate_checks: tuple[str, ...] = ()
+    required_resources: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "asset_selection", tuple(self.asset_selection))
+        object.__setattr__(self, "gate_checks", tuple(self.gate_checks))
+        object.__setattr__(self, "required_resources", tuple(self.required_resources))
+
+
+@dataclass(frozen=True, slots=True)
+class TemporalCycleRequest:
+    """Request shape for the optional Phase 1-3 workflow."""
+
+    cycle_id: str
+    dagster_run_id: str
+    phase0_run_id: str
+    policy_version: str
+    contract_version: str
+    phase_specs: tuple[TemporalPhaseSpec, ...]
+    tags: Mapping[str, str] = _EMPTY_TAGS
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "phase_specs", tuple(self.phase_specs))
+        object.__setattr__(
+            self,
+            "tags",
+            MappingProxyType(dict(self.tags)),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TemporalPhaseResult:
+    """Result returned by a phase executor for one phase."""
+
+    phase: PhaseEnum
+    status: TemporalWorkflowStatus
+    gate_decision: GateDecision | None = None
+    manifest_fields: Mapping[str, object] = _EMPTY_MAPPING
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "manifest_fields",
+            MappingProxyType(dict(self.manifest_fields)),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TemporalCycleResult:
+    """Final Phase 1-3 workflow result."""
+
+    cycle_id: str
+    status: TemporalWorkflowStatus
+    phase_results: tuple[TemporalPhaseResult, ...]
+    manifest_fields: Mapping[str, object]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "phase_results", tuple(self.phase_results))
+        object.__setattr__(
+            self,
+            "manifest_fields",
+            MappingProxyType(dict(self.manifest_fields)),
+        )
+
+
+__all__ = [
+    "TemporalCycleRequest",
+    "TemporalCycleResult",
+    "TemporalPhaseResult",
+    "TemporalPhaseSpec",
+    "TemporalWorkflowStatus",
+]

--- a/src/orchestrator/temporal/phase_specs.py
+++ b/src/orchestrator/temporal/phase_specs.py
@@ -1,0 +1,43 @@
+"""Default Phase 1-3 Temporal execution specs."""
+
+from __future__ import annotations
+
+from orchestrator.jobs.phase1 import (
+    PHASE1_GRAPH_PROMOTION_ASSET_KEY,
+    PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
+)
+from orchestrator.jobs.phase2 import PHASE2_STAGE_KEYS
+from orchestrator.jobs.phase3 import (
+    PHASE3_FORMAL_COMMIT_ASSET_KEY,
+    PHASE3_MANIFEST_ASSET_KEY,
+)
+from orchestrator.policy import PhaseEnum
+from orchestrator.temporal.models import TemporalPhaseSpec
+
+
+def default_phase1_3_specs() -> tuple[TemporalPhaseSpec, ...]:
+    """Return the canonical Phase 1 -> Phase 2 -> Phase 3 execution specs."""
+
+    return (
+        TemporalPhaseSpec(
+            phase=PhaseEnum.PHASE1,
+            asset_selection=(
+                PHASE1_GRAPH_PROMOTION_ASSET_KEY,
+                PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
+            ),
+        ),
+        TemporalPhaseSpec(
+            phase=PhaseEnum.PHASE2,
+            asset_selection=PHASE2_STAGE_KEYS,
+        ),
+        TemporalPhaseSpec(
+            phase=PhaseEnum.PHASE3,
+            asset_selection=(
+                PHASE3_FORMAL_COMMIT_ASSET_KEY,
+                PHASE3_MANIFEST_ASSET_KEY,
+            ),
+        ),
+    )
+
+
+__all__ = ["default_phase1_3_specs"]

--- a/src/orchestrator/temporal/workflow.py
+++ b/src/orchestrator/temporal/workflow.py
@@ -1,0 +1,123 @@
+"""SDK-independent async helper for the optional Phase 1-3 workflow."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from orchestrator.policy import GateAction
+from orchestrator.temporal.models import (
+    TemporalCycleRequest,
+    TemporalCycleResult,
+    TemporalPhaseResult,
+    TemporalPhaseSpec,
+    TemporalWorkflowStatus,
+)
+
+
+class TemporalPhaseExecutor(Protocol):
+    """Protocol implemented by future Temporal handoff and parity executors."""
+
+    async def execute_phase(
+        self,
+        request: TemporalCycleRequest,
+        phase_spec: TemporalPhaseSpec,
+    ) -> TemporalPhaseResult:
+        """Execute one phase and return its normalized result."""
+
+
+def phase_result_should_continue(result: TemporalPhaseResult) -> bool:
+    """Return whether the workflow may advance past a phase result."""
+
+    decision = result.gate_decision
+    if decision is not None:
+        return decision.action in (
+            GateAction.CONTINUE,
+            GateAction.MARK_INCONCLUSIVE,
+        )
+
+    return result.status == "succeeded"
+
+
+async def run_phase1_3_temporal_workflow(
+    request: TemporalCycleRequest,
+    executor: TemporalPhaseExecutor,
+) -> TemporalCycleResult:
+    """Run Phase 1 -> Phase 2 -> Phase 3 through a pure async executor."""
+
+    phase_results: list[TemporalPhaseResult] = []
+    cycle_status: TemporalWorkflowStatus = "succeeded"
+
+    for index, phase_spec in enumerate(request.phase_specs):
+        result = await executor.execute_phase(request, phase_spec)
+        if result.phase is not phase_spec.phase:
+            msg = (
+                "Temporal phase executor returned "
+                f"{result.phase.value!r} for requested phase "
+                f"{phase_spec.phase.value!r}"
+            )
+            raise ValueError(msg)
+
+        phase_results.append(result)
+        if phase_result_should_continue(result):
+            continue
+
+        cycle_status = _cycle_status_from_terminal_phase(result)
+        phase_results.extend(
+            _skipped_phase_results(request.phase_specs[index + 1 :]),
+        )
+        break
+
+    phase_results_tuple = tuple(phase_results)
+    return TemporalCycleResult(
+        cycle_id=request.cycle_id,
+        status=cycle_status,
+        phase_results=phase_results_tuple,
+        manifest_fields=_cycle_manifest_fields(
+            request,
+            phase_results_tuple,
+        ),
+    )
+
+
+def _cycle_status_from_terminal_phase(
+    result: TemporalPhaseResult,
+) -> TemporalWorkflowStatus:
+    decision = result.gate_decision
+    if (
+        result.status == "repair_required"
+        or decision is not None
+        and decision.action is GateAction.REPAIR_MANIFEST
+    ):
+        return "repair_required"
+    return "failed"
+
+
+def _skipped_phase_results(
+    phase_specs: tuple[TemporalPhaseSpec, ...],
+) -> tuple[TemporalPhaseResult, ...]:
+    return tuple(
+        TemporalPhaseResult(phase=phase_spec.phase, status="skipped")
+        for phase_spec in phase_specs
+    )
+
+
+def _cycle_manifest_fields(
+    request: TemporalCycleRequest,
+    phase_results: tuple[TemporalPhaseResult, ...],
+) -> dict[str, object]:
+    return {
+        "cycle_id": request.cycle_id,
+        "policy_version": request.policy_version,
+        "contract_version": request.contract_version,
+        "phase_statuses": tuple(
+            {"phase": result.phase.value, "status": result.status}
+            for result in phase_results
+        ),
+    }
+
+
+__all__ = [
+    "TemporalPhaseExecutor",
+    "phase_result_should_continue",
+    "run_phase1_3_temporal_workflow",
+]

--- a/tests/temporal/test_workflow.py
+++ b/tests/temporal/test_workflow.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+from orchestrator.checks.models import GateDecision
+from orchestrator.jobs.phase1 import (
+    PHASE1_GRAPH_PROMOTION_ASSET_KEY,
+    PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
+)
+from orchestrator.jobs.phase2 import PHASE2_STAGE_KEYS
+from orchestrator.jobs.phase3 import (
+    PHASE3_FORMAL_COMMIT_ASSET_KEY,
+    PHASE3_MANIFEST_ASSET_KEY,
+)
+from orchestrator.policy import FailureClass, GateAction, PhaseEnum
+from orchestrator.temporal import (
+    TemporalCycleRequest,
+    TemporalPhaseResult,
+    TemporalPhaseSpec,
+    default_phase1_3_specs,
+    phase_result_should_continue,
+    run_phase1_3_temporal_workflow,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class RecordingExecutor:
+    def __init__(
+        self,
+        results: Mapping[PhaseEnum, TemporalPhaseResult],
+    ) -> None:
+        self._results = dict(results)
+        self.calls: list[PhaseEnum] = []
+
+    async def execute_phase(
+        self,
+        request: TemporalCycleRequest,
+        phase_spec: TemporalPhaseSpec,
+    ) -> TemporalPhaseResult:
+        del request
+        self.calls.append(phase_spec.phase)
+        return self._results[phase_spec.phase]
+
+
+def test_temporal_facade_import_does_not_require_temporal_sdk() -> None:
+    env = {
+        **os.environ,
+        "PYTHONPATH": str(REPO_ROOT / "src"),
+    }
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "import orchestrator.temporal; "
+                "assert 'temporalio' not in sys.modules; "
+                "print('ok')"
+            ),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.stdout.strip() == "ok"
+
+
+def test_default_phase1_3_specs_use_canonical_asset_constants() -> None:
+    specs = default_phase1_3_specs()
+
+    assert tuple(spec.phase for spec in specs) == (
+        PhaseEnum.PHASE1,
+        PhaseEnum.PHASE2,
+        PhaseEnum.PHASE3,
+    )
+    assert specs[0].asset_selection == (
+        PHASE1_GRAPH_PROMOTION_ASSET_KEY,
+        PHASE1_GRAPH_SNAPSHOT_ASSET_KEY,
+    )
+    assert specs[1].asset_selection == PHASE2_STAGE_KEYS
+    assert specs[2].asset_selection == (
+        PHASE3_FORMAL_COMMIT_ASSET_KEY,
+        PHASE3_MANIFEST_ASSET_KEY,
+    )
+
+
+def test_happy_path_runs_phase1_then_phase2_then_phase3() -> None:
+    request = _request()
+    executor = RecordingExecutor(
+        {
+            PhaseEnum.PHASE1: TemporalPhaseResult(
+                phase=PhaseEnum.PHASE1,
+                status="succeeded",
+            ),
+            PhaseEnum.PHASE2: TemporalPhaseResult(
+                phase=PhaseEnum.PHASE2,
+                status="succeeded",
+            ),
+            PhaseEnum.PHASE3: TemporalPhaseResult(
+                phase=PhaseEnum.PHASE3,
+                status="succeeded",
+            ),
+        }
+    )
+
+    result = asyncio.run(run_phase1_3_temporal_workflow(request, executor))
+
+    assert executor.calls == [PhaseEnum.PHASE1, PhaseEnum.PHASE2, PhaseEnum.PHASE3]
+    assert result.status == "succeeded"
+    assert result.manifest_fields["cycle_id"] == request.cycle_id
+    assert result.manifest_fields["policy_version"] == request.policy_version
+    assert result.manifest_fields["contract_version"] == request.contract_version
+    assert result.manifest_fields["phase_statuses"] == (
+        {"phase": "phase1", "status": "succeeded"},
+        {"phase": "phase2", "status": "succeeded"},
+        {"phase": "phase3", "status": "succeeded"},
+    )
+
+
+def test_phase1_fail_run_stops_and_marks_phase2_and_phase3_skipped() -> None:
+    request = _request()
+    decision = GateDecision(
+        phase=PhaseEnum.PHASE1,
+        failure_class=FailureClass.PUBLISH,
+        action=GateAction.FAIL_RUN,
+        reason="retain previous graph",
+        scenario_id="phase1_graph_promotion_snapshot_failed",
+    )
+    executor = RecordingExecutor(
+        {
+            PhaseEnum.PHASE1: TemporalPhaseResult(
+                phase=PhaseEnum.PHASE1,
+                status="failed",
+                gate_decision=decision,
+            ),
+        }
+    )
+
+    result = asyncio.run(run_phase1_3_temporal_workflow(request, executor))
+
+    assert executor.calls == [PhaseEnum.PHASE1]
+    assert result.status == "failed"
+    assert tuple(phase_result.status for phase_result in result.phase_results) == (
+        "failed",
+        "skipped",
+        "skipped",
+    )
+    assert result.phase_results[0].gate_decision == decision
+
+
+def test_phase2_mark_inconclusive_continues_to_phase3() -> None:
+    request = _request()
+    decision = GateDecision(
+        phase=PhaseEnum.PHASE2,
+        failure_class=FailureClass.TASK_LEVEL,
+        action=GateAction.MARK_INCONCLUSIVE,
+        reason="single stock failed within tolerance",
+        scenario_id="phase2_single_stock_task_failed",
+    )
+    executor = RecordingExecutor(
+        {
+            PhaseEnum.PHASE1: TemporalPhaseResult(
+                phase=PhaseEnum.PHASE1,
+                status="succeeded",
+            ),
+            PhaseEnum.PHASE2: TemporalPhaseResult(
+                phase=PhaseEnum.PHASE2,
+                status="failed",
+                gate_decision=decision,
+            ),
+            PhaseEnum.PHASE3: TemporalPhaseResult(
+                phase=PhaseEnum.PHASE3,
+                status="succeeded",
+            ),
+        }
+    )
+
+    result = asyncio.run(run_phase1_3_temporal_workflow(request, executor))
+
+    assert executor.calls == [PhaseEnum.PHASE1, PhaseEnum.PHASE2, PhaseEnum.PHASE3]
+    assert result.status == "succeeded"
+    assert result.phase_results[1].gate_decision == decision
+    assert phase_result_should_continue(result.phase_results[1]) is True
+
+
+def test_phase3_repair_manifest_returns_repair_required_with_scenario_id() -> None:
+    request = _request()
+    decision = GateDecision(
+        phase=PhaseEnum.PHASE3,
+        failure_class=FailureClass.INFRA,
+        action=GateAction.REPAIR_MANIFEST,
+        reason="manifest write failed",
+        scenario_id="phase3_manifest_write_failed",
+    )
+    executor = RecordingExecutor(
+        {
+            PhaseEnum.PHASE1: TemporalPhaseResult(
+                phase=PhaseEnum.PHASE1,
+                status="succeeded",
+            ),
+            PhaseEnum.PHASE2: TemporalPhaseResult(
+                phase=PhaseEnum.PHASE2,
+                status="succeeded",
+            ),
+            PhaseEnum.PHASE3: TemporalPhaseResult(
+                phase=PhaseEnum.PHASE3,
+                status="repair_required",
+                gate_decision=decision,
+            ),
+        }
+    )
+
+    result = asyncio.run(run_phase1_3_temporal_workflow(request, executor))
+
+    assert executor.calls == [PhaseEnum.PHASE1, PhaseEnum.PHASE2, PhaseEnum.PHASE3]
+    assert result.status == "repair_required"
+    assert result.phase_results[2].gate_decision == decision
+    assert result.phase_results[2].gate_decision is not None
+    assert result.phase_results[2].gate_decision.scenario_id == (
+        "phase3_manifest_write_failed"
+    )
+
+
+def test_non_continue_gate_decision_retains_full_runtime_identity() -> None:
+    decision = GateDecision(
+        phase=PhaseEnum.PHASE3,
+        failure_class=FailureClass.PUBLISH,
+        action=GateAction.FAIL_RUN,
+        reason="formal commit failed",
+        scenario_id="phase3_formal_commit_failed",
+    )
+    phase_result = TemporalPhaseResult(
+        phase=PhaseEnum.PHASE3,
+        status="failed",
+        gate_decision=decision,
+    )
+
+    assert phase_result.gate_decision == decision
+    assert phase_result.gate_decision.scenario_id == "phase3_formal_commit_failed"
+    assert phase_result.gate_decision.failure_class is FailureClass.PUBLISH
+    assert phase_result.gate_decision.action is GateAction.FAIL_RUN
+    assert phase_result.gate_decision.reason == "formal commit failed"
+
+
+def test_cycle_manifest_excludes_backend_runtime_ids() -> None:
+    request = _request(
+        tags={
+            "temporal_workflow_id": "workflow-cycle-20260416",
+            "temporal_run_id": "temporal-run-1",
+        }
+    )
+    executor = RecordingExecutor(
+        {
+            PhaseEnum.PHASE1: TemporalPhaseResult(
+                phase=PhaseEnum.PHASE1,
+                status="succeeded",
+                manifest_fields={"temporal_workflow_id": "phase1-workflow"},
+            ),
+            PhaseEnum.PHASE2: TemporalPhaseResult(
+                phase=PhaseEnum.PHASE2,
+                status="succeeded",
+                manifest_fields={"temporal_run_id": "phase2-run"},
+            ),
+            PhaseEnum.PHASE3: TemporalPhaseResult(
+                phase=PhaseEnum.PHASE3,
+                status="succeeded",
+            ),
+        }
+    )
+
+    result = asyncio.run(run_phase1_3_temporal_workflow(request, executor))
+
+    assert "temporal_workflow_id" not in result.manifest_fields
+    assert "temporal_run_id" not in result.manifest_fields
+    assert result.manifest_fields["cycle_id"] == "cycle-20260416"
+
+
+def _request(
+    tags: Mapping[str, str] | None = None,
+) -> TemporalCycleRequest:
+    return TemporalCycleRequest(
+        cycle_id="cycle-20260416",
+        dagster_run_id="dagster-run-1",
+        phase0_run_id="phase0-run-1",
+        policy_version="lite-0.1",
+        contract_version="stub-0.1",
+        phase_specs=default_phase1_3_specs(),
+        tags=tags or {},
+    )


### PR DESCRIPTION
Closes #36

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `scripts/check_boundaries.py`, `src/orchestrator/checks/phase1.py`, `src/orchestrator/checks/phase3.py`, `src/orchestrator/jobs/cycle.py`, `src/orchestrator/resources/infra.py`, `src/orchestrator/sensors/manual_rerun.py`, `tests/cli/__init__.py`, `tests/integration/test_daily_cycle_four_phase.py`, `tests/test_definitions.py`


---
### 1. 背景与目标
`docs/orchestrator.project-doc.md` §14、§21 把 `orchestrator.temporal` 定义为 P5+ 可选扩展，只能包装 Phase 1-3 pause/resume 语义，不能改变 `graph-engine`、`main-core`、`audit-eval` 的公开工厂接口。当前代码中 `src/orchestrator/temporal/__init__.py` 只有占位内容，而 Phase 1/2/3 的实际边界已经通过 `src/orchestrator/jobs/phase1.py`、`src/orchestrator/jobs/phase2.py`、`src/orchestrator/jobs/phase3.py` 常量以及 `src/orchestrator/checks/phase1.py`、`src/orchestrator/checks/phase2.py`、`src/orchestrator/checks/phase3.py` 的 Gate adapter 固化。目标是先建立一个 SDK-independent 的 Temporal workflow 骨架，让后续 handoff 和 parity test 可以复用统一的 Phase 1-3 请求/结果模型。该骨架必须保持 `execution_backend == dagster_only` 时不加载 Temporal SDK，也不引入业务模块私有 import。

### 2. 所属模块
主写入路径：
- `src/orchestrator/temporal/__init__.py`
- `src/orchestrator/temporal/models.py`（新建）
- `src/orchestrator/temporal/phase_specs.py`（新建）
- `src/orchestrator/temporal/workflow.py`（新建）
- `tests/temporal/test_workflow.py`（新建）
- `tests/test_public_api.py`（仅在需要暴露 public import facade 时小幅更新）

相邻只读 / 集成路径：
- `src/orchestrator/jobs/phase1.py`
- `src/orchestrator/jobs/phase2.py`
- `src/orchestrator/jobs/phase3.py`
- `src/orchestrator/checks/models.py`
- `src/orchestrator/checks/phase1.py`
- `src/orchestrator/checks/phase2.py`
- `src/orchestrator/checks/phase3.py`
- `src/orchestrator/policy/schema.py`

### 3. 实现范围
- 扩展 `src/orchestrator/temporal/__init__.py`，只导出本 issue 新增的纯 Python dataclass / protocol / workflow helper；模块 import 不得直接 import `temporalio`。
- 新建 `src/orchestrator/temporal/models.py`，定义 Phase 1-3 workflow 请求、阶段结果、cycle 结果与状态 Literal，字段使用现有 `orchestrator.policy.PhaseEnum`、`orchestrator.policy.GateAction`、`orchestrator.checks.models.GateDecision`。
- 新建 `src/orchestrator/temporal/phase_specs.py`，从 `PHASE1_GRAPH_PROMOTION_ASSET_KEY`、`PHASE1_GRAPH_SNAPSHOT_ASSET_KEY`、`PHASE2_STAGE_KEYS`、`PHASE3_FORMAL_COMMIT_ASSET_KEY`、`PHASE3_MANIFEST_ASSET_KEY` 生成默认 Phase 1-3 specs。
- 新建 `src/orchestrator/temporal/workflow.py`，实现顺序执行 Phase 1 -> Phase 2 -> Phase 3 的纯 async workflow helper，不直接调用 Dagster、Tempor