### PR TITLE
feat(#37): execution_backend 切换配置与 handoff

### DIFF
--- a/src/orchestrator/definitions.py
+++ b/src/orchestrator/definitions.py
@@ -25,7 +25,7 @@ from orchestrator.jobs.audit import (
     AUDIT_EVAL_GROUP_NAME,
     RETROSPECTIVE_HOOK_ASSET_KEY,
 )
-from orchestrator.jobs.cycle import daily_cycle_job
+from orchestrator.jobs.cycle import build_daily_cycle_jobs
 from orchestrator.jobs.phase0 import (
     DBT_PROFILES_DIR,
     DBT_PROJECT_DIR,
@@ -46,19 +46,21 @@ from orchestrator.jobs.phase3 import (
     PHASE3_GROUP_NAME,
     PHASE3_MANIFEST_ASSET_KEY,
 )
+from orchestrator.policy import load_gate_policy
 from orchestrator.resources import (
     INFRASTRUCTURE_RESOURCE_PHASES,
     AssetFactoryProvider,
     build_resource_bundle,
     guard_infrastructure_resource,
 )
-from orchestrator.schedules import daily_cycle_schedule
+from orchestrator.schedules import build_daily_cycle_schedule
 from orchestrator.sensors.data_readiness import (
     DATA_READINESS_PROVIDER_RESOURCE_KEY,
     DATA_READINESS_RESOURCE_KEY,
-    data_readiness_sensor,
+    build_data_readiness_sensor,
 )
 from orchestrator.sensors.manual_rerun import manual_rerun_sensor
+from orchestrator.sensors.temporal_handoff import build_temporal_handoff_sensor
 
 DEFAULT_POLICY_PATH = "config/policy/gate_policy.lite.yaml"
 _RESERVED_RESOURCE_KEYS = ("gate_policy", "dbt", "resource_bundle")
@@ -186,6 +188,15 @@ def build_definitions(
             DEFAULT_POLICY_PATH,
         )
     module_factory_list = _resolve_module_factories(module_factories)
+    policy = load_gate_policy(policy_path)
+    phase_config = {"execution_backend": policy.execution_backend}
+    daily_cycle_jobs = build_daily_cycle_jobs(phase_config)
+    automatic_cycle_job = daily_cycle_jobs[0]
+    daily_cycle_schedule = build_daily_cycle_schedule(automatic_cycle_job)
+    data_readiness_sensor = build_data_readiness_sensor(automatic_cycle_job)
+    sensors: list[object] = [data_readiness_sensor, manual_rerun_sensor]
+    if policy.execution_backend == "dagster_plus_temporal":
+        sensors.append(build_temporal_handoff_sensor(policy=policy))
 
     resource_bundle = build_resource_bundle(str(policy_path), module_factory_list)
     for reserved in _RESERVED_RESOURCE_KEYS:
@@ -249,9 +260,9 @@ def build_definitions(
             *builtin_checks,
             *provider_checks,
         ],
-        jobs=[daily_cycle_job],
+        jobs=list(daily_cycle_jobs),
         schedules=[daily_cycle_schedule],
-        sensors=[data_readiness_sensor, manual_rerun_sensor],
+        sensors=sensors,
         resources=resources,
     )
 

--- a/src/orchestrator/jobs/__init__.py
+++ b/src/orchestrator/jobs/__init__.py
@@ -11,6 +11,10 @@ _PUBLIC_JOB_IMPORTS = {
         "build_daily_cycle_jobs",
     ),
     "daily_cycle_job": ("orchestrator.jobs.cycle", "daily_cycle_job"),
+    "daily_cycle_phase0_job": (
+        "orchestrator.jobs.cycle",
+        "daily_cycle_phase0_job",
+    ),
     "PHASE0_CANDIDATE_FREEZE_ASSET_KEY": (
         "orchestrator.jobs.phase0",
         "PHASE0_CANDIDATE_FREEZE_ASSET_KEY",
@@ -77,6 +81,7 @@ __all__ = [
     "RETROSPECTIVE_HOOK_ASSET_KEY",
     "build_daily_cycle_jobs",
     "daily_cycle_job",
+    "daily_cycle_phase0_job",
     "dbt_phase0_assets",
     "phase0_readiness_ping",
 ]

--- a/src/orchestrator/jobs/cycle.py
+++ b/src/orchestrator/jobs/cycle.py
@@ -210,15 +210,30 @@ daily_cycle_job = define_asset_job(
 )
 
 
+daily_cycle_phase0_job = define_asset_job(
+    name="daily_cycle_phase0_job",
+    selection=AssetSelection.groups(PHASE0_GROUP_NAME),
+)
+
+
 def build_daily_cycle_jobs(
     phase_config: Mapping[str, Any] | None,
 ) -> tuple[object, ...]:
     """Build daily cycle jobs from the phase configuration facade."""
 
-    return (daily_cycle_job,)
+    execution_backend = (
+        phase_config.get("execution_backend") if phase_config is not None else None
+    )
+    if execution_backend in (None, "dagster_only"):
+        return (daily_cycle_job,)
+    if execution_backend == "dagster_plus_temporal":
+        return (daily_cycle_phase0_job, daily_cycle_job)
+
+    raise ValueError(f"unsupported execution_backend: {execution_backend!r}")
 
 
 __all__ = [
     "build_daily_cycle_jobs",
     "daily_cycle_job",
+    "daily_cycle_phase0_job",
 ]

--- a/src/orchestrator/schedules/__init__.py
+++ b/src/orchestrator/schedules/__init__.py
@@ -1,5 +1,8 @@
 """Dagster schedule exports."""
 
-from orchestrator.schedules.daily_cycle import daily_cycle_schedule
+from orchestrator.schedules.daily_cycle import (
+    build_daily_cycle_schedule,
+    daily_cycle_schedule,
+)
 
-__all__ = ["daily_cycle_schedule"]
+__all__ = ["build_daily_cycle_schedule", "daily_cycle_schedule"]

--- a/src/orchestrator/schedules/daily_cycle.py
+++ b/src/orchestrator/schedules/daily_cycle.py
@@ -8,12 +8,23 @@ from orchestrator.jobs.cycle import daily_cycle_job
 _DAILY_CYCLE_CRON = "0 17 * * 1-5"
 _DAILY_CYCLE_TIMEZONE = "Asia/Shanghai"
 
-daily_cycle_schedule = ScheduleDefinition(
-    job=daily_cycle_job,
-    cron_schedule=_DAILY_CYCLE_CRON,
-    execution_timezone=_DAILY_CYCLE_TIMEZONE,
-    name="daily_cycle_schedule",
-)
+
+def build_daily_cycle_schedule(
+    job: object,
+    *,
+    name: str = "daily_cycle_schedule",
+) -> ScheduleDefinition:
+    """Build the daily cycle schedule for the selected automatic entrypoint."""
+
+    return ScheduleDefinition(
+        job=job,
+        cron_schedule=_DAILY_CYCLE_CRON,
+        execution_timezone=_DAILY_CYCLE_TIMEZONE,
+        name=name,
+    )
 
 
-__all__ = ["daily_cycle_schedule"]
+daily_cycle_schedule = build_daily_cycle_schedule(daily_cycle_job)
+
+
+__all__ = ["build_daily_cycle_schedule", "daily_cycle_schedule"]

--- a/src/orchestrator/sensors/__init__.py
+++ b/src/orchestrator/sensors/__init__.py
@@ -1,6 +1,25 @@
 """Dagster sensor exports."""
 
-from orchestrator.sensors.data_readiness import data_readiness_sensor
+from orchestrator.sensors.data_readiness import (
+    build_data_readiness_sensor,
+    data_readiness_sensor,
+    evaluate_data_readiness_sensor,
+)
 from orchestrator.sensors.manual_rerun import manual_rerun_sensor
+from orchestrator.sensors.temporal_handoff import (
+    TEMPORAL_HANDOFF_CLIENT_RESOURCE_KEY,
+    build_temporal_handoff_sensor,
+    evaluate_temporal_handoff_sensor,
+    temporal_handoff_sensor,
+)
 
-__all__ = ["data_readiness_sensor", "manual_rerun_sensor"]
+__all__ = [
+    "TEMPORAL_HANDOFF_CLIENT_RESOURCE_KEY",
+    "build_data_readiness_sensor",
+    "build_temporal_handoff_sensor",
+    "data_readiness_sensor",
+    "evaluate_data_readiness_sensor",
+    "evaluate_temporal_handoff_sensor",
+    "manual_rerun_sensor",
+    "temporal_handoff_sensor",
+]

--- a/src/orchestrator/sensors/data_readiness.py
+++ b/src/orchestrator/sensors/data_readiness.py
@@ -47,14 +47,11 @@ class _DataReadinessGateEvent:
     reason: str | None = None
 
 
-@sensor(
-    job=daily_cycle_job,
-    name="data_readiness_sensor",
-    required_resource_keys=DATA_READINESS_SENSOR_REQUIRED_RESOURCE_KEYS,
-)
-def data_readiness_sensor(
+def evaluate_data_readiness_sensor(
     context: SensorEvaluationContext,
 ) -> RunRequest | SkipReason:
+    """Evaluate data readiness independent of the target Dagster job."""
+
     signal = _read_data_readiness_signal(context)
 
     if signal.ready:
@@ -87,6 +84,29 @@ def data_readiness_sensor(
     if signal.reason:
         return SkipReason(f"data readiness not ready: {signal.reason}")
     return SkipReason("data readiness not ready")
+
+
+def build_data_readiness_sensor(
+    job: object,
+    *,
+    name: str = "data_readiness_sensor",
+) -> object:
+    """Build a data readiness sensor targeting the selected cycle entrypoint."""
+
+    @sensor(
+        job=job,
+        name=name,
+        required_resource_keys=DATA_READINESS_SENSOR_REQUIRED_RESOURCE_KEYS,
+    )
+    def _data_readiness_sensor(
+        context: SensorEvaluationContext,
+    ) -> RunRequest | SkipReason:
+        return evaluate_data_readiness_sensor(context)
+
+    return _data_readiness_sensor
+
+
+data_readiness_sensor = build_data_readiness_sensor(daily_cycle_job)
 
 
 def _read_data_readiness_signal(
@@ -198,5 +218,7 @@ __all__ = [
     "DATA_READINESS_RESOURCE_KEY",
     "DATA_READINESS_SENSOR_REQUIRED_RESOURCE_KEYS",
     "GATE_POLICY_RESOURCE_KEY",
+    "build_data_readiness_sensor",
     "data_readiness_sensor",
+    "evaluate_data_readiness_sensor",
 ]

--- a/src/orchestrator/sensors/temporal_handoff.py
+++ b/src/orchestrator/sensors/temporal_handoff.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Any
 
 from dagster import RunRequest, SensorEvaluationContext, SkipReason, sensor
@@ -23,8 +25,26 @@ GATE_POLICY_RESOURCE_KEY = "gate_policy"
 RESOURCE_BUNDLE_RESOURCE_KEY = "resource_bundle"
 TEMPORAL_HANDOFF_SENSOR_NAME = "temporal_handoff_sensor"
 TEMPORAL_HANDOFF_SENSOR_REQUIRED_RESOURCE_KEYS = frozenset(
-    {GATE_POLICY_RESOURCE_KEY},
+    {
+        GATE_POLICY_RESOURCE_KEY,
+        RESOURCE_BUNDLE_RESOURCE_KEY,
+        TEMPORAL_HANDOFF_CLIENT_RESOURCE_KEY,
+    },
 )
+_TEMPORAL_HANDOFF_CURSOR_VERSION = 1
+_TEMPORAL_WORKFLOW_ID_TAG = "temporal_workflow_id"
+
+
+@dataclass(frozen=True, slots=True)
+class _HandoffCursor:
+    processed_run_ids: frozenset[str] = frozenset()
+    high_water_timestamp: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _Phase0RunCandidate:
+    raw_run: object
+    run: object
 
 
 def evaluate_temporal_handoff_sensor(
@@ -104,16 +124,15 @@ def build_temporal_handoff_sensor(
     def _temporal_handoff_sensor(
         context: SensorEvaluationContext,
     ) -> RunRequest | SkipReason:
-        phase0_run = _latest_successful_phase0_run(context, phase0_job_name)
-        if phase0_run is None:
+        cursor = _parse_handoff_cursor(context.cursor)
+        candidate = _latest_successful_phase0_run(context, phase0_job_name, cursor)
+        if candidate is None:
             return SkipReason(
                 f"no successful {phase0_job_name} run is ready for Temporal handoff",
             )
 
+        phase0_run = candidate.run
         phase0_run_id = _run_id(phase0_run)
-        if context.cursor == phase0_run_id:
-            return SkipReason(f"Temporal handoff already evaluated for {phase0_run_id}")
-
         run_tags = _string_tags(_run_tags(phase0_run))
         cycle_id = _cycle_id_from_run(phase0_run, run_tags)
         result = evaluate_temporal_handoff_sensor(
@@ -121,13 +140,23 @@ def build_temporal_handoff_sensor(
             phase0_run_id=phase0_run_id,
             dagster_run_id=phase0_run_id,
             cycle_id=cycle_id,
-            tags=run_tags,
+            tags=_temporal_handoff_tags(
+                run_tags,
+                cycle_id=cycle_id,
+                phase0_run_id=phase0_run_id,
+            ),
             client=_handoff_client_from_context(context),
             failover_mode=failover_mode,
             failover_job_name=failover_job_name,
         )
         if _handoff_result_consumed_phase0_run(result):
-            context.update_cursor(phase0_run_id)
+            context.update_cursor(
+                _advance_handoff_cursor(
+                    cursor,
+                    raw_run=candidate.raw_run,
+                    run=phase0_run,
+                )
+            )
         return result
 
     return _temporal_handoff_sensor
@@ -174,27 +203,45 @@ def _handoff_result_consumed_phase0_run(result: RunRequest | SkipReason) -> bool
 def _latest_successful_phase0_run(
     context: SensorEvaluationContext,
     phase0_job_name: str,
-) -> object | None:
+    cursor: _HandoffCursor,
+) -> _Phase0RunCandidate | None:
     instance = getattr(context, "instance", None)
     if instance is None:
         return None
 
+    candidates: list[_Phase0RunCandidate] = []
     for raw_run in _query_runs(instance, phase0_job_name):
         run = _dagster_run(raw_run)
-        if _run_id_or_none(run) == context.cursor:
-            continue
         if _run_job_name(run) != phase0_job_name:
             continue
         if not _run_succeeded(run):
             continue
-        return run
+        if _cursor_consumed_phase0_run(cursor, raw_run=raw_run, run=run):
+            if cursor.high_water_timestamp is None:
+                break
+            continue
+        candidates.append(_Phase0RunCandidate(raw_run=raw_run, run=run))
 
-    return None
+    if not candidates:
+        return None
+
+    candidates_with_timestamps = [
+        candidate
+        for candidate in candidates
+        if _run_timestamp(candidate.raw_run, candidate.run) is not None
+    ]
+    if candidates_with_timestamps:
+        return max(
+            candidates_with_timestamps,
+            key=lambda candidate: _run_timestamp(candidate.raw_run, candidate.run)
+            or 0.0,
+        )
+    return candidates[0]
 
 
 def _query_runs(instance: object, phase0_job_name: str) -> tuple[object, ...]:
     filters = _runs_filter(phase0_job_name)
-    for method_name in ("get_runs", "get_run_records"):
+    for method_name in ("get_run_records", "get_runs"):
         method = getattr(instance, method_name, None)
         if not callable(method):
             continue
@@ -283,6 +330,154 @@ def _cycle_id_from_run(run: object, tags: Mapping[str, str]) -> str:
     if cycle_id:
         return cycle_id
     return _run_id(run)
+
+
+def _parse_handoff_cursor(raw_cursor: str | None) -> _HandoffCursor:
+    if not raw_cursor:
+        return _HandoffCursor()
+
+    try:
+        decoded = json.loads(raw_cursor)
+    except json.JSONDecodeError:
+        return _HandoffCursor(processed_run_ids=frozenset({raw_cursor}))
+
+    if not isinstance(decoded, Mapping):
+        return _HandoffCursor(processed_run_ids=frozenset({raw_cursor}))
+
+    processed_run_ids = {
+        value
+        for value in decoded.get("processed_run_ids", ())
+        if isinstance(value, str) and value
+    }
+    last_run_id = decoded.get("last_run_id")
+    if isinstance(last_run_id, str) and last_run_id:
+        processed_run_ids.add(last_run_id)
+
+    high_water_timestamp = decoded.get("high_water_timestamp")
+    if isinstance(high_water_timestamp, bool):
+        timestamp = None
+    elif isinstance(high_water_timestamp, (int, float)):
+        timestamp = float(high_water_timestamp)
+    else:
+        timestamp = None
+
+    return _HandoffCursor(
+        processed_run_ids=frozenset(processed_run_ids),
+        high_water_timestamp=timestamp,
+    )
+
+
+def _advance_handoff_cursor(
+    cursor: _HandoffCursor,
+    *,
+    raw_run: object,
+    run: object,
+) -> str:
+    run_id = _run_id(run)
+    processed_run_ids = set(cursor.processed_run_ids)
+    processed_run_ids.add(run_id)
+
+    run_timestamp = _run_timestamp(raw_run, run)
+    high_water_timestamp = cursor.high_water_timestamp
+    if run_timestamp is not None:
+        high_water_timestamp = max(
+            high_water_timestamp if high_water_timestamp is not None else run_timestamp,
+            run_timestamp,
+        )
+
+    payload: dict[str, object] = {
+        "version": _TEMPORAL_HANDOFF_CURSOR_VERSION,
+        "last_run_id": run_id,
+        "processed_run_ids": sorted(processed_run_ids),
+    }
+    if high_water_timestamp is not None:
+        payload["high_water_timestamp"] = high_water_timestamp
+
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True)
+
+
+def _cursor_consumed_phase0_run(
+    cursor: _HandoffCursor,
+    *,
+    raw_run: object,
+    run: object,
+) -> bool:
+    run_id = _run_id_or_none(run)
+    if run_id is not None and run_id in cursor.processed_run_ids:
+        return True
+
+    run_timestamp = _run_timestamp(raw_run, run)
+    return (
+        cursor.high_water_timestamp is not None
+        and run_timestamp is not None
+        and run_timestamp <= cursor.high_water_timestamp
+    )
+
+
+def _run_timestamp(raw_run: object, run: object) -> float | None:
+    for source in (raw_run, run):
+        for attribute_name in (
+            "create_timestamp",
+            "start_time",
+            "end_time",
+            "update_timestamp",
+            "timestamp",
+        ):
+            value = _mapping_or_attr(source, attribute_name)
+            parsed = _timestamp_value(value)
+            if parsed is not None:
+                return parsed
+    return None
+
+
+def _timestamp_value(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+
+    timestamp = getattr(value, "timestamp", None)
+    if callable(timestamp):
+        parsed = timestamp()
+        if isinstance(parsed, (int, float)):
+            return float(parsed)
+    return None
+
+
+def _temporal_handoff_tags(
+    tags: Mapping[str, str],
+    *,
+    cycle_id: str,
+    phase0_run_id: str,
+) -> dict[str, str]:
+    handoff_tags = dict(tags)
+    handoff_tags.setdefault(
+        _TEMPORAL_WORKFLOW_ID_TAG,
+        _deterministic_temporal_workflow_id(
+            cycle_id=cycle_id,
+            phase0_run_id=phase0_run_id,
+        ),
+    )
+    return handoff_tags
+
+
+def _deterministic_temporal_workflow_id(
+    *,
+    cycle_id: str,
+    phase0_run_id: str,
+) -> str:
+    return (
+        "orchestrator-cycle-"
+        f"{_workflow_id_component(cycle_id)}-"
+        f"phase1-3-{_workflow_id_component(phase0_run_id)}"
+    )
+
+
+def _workflow_id_component(value: str) -> str:
+    return "".join(
+        character if character.isalnum() or character in {"-", "_"} else "-"
+        for character in value
+    ).strip("-") or "unknown"
 
 
 def _gate_policy_from_context(context: SensorEvaluationContext) -> GatePolicyProfile:

--- a/src/orchestrator/sensors/temporal_handoff.py
+++ b/src/orchestrator/sensors/temporal_handoff.py
@@ -410,7 +410,7 @@ def _cursor_consumed_phase0_run(
     return (
         cursor.high_water_timestamp is not None
         and run_timestamp is not None
-        and run_timestamp <= cursor.high_water_timestamp
+        and run_timestamp < cursor.high_water_timestamp
     )
 
 

--- a/src/orchestrator/sensors/temporal_handoff.py
+++ b/src/orchestrator/sensors/temporal_handoff.py
@@ -1,0 +1,375 @@
+"""Temporal handoff sensor for successful Phase 0 Dagster runs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from dagster import RunRequest, SensorEvaluationContext, SkipReason, sensor
+
+from orchestrator.jobs.cycle import daily_cycle_job, daily_cycle_phase0_job
+from orchestrator.policy import GatePolicyProfile
+from orchestrator.temporal.handoff import (
+    DefaultTemporalHandoffClient,
+    TEMPORAL_HANDOFF_CLIENT_RESOURCE_KEY,
+    TemporalFailoverMode,
+    TemporalHandoffClient,
+    TemporalHandoffStartError,
+    start_temporal_handoff,
+)
+
+
+GATE_POLICY_RESOURCE_KEY = "gate_policy"
+RESOURCE_BUNDLE_RESOURCE_KEY = "resource_bundle"
+TEMPORAL_HANDOFF_SENSOR_NAME = "temporal_handoff_sensor"
+TEMPORAL_HANDOFF_SENSOR_REQUIRED_RESOURCE_KEYS = frozenset(
+    {GATE_POLICY_RESOURCE_KEY},
+)
+
+
+def evaluate_temporal_handoff_sensor(
+    *,
+    policy: GatePolicyProfile,
+    phase0_run_id: str,
+    dagster_run_id: str,
+    cycle_id: str,
+    tags: Mapping[str, str],
+    client: TemporalHandoffClient | None = None,
+    failover_mode: TemporalFailoverMode = "failed_over",
+    failover_job_name: str = "daily_cycle_job",
+) -> RunRequest | SkipReason:
+    """Evaluate a single successful Phase 0 run for Temporal handoff."""
+
+    if policy.execution_backend != "dagster_plus_temporal":
+        return SkipReason("temporal handoff disabled for dagster_only backend")
+
+    active_client = client or DefaultTemporalHandoffClient(
+        failover_mode=failover_mode,
+    )
+    try:
+        result = start_temporal_handoff(
+            policy=policy,
+            phase0_run_id=phase0_run_id,
+            dagster_run_id=dagster_run_id,
+            cycle_id=cycle_id,
+            tags=tags,
+            client=active_client,
+        )
+    except TemporalHandoffStartError as exc:
+        if failover_mode == "failed_over":
+            return _failover_run_request(
+                failover_job_name=failover_job_name,
+                phase0_run_id=phase0_run_id,
+                cycle_id=cycle_id,
+                tags=tags,
+                reason=str(exc),
+            )
+        return SkipReason(f"temporal handoff deferred: {exc}")
+
+    if result.status == "started":
+        workflow_id = result.workflow_id or "unknown-workflow"
+        return SkipReason(f"temporal handoff started: {workflow_id}")
+    if result.status == "deferred":
+        return SkipReason(
+            "temporal handoff deferred"
+            + (f": {result.reason}" if result.reason else ""),
+        )
+    return _failover_run_request(
+        failover_job_name=failover_job_name,
+        phase0_run_id=phase0_run_id,
+        cycle_id=cycle_id,
+        tags=tags,
+        reason=result.reason,
+    )
+
+
+def build_temporal_handoff_sensor(
+    *,
+    policy: GatePolicyProfile | None = None,
+    phase0_job: object = daily_cycle_phase0_job,
+    failover_job: object = daily_cycle_job,
+    name: str = TEMPORAL_HANDOFF_SENSOR_NAME,
+    failover_mode: TemporalFailoverMode = "failed_over",
+) -> object:
+    """Build the sensor that hands successful Phase 0 runs to Temporal."""
+
+    phase0_job_name = _job_name(phase0_job)
+    failover_job_name = _job_name(failover_job)
+
+    @sensor(
+        job=failover_job,
+        name=name,
+        required_resource_keys=TEMPORAL_HANDOFF_SENSOR_REQUIRED_RESOURCE_KEYS,
+    )
+    def _temporal_handoff_sensor(
+        context: SensorEvaluationContext,
+    ) -> RunRequest | SkipReason:
+        phase0_run = _latest_successful_phase0_run(context, phase0_job_name)
+        if phase0_run is None:
+            return SkipReason(
+                f"no successful {phase0_job_name} run is ready for Temporal handoff",
+            )
+
+        phase0_run_id = _run_id(phase0_run)
+        if context.cursor == phase0_run_id:
+            return SkipReason(f"Temporal handoff already evaluated for {phase0_run_id}")
+
+        run_tags = _string_tags(_run_tags(phase0_run))
+        cycle_id = _cycle_id_from_run(phase0_run, run_tags)
+        result = evaluate_temporal_handoff_sensor(
+            policy=policy or _gate_policy_from_context(context),
+            phase0_run_id=phase0_run_id,
+            dagster_run_id=phase0_run_id,
+            cycle_id=cycle_id,
+            tags=run_tags,
+            client=_handoff_client_from_context(context),
+            failover_mode=failover_mode,
+            failover_job_name=failover_job_name,
+        )
+        if _handoff_result_consumed_phase0_run(result):
+            context.update_cursor(phase0_run_id)
+        return result
+
+    return _temporal_handoff_sensor
+
+
+temporal_handoff_sensor = build_temporal_handoff_sensor()
+
+
+def _failover_run_request(
+    *,
+    failover_job_name: str,
+    phase0_run_id: str,
+    cycle_id: str,
+    tags: Mapping[str, str],
+    reason: str | None,
+) -> RunRequest:
+    failover_tags = dict(tags)
+    failover_tags.update(
+        {
+            "execution_backend": "dagster_only",
+            "temporal_failover_of": phase0_run_id,
+            "cycle_id": cycle_id,
+        }
+    )
+    if reason:
+        failover_tags.setdefault("temporal_handoff_reason", reason)
+
+    return RunRequest(
+        job_name=failover_job_name,
+        run_key=f"temporal-failover:{phase0_run_id}",
+        run_config={},
+        tags=failover_tags,
+    )
+
+
+def _handoff_result_consumed_phase0_run(result: RunRequest | SkipReason) -> bool:
+    if isinstance(result, RunRequest):
+        return True
+
+    message = getattr(result, "skip_message", "")
+    return isinstance(message, str) and message.startswith("temporal handoff started")
+
+
+def _latest_successful_phase0_run(
+    context: SensorEvaluationContext,
+    phase0_job_name: str,
+) -> object | None:
+    instance = getattr(context, "instance", None)
+    if instance is None:
+        return None
+
+    for raw_run in _query_runs(instance, phase0_job_name):
+        run = _dagster_run(raw_run)
+        if _run_id_or_none(run) == context.cursor:
+            continue
+        if _run_job_name(run) != phase0_job_name:
+            continue
+        if not _run_succeeded(run):
+            continue
+        return run
+
+    return None
+
+
+def _query_runs(instance: object, phase0_job_name: str) -> tuple[object, ...]:
+    filters = _runs_filter(phase0_job_name)
+    for method_name in ("get_runs", "get_run_records"):
+        method = getattr(instance, method_name, None)
+        if not callable(method):
+            continue
+
+        if filters is not None:
+            for kwargs in (
+                {"filters": filters, "limit": 25},
+                {"run_filter": filters, "limit": 25},
+                {"filters": filters},
+                {"run_filter": filters},
+            ):
+                try:
+                    return _as_tuple(method(**kwargs))
+                except TypeError:
+                    continue
+
+        try:
+            return _as_tuple(method(limit=25))
+        except TypeError:
+            try:
+                return _as_tuple(method())
+            except TypeError:
+                continue
+
+    return ()
+
+
+def _runs_filter(phase0_job_name: str) -> object | None:
+    try:
+        from dagster import DagsterRunStatus, RunsFilter
+    except Exception:
+        return None
+
+    try:
+        return RunsFilter(
+            job_name=phase0_job_name,
+            statuses=[DagsterRunStatus.SUCCESS],
+        )
+    except TypeError:
+        return None
+
+
+def _dagster_run(raw_run: object) -> object:
+    return _mapping_or_attr(raw_run, "dagster_run") or raw_run
+
+
+def _run_id(run: object) -> str:
+    run_id = _run_id_or_none(run)
+    if run_id is None:
+        raise TypeError("Phase 0 run must expose a non-empty run_id")
+    return run_id
+
+
+def _run_id_or_none(run: object) -> str | None:
+    value = _mapping_or_attr(run, "run_id")
+    return value if isinstance(value, str) and value else None
+
+
+def _run_job_name(run: object) -> str | None:
+    for attribute_name in ("job_name", "pipeline_name"):
+        value = _mapping_or_attr(run, attribute_name)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _run_succeeded(run: object) -> bool:
+    status = _mapping_or_attr(run, "status")
+    if isinstance(status, str):
+        return status.lower() in {"success", "succeeded"}
+
+    for attribute_name in ("name", "value"):
+        value = getattr(status, attribute_name, None)
+        if isinstance(value, str) and value.lower() in {"success", "succeeded"}:
+            return True
+    return False
+
+
+def _run_tags(run: object) -> Mapping[str, object]:
+    tags = _mapping_or_attr(run, "tags")
+    return tags if isinstance(tags, Mapping) else {}
+
+
+def _cycle_id_from_run(run: object, tags: Mapping[str, str]) -> str:
+    cycle_id = tags.get("cycle_id")
+    if cycle_id:
+        return cycle_id
+    return _run_id(run)
+
+
+def _gate_policy_from_context(context: SensorEvaluationContext) -> GatePolicyProfile:
+    resource = _resource_from_context(context, GATE_POLICY_RESOURCE_KEY)
+    if isinstance(resource, GatePolicyProfile):
+        return resource
+
+    policy = getattr(resource, "policy", None)
+    if isinstance(policy, GatePolicyProfile):
+        return policy
+
+    if resource is None:
+        raise RuntimeError("gate_policy resource is required")
+
+    raise TypeError(
+        "gate_policy resource must be a GatePolicyProfile or expose "
+        "a GatePolicyProfile policy",
+    )
+
+
+def _handoff_client_from_context(
+    context: SensorEvaluationContext,
+) -> TemporalHandoffClient | None:
+    resource_bundle = _resource_from_context(context, RESOURCE_BUNDLE_RESOURCE_KEY)
+    bundle_resources = getattr(resource_bundle, "resources", None)
+    if isinstance(bundle_resources, Mapping):
+        bundled = bundle_resources.get(TEMPORAL_HANDOFF_CLIENT_RESOURCE_KEY)
+        if _is_handoff_client(bundled):
+            return bundled
+
+    direct = _resource_from_context(context, TEMPORAL_HANDOFF_CLIENT_RESOURCE_KEY)
+    if _is_handoff_client(direct):
+        return direct
+
+    return None
+
+
+def _is_handoff_client(value: object) -> bool:
+    return callable(getattr(value, "start_cycle", None))
+
+
+def _resource_from_context(context: SensorEvaluationContext, key: str) -> Any:
+    resources = getattr(context, "resources", None)
+    if resources is None:
+        return None
+
+    if isinstance(resources, Mapping):
+        return resources.get(key)
+
+    try:
+        return getattr(resources, key)
+    except AttributeError:
+        return None
+
+
+def _string_tags(tags: Mapping[str, object]) -> dict[str, str]:
+    return {key: value for key, value in tags.items() if isinstance(value, str)}
+
+
+def _mapping_or_attr(value: object, name: str) -> object | None:
+    if isinstance(value, Mapping):
+        return value.get(name)
+    return getattr(value, name, None)
+
+
+def _as_tuple(value: object) -> tuple[object, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, tuple):
+        return value
+    if isinstance(value, list):
+        return tuple(value)
+    return tuple(value) if hasattr(value, "__iter__") else (value,)
+
+
+def _job_name(job: object) -> str:
+    name = getattr(job, "name", None)
+    if isinstance(name, str) and name:
+        return name
+    raise TypeError("Dagster job must expose a non-empty name")
+
+
+__all__ = [
+    "TEMPORAL_HANDOFF_CLIENT_RESOURCE_KEY",
+    "TEMPORAL_HANDOFF_SENSOR_NAME",
+    "TEMPORAL_HANDOFF_SENSOR_REQUIRED_RESOURCE_KEYS",
+    "build_temporal_handoff_sensor",
+    "evaluate_temporal_handoff_sensor",
+    "temporal_handoff_sensor",
+]

--- a/src/orchestrator/temporal/__init__.py
+++ b/src/orchestrator/temporal/__init__.py
@@ -7,6 +7,16 @@ from orchestrator.temporal.models import (
     TemporalPhaseSpec,
     TemporalWorkflowStatus,
 )
+from orchestrator.temporal.handoff import (
+    DefaultTemporalHandoffClient,
+    TEMPORAL_HANDOFF_CLIENT_RESOURCE_KEY,
+    TemporalFailoverMode,
+    TemporalHandoffClient,
+    TemporalHandoffResult,
+    TemporalHandoffStartError,
+    build_temporal_cycle_request_from_phase0_run,
+    start_temporal_handoff,
+)
 from orchestrator.temporal.phase_specs import default_phase1_3_specs
 from orchestrator.temporal.workflow import (
     TemporalPhaseExecutor,
@@ -15,13 +25,21 @@ from orchestrator.temporal.workflow import (
 )
 
 __all__ = [
+    "DefaultTemporalHandoffClient",
+    "TEMPORAL_HANDOFF_CLIENT_RESOURCE_KEY",
     "TemporalCycleRequest",
     "TemporalCycleResult",
+    "TemporalFailoverMode",
+    "TemporalHandoffClient",
+    "TemporalHandoffResult",
+    "TemporalHandoffStartError",
     "TemporalPhaseExecutor",
     "TemporalPhaseResult",
     "TemporalPhaseSpec",
     "TemporalWorkflowStatus",
+    "build_temporal_cycle_request_from_phase0_run",
     "default_phase1_3_specs",
     "phase_result_should_continue",
     "run_phase1_3_temporal_workflow",
+    "start_temporal_handoff",
 ]

--- a/src/orchestrator/temporal/handoff.py
+++ b/src/orchestrator/temporal/handoff.py
@@ -1,0 +1,133 @@
+"""Temporal handoff helpers for Phase 1-3 execution."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Literal, Protocol, TypeAlias
+
+from orchestrator.policy import GatePolicyProfile
+from orchestrator.temporal.models import TemporalCycleRequest
+from orchestrator.temporal.phase_specs import default_phase1_3_specs
+
+
+TEMPORAL_HANDOFF_CLIENT_RESOURCE_KEY = "temporal_handoff_client"
+TemporalFailoverMode: TypeAlias = Literal["deferred", "failed_over"]
+TemporalHandoffStatus: TypeAlias = Literal["started", "deferred", "failed_over"]
+
+
+class TemporalHandoffStartError(RuntimeError):
+    """Controlled error raised when a Temporal cycle cannot be started."""
+
+
+@dataclass(frozen=True, slots=True)
+class TemporalHandoffResult:
+    status: TemporalHandoffStatus
+    workflow_id: str | None = None
+    run_id: str | None = None
+    reason: str | None = None
+
+
+class TemporalHandoffClient(Protocol):
+    def start_cycle(self, request: TemporalCycleRequest) -> TemporalHandoffResult:
+        """Start the Phase 1-3 Temporal cycle."""
+
+
+@dataclass(frozen=True, slots=True)
+class DefaultTemporalHandoffClient:
+    """Non-network fallback used when assembly has not injected a client."""
+
+    failover_mode: TemporalFailoverMode = "failed_over"
+    reason: str = "temporal_handoff_client resource is not configured"
+
+    def start_cycle(self, request: TemporalCycleRequest) -> TemporalHandoffResult:
+        del request
+        return TemporalHandoffResult(status=self.failover_mode, reason=self.reason)
+
+
+def build_temporal_cycle_request_from_phase0_run(
+    *,
+    policy: GatePolicyProfile,
+    cycle_id: str,
+    phase0_run_id: str,
+    dagster_run_id: str,
+    tags: Mapping[str, str],
+) -> TemporalCycleRequest:
+    """Convert a successful Phase 0 Dagster run into a Temporal request."""
+
+    return TemporalCycleRequest(
+        cycle_id=_required_text(cycle_id, "cycle_id"),
+        dagster_run_id=_required_text(dagster_run_id, "dagster_run_id"),
+        phase0_run_id=_required_text(phase0_run_id, "phase0_run_id"),
+        policy_version=policy.policy_version,
+        contract_version=policy.contract_version,
+        phase_specs=default_phase1_3_specs(),
+        tags=_request_tags(
+            tags,
+            cycle_id=cycle_id,
+            phase0_run_id=phase0_run_id,
+            dagster_run_id=dagster_run_id,
+            policy=policy,
+        ),
+    )
+
+
+def start_temporal_handoff(
+    *,
+    policy: GatePolicyProfile,
+    phase0_run_id: str,
+    dagster_run_id: str,
+    cycle_id: str,
+    tags: Mapping[str, str],
+    client: TemporalHandoffClient,
+) -> TemporalHandoffResult:
+    """Start Temporal Phase 1-3 execution through the injected client."""
+
+    request = build_temporal_cycle_request_from_phase0_run(
+        policy=policy,
+        cycle_id=cycle_id,
+        phase0_run_id=phase0_run_id,
+        dagster_run_id=dagster_run_id,
+        tags=tags,
+    )
+    result = client.start_cycle(request)
+    if result.status not in ("started", "deferred", "failed_over"):
+        raise TemporalHandoffStartError(
+            f"temporal handoff client returned unsupported status {result.status!r}",
+        )
+    return result
+
+
+def _request_tags(
+    tags: Mapping[str, str],
+    *,
+    cycle_id: str,
+    phase0_run_id: str,
+    dagster_run_id: str,
+    policy: GatePolicyProfile,
+) -> dict[str, str]:
+    request_tags = dict(tags)
+    request_tags.setdefault("cycle_id", cycle_id)
+    request_tags.setdefault("phase0_run_id", phase0_run_id)
+    request_tags.setdefault("dagster_run_id", dagster_run_id)
+    request_tags.setdefault("policy_version", policy.policy_version)
+    request_tags.setdefault("contract_version", policy.contract_version)
+    return request_tags
+
+
+def _required_text(value: str, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return value
+
+
+__all__ = [
+    "DefaultTemporalHandoffClient",
+    "TEMPORAL_HANDOFF_CLIENT_RESOURCE_KEY",
+    "TemporalFailoverMode",
+    "TemporalHandoffClient",
+    "TemporalHandoffResult",
+    "TemporalHandoffStartError",
+    "build_temporal_cycle_request_from_phase0_run",
+    "start_temporal_handoff",
+]

--- a/tests/jobs/test_cycle_backend.py
+++ b/tests/jobs/test_cycle_backend.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def cycle_exports() -> dict[str, Any]:
+    dagster = pytest.importorskip("dagster", reason="dagster is not installed")
+
+    from orchestrator.jobs.cycle import (
+        build_daily_cycle_jobs,
+        daily_cycle_job,
+        daily_cycle_phase0_job,
+    )
+    from orchestrator.jobs.phase0_constants import PHASE0_GROUP_NAME
+    from orchestrator.jobs.phase1 import PHASE1_GROUP_NAME
+
+    return {
+        "build_daily_cycle_jobs": build_daily_cycle_jobs,
+        "dagster": dagster,
+        "daily_cycle_job": daily_cycle_job,
+        "daily_cycle_phase0_job": daily_cycle_phase0_job,
+        "PHASE0_GROUP_NAME": PHASE0_GROUP_NAME,
+        "PHASE1_GROUP_NAME": PHASE1_GROUP_NAME,
+    }
+
+
+def test_build_daily_cycle_jobs_defaults_to_full_dagster_job(
+    cycle_exports: dict[str, Any],
+) -> None:
+    build_daily_cycle_jobs = cycle_exports["build_daily_cycle_jobs"]
+    daily_cycle_job = cycle_exports["daily_cycle_job"]
+
+    assert build_daily_cycle_jobs(None) == (daily_cycle_job,)
+    assert build_daily_cycle_jobs({"execution_backend": "dagster_only"}) == (
+        daily_cycle_job,
+    )
+    assert build_daily_cycle_jobs({"enabled_phases": ["phase0"]}) == (
+        daily_cycle_job,
+    )
+
+
+def test_build_daily_cycle_jobs_temporal_backend_returns_stable_targets(
+    cycle_exports: dict[str, Any],
+) -> None:
+    build_daily_cycle_jobs = cycle_exports["build_daily_cycle_jobs"]
+    daily_cycle_job = cycle_exports["daily_cycle_job"]
+    daily_cycle_phase0_job = cycle_exports["daily_cycle_phase0_job"]
+
+    jobs = build_daily_cycle_jobs({"execution_backend": "dagster_plus_temporal"})
+
+    assert jobs == (daily_cycle_phase0_job, daily_cycle_job)
+    assert [job.name for job in jobs] == [
+        "daily_cycle_phase0_job",
+        "daily_cycle_job",
+    ]
+    assert len({job.name for job in jobs}) == 2
+
+
+def test_build_daily_cycle_jobs_rejects_unknown_backend(
+    cycle_exports: dict[str, Any],
+) -> None:
+    build_daily_cycle_jobs = cycle_exports["build_daily_cycle_jobs"]
+
+    with pytest.raises(ValueError, match="unsupported execution_backend"):
+        build_daily_cycle_jobs({"execution_backend": "temporal"})
+
+
+def test_daily_cycle_phase0_job_selects_only_phase0_group(
+    cycle_exports: dict[str, Any],
+) -> None:
+    dagster = cycle_exports["dagster"]
+    daily_cycle_phase0_job = cycle_exports["daily_cycle_phase0_job"]
+    phase0_group_name = cycle_exports["PHASE0_GROUP_NAME"]
+    phase1_group_name = cycle_exports["PHASE1_GROUP_NAME"]
+
+    @dagster.asset(name="unit_phase0_asset", group_name=phase0_group_name)
+    def unit_phase0_asset() -> str:
+        return "ok"
+
+    @dagster.asset(name="unit_phase1_asset", group_name=phase1_group_name)
+    def unit_phase1_asset() -> str:
+        return "ok"
+
+    selected = daily_cycle_phase0_job.selection.resolve(
+        [unit_phase0_asset, unit_phase1_asset],
+    )
+
+    assert selected == {dagster.AssetKey(["unit_phase0_asset"])}

--- a/tests/schedules/test_daily_cycle.py
+++ b/tests/schedules/test_daily_cycle.py
@@ -28,3 +28,46 @@ def test_daily_cycle_schedule_name(
     daily_cycle_schedule_definition: Any,
 ) -> None:
     assert daily_cycle_schedule_definition.name == "daily_cycle_schedule"
+
+
+def test_build_daily_cycle_schedule_targets_supplied_job() -> None:
+    pytest.importorskip("dagster", reason="dagster is not installed")
+
+    from orchestrator.jobs.cycle import daily_cycle_phase0_job
+    from orchestrator.schedules import build_daily_cycle_schedule
+
+    schedule = build_daily_cycle_schedule(
+        daily_cycle_phase0_job,
+        name="phase0_cycle_schedule",
+    )
+
+    assert schedule.name == "phase0_cycle_schedule"
+    assert _target_name(schedule) == "daily_cycle_phase0_job"
+
+
+def test_default_daily_cycle_schedule_targets_full_cycle_job(
+    daily_cycle_schedule_definition: Any,
+) -> None:
+    assert _target_name(daily_cycle_schedule_definition) == "daily_cycle_job"
+
+
+def _target_name(definition: Any) -> str | None:
+    for attribute_name in ("job_name", "target_name"):
+        value = getattr(definition, attribute_name, None)
+        if isinstance(value, str):
+            return value
+
+    for attribute_name in ("job", "job_def", "_job", "_job_def"):
+        target = getattr(definition, attribute_name, None)
+        name = getattr(target, "name", None)
+        if isinstance(name, str):
+            return name
+
+    targets = getattr(definition, "targets", None)
+    if targets:
+        first_target = next(iter(targets))
+        for attribute_name in ("job_name", "target_name"):
+            value = getattr(first_target, attribute_name, None)
+            if isinstance(value, str):
+                return value
+    return None

--- a/tests/sensors/test_data_readiness.py
+++ b/tests/sensors/test_data_readiness.py
@@ -199,6 +199,21 @@ def test_data_readiness_sensor_name(sensor_exports: dict[str, Any]) -> None:
     assert data_readiness_sensor.name == "data_readiness_sensor"
 
 
+def test_build_data_readiness_sensor_targets_supplied_job(
+    sensor_exports: dict[str, Any],
+) -> None:
+    from orchestrator.jobs.cycle import daily_cycle_phase0_job
+    from orchestrator.sensors.data_readiness import build_data_readiness_sensor
+
+    sensor_definition = build_data_readiness_sensor(
+        daily_cycle_phase0_job,
+        name="phase0_data_readiness_sensor",
+    )
+
+    assert sensor_definition.name == "phase0_data_readiness_sensor"
+    assert _target_name(sensor_definition) == "daily_cycle_phase0_job"
+
+
 def test_data_readiness_sensor_declares_required_resources(
     sensor_exports: dict[str, Any],
 ) -> None:
@@ -233,3 +248,19 @@ class _RawReadinessResource:
 
     def get_data_readiness_signal(self) -> object:
         return self.signal
+
+
+def _target_name(definition: Any) -> str | None:
+    for attribute_name in ("job_name", "target_name"):
+        value = getattr(definition, attribute_name, None)
+        if isinstance(value, str):
+            return value
+
+    targets = getattr(definition, "targets", None)
+    if targets:
+        first_target = next(iter(targets))
+        for attribute_name in ("job_name", "target_name"):
+            value = getattr(first_target, attribute_name, None)
+            if isinstance(value, str):
+                return value
+    return None

--- a/tests/sensors/test_temporal_handoff.py
+++ b/tests/sensors/test_temporal_handoff.py
@@ -313,6 +313,47 @@ def test_temporal_handoff_sensor_cursor_does_not_reprocess_older_run(
     assert context.updated_cursor is None
 
 
+def test_temporal_handoff_sensor_processes_unseen_run_at_same_timestamp(
+    temporal_sensor_exports: dict[str, Any],
+) -> None:
+    SkipReason = temporal_sensor_exports["SkipReason"]
+    build_temporal_handoff_sensor = temporal_sensor_exports[
+        "build_temporal_handoff_sensor"
+    ]
+    client = RecordingHandoffClient()
+    context = _FakeTemporalSensorContext(
+        resources={
+            "resource_bundle": SimpleNamespace(
+                resources={"temporal_handoff_client": client},
+            ),
+        },
+        runs=[
+            _phase0_run_record("phase0-run-2", "cycle-20260417", timestamp=2.0),
+            _phase0_run_record("phase0-run-1", "cycle-20260416", timestamp=2.0),
+        ],
+    )
+    sensor_definition = build_temporal_handoff_sensor(policy=_temporal_policy())
+
+    first_result = sensor_definition.evaluation_fn(context)
+    second_result = sensor_definition.evaluation_fn(context)
+    third_result = sensor_definition.evaluation_fn(context)
+
+    assert isinstance(first_result, SkipReason)
+    assert isinstance(second_result, SkipReason)
+    assert isinstance(third_result, SkipReason)
+    assert [request.phase0_run_id for request in client.requests] == [
+        "phase0-run-2",
+        "phase0-run-1",
+    ]
+    assert "no successful daily_cycle_phase0_job run is ready" in (
+        third_result.skip_message
+    )
+    assert context.updated_cursor is not None
+    cursor = json.loads(context.updated_cursor)
+    assert cursor["processed_run_ids"] == ["phase0-run-1", "phase0-run-2"]
+    assert cursor["high_water_timestamp"] == 2.0
+
+
 def test_temporal_handoff_sensor_legacy_cursor_stops_at_processed_run(
     temporal_sensor_exports: dict[str, Any],
 ) -> None:

--- a/tests/sensors/test_temporal_handoff.py
+++ b/tests/sensors/test_temporal_handoff.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -45,12 +47,24 @@ def temporal_sensor_exports() -> dict[str, Any]:
     dagster = pytest.importorskip("dagster", reason="dagster is not installed")
 
     from orchestrator.sensors.temporal_handoff import (
+        TEMPORAL_HANDOFF_CLIENT_RESOURCE_KEY,
+        TEMPORAL_HANDOFF_SENSOR_REQUIRED_RESOURCE_KEYS,
+        RESOURCE_BUNDLE_RESOURCE_KEY,
+        build_temporal_handoff_sensor,
         evaluate_temporal_handoff_sensor,
     )
 
     return {
         "RunRequest": dagster.RunRequest,
         "SkipReason": dagster.SkipReason,
+        "TEMPORAL_HANDOFF_CLIENT_RESOURCE_KEY": (
+            TEMPORAL_HANDOFF_CLIENT_RESOURCE_KEY
+        ),
+        "TEMPORAL_HANDOFF_SENSOR_REQUIRED_RESOURCE_KEYS": (
+            TEMPORAL_HANDOFF_SENSOR_REQUIRED_RESOURCE_KEYS
+        ),
+        "RESOURCE_BUNDLE_RESOURCE_KEY": RESOURCE_BUNDLE_RESOURCE_KEY,
+        "build_temporal_handoff_sensor": build_temporal_handoff_sensor,
         "evaluate_temporal_handoff_sensor": evaluate_temporal_handoff_sensor,
     }
 
@@ -207,6 +221,128 @@ def test_missing_handoff_client_defaults_to_failed_over(
     assert "not configured" in result.tags["temporal_handoff_reason"]
 
 
+def test_temporal_handoff_sensor_declares_client_discovery_resources(
+    temporal_sensor_exports: dict[str, Any],
+) -> None:
+    required_resource_keys = temporal_sensor_exports[
+        "TEMPORAL_HANDOFF_SENSOR_REQUIRED_RESOURCE_KEYS"
+    ]
+
+    assert "gate_policy" in required_resource_keys
+    assert (
+        temporal_sensor_exports["RESOURCE_BUNDLE_RESOURCE_KEY"]
+        in required_resource_keys
+    )
+    assert (
+        temporal_sensor_exports["TEMPORAL_HANDOFF_CLIENT_RESOURCE_KEY"]
+        in required_resource_keys
+    )
+
+
+def test_temporal_handoff_sensor_uses_client_from_resource_bundle_and_cursors_run(
+    temporal_sensor_exports: dict[str, Any],
+) -> None:
+    SkipReason = temporal_sensor_exports["SkipReason"]
+    build_temporal_handoff_sensor = temporal_sensor_exports[
+        "build_temporal_handoff_sensor"
+    ]
+    client = RecordingHandoffClient()
+    context = _FakeTemporalSensorContext(
+        resources={
+            "resource_bundle": SimpleNamespace(
+                resources={"temporal_handoff_client": client},
+            ),
+        },
+        runs=[
+            _phase0_run_record("phase0-run-2", "cycle-20260417", timestamp=2.0),
+            _phase0_run_record("phase0-run-1", "cycle-20260416", timestamp=1.0),
+        ],
+    )
+    sensor_definition = build_temporal_handoff_sensor(policy=_temporal_policy())
+
+    result = sensor_definition.evaluation_fn(context)
+
+    assert isinstance(result, SkipReason)
+    assert "started" in result.skip_message
+    assert [request.phase0_run_id for request in client.requests] == ["phase0-run-2"]
+    assert client.requests[0].tags["temporal_workflow_id"] == (
+        "orchestrator-cycle-cycle-20260417-phase1-3-phase0-run-2"
+    )
+    assert context.updated_cursor is not None
+    cursor = json.loads(context.updated_cursor)
+    assert cursor["last_run_id"] == "phase0-run-2"
+    assert cursor["processed_run_ids"] == ["phase0-run-2"]
+    assert cursor["high_water_timestamp"] == 2.0
+
+
+def test_temporal_handoff_sensor_cursor_does_not_reprocess_older_run(
+    temporal_sensor_exports: dict[str, Any],
+) -> None:
+    SkipReason = temporal_sensor_exports["SkipReason"]
+    build_temporal_handoff_sensor = temporal_sensor_exports[
+        "build_temporal_handoff_sensor"
+    ]
+    client = RecordingHandoffClient()
+    cursor = json.dumps(
+        {
+            "version": 1,
+            "last_run_id": "phase0-run-2",
+            "processed_run_ids": ["phase0-run-2"],
+            "high_water_timestamp": 2.0,
+        }
+    )
+    context = _FakeTemporalSensorContext(
+        cursor=cursor,
+        resources={
+            "resource_bundle": SimpleNamespace(
+                resources={"temporal_handoff_client": client},
+            ),
+        },
+        runs=[
+            _phase0_run_record("phase0-run-2", "cycle-20260417", timestamp=2.0),
+            _phase0_run_record("phase0-run-1", "cycle-20260416", timestamp=1.0),
+        ],
+    )
+    sensor_definition = build_temporal_handoff_sensor(policy=_temporal_policy())
+
+    result = sensor_definition.evaluation_fn(context)
+
+    assert isinstance(result, SkipReason)
+    assert "no successful daily_cycle_phase0_job run is ready" in result.skip_message
+    assert client.requests == []
+    assert context.updated_cursor is None
+
+
+def test_temporal_handoff_sensor_legacy_cursor_stops_at_processed_run(
+    temporal_sensor_exports: dict[str, Any],
+) -> None:
+    SkipReason = temporal_sensor_exports["SkipReason"]
+    build_temporal_handoff_sensor = temporal_sensor_exports[
+        "build_temporal_handoff_sensor"
+    ]
+    client = RecordingHandoffClient()
+    context = _FakeTemporalSensorContext(
+        cursor="phase0-run-2",
+        resources={
+            "resource_bundle": SimpleNamespace(
+                resources={"temporal_handoff_client": client},
+            ),
+        },
+        runs=[
+            _phase0_run_record("phase0-run-2", "cycle-20260417", timestamp=2.0),
+            _phase0_run_record("phase0-run-1", "cycle-20260416", timestamp=1.0),
+        ],
+    )
+    sensor_definition = build_temporal_handoff_sensor(policy=_temporal_policy())
+
+    result = sensor_definition.evaluation_fn(context)
+
+    assert isinstance(result, SkipReason)
+    assert "no successful daily_cycle_phase0_job run is ready" in result.skip_message
+    assert client.requests == []
+    assert context.updated_cursor is None
+
+
 def _temporal_policy() -> Any:
     policy = load_gate_policy(LITE_POLICY_PATH)
     return policy.model_copy(update={"execution_backend": "dagster_plus_temporal"})
@@ -218,3 +354,46 @@ def _tags() -> Mapping[str, str]:
         "scenario_id": "phase0_data_readiness_delayed",
         "runbook_url": "https://runbooks.example/phase0",
     }
+
+
+def _phase0_run_record(
+    run_id: str,
+    cycle_id: str,
+    *,
+    timestamp: float,
+) -> Mapping[str, object]:
+    return {
+        "create_timestamp": timestamp,
+        "dagster_run": {
+            "run_id": run_id,
+            "job_name": "daily_cycle_phase0_job",
+            "status": "SUCCESS",
+            "tags": _tags() | {"cycle_id": cycle_id},
+        },
+    }
+
+
+class _FakeRunStorage:
+    def __init__(self, runs: list[object]) -> None:
+        self.runs = runs
+
+    def get_run_records(self, **_kwargs: object) -> tuple[object, ...]:
+        return tuple(self.runs)
+
+
+class _FakeTemporalSensorContext:
+    def __init__(
+        self,
+        *,
+        runs: list[object],
+        resources: Mapping[str, object],
+        cursor: str | None = None,
+    ) -> None:
+        self.cursor = cursor
+        self.updated_cursor: str | None = None
+        self.instance = _FakeRunStorage(runs)
+        self.resources = SimpleNamespace(**resources)
+
+    def update_cursor(self, cursor: str) -> None:
+        self.updated_cursor = cursor
+        self.cursor = cursor

--- a/tests/sensors/test_temporal_handoff.py
+++ b/tests/sensors/test_temporal_handoff.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from orchestrator.policy import load_gate_policy
+from orchestrator.temporal import (
+    TemporalCycleRequest,
+    TemporalHandoffResult,
+    TemporalHandoffStartError,
+    build_temporal_cycle_request_from_phase0_run,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LITE_POLICY_PATH = REPO_ROOT / "config" / "policy" / "gate_policy.lite.yaml"
+
+
+class RecordingHandoffClient:
+    def __init__(
+        self,
+        result: TemporalHandoffResult | None = None,
+        error: BaseException | None = None,
+    ) -> None:
+        self.result = result or TemporalHandoffResult(
+            status="started",
+            workflow_id="workflow-cycle-20260416",
+            run_id="temporal-run-1",
+        )
+        self.error = error
+        self.requests: list[TemporalCycleRequest] = []
+
+    def start_cycle(self, request: TemporalCycleRequest) -> TemporalHandoffResult:
+        self.requests.append(request)
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+@pytest.fixture
+def temporal_sensor_exports() -> dict[str, Any]:
+    dagster = pytest.importorskip("dagster", reason="dagster is not installed")
+
+    from orchestrator.sensors.temporal_handoff import (
+        evaluate_temporal_handoff_sensor,
+    )
+
+    return {
+        "RunRequest": dagster.RunRequest,
+        "SkipReason": dagster.SkipReason,
+        "evaluate_temporal_handoff_sensor": evaluate_temporal_handoff_sensor,
+    }
+
+
+def test_temporal_cycle_request_uses_phase1_3_specs_and_preserves_metadata() -> None:
+    policy = _temporal_policy()
+    tags = {
+        "cycle_id": "cycle-20260416",
+        "scenario_id": "phase0_data_readiness_delayed",
+        "runbook_url": "https://runbooks.example/phase0",
+        "rerun_request_status": "none",
+    }
+
+    request = build_temporal_cycle_request_from_phase0_run(
+        policy=policy,
+        cycle_id="cycle-20260416",
+        phase0_run_id="phase0-run-1",
+        dagster_run_id="dagster-run-1",
+        tags=tags,
+    )
+
+    assert request.cycle_id == "cycle-20260416"
+    assert request.phase0_run_id == "phase0-run-1"
+    assert request.dagster_run_id == "dagster-run-1"
+    assert request.policy_version == policy.policy_version
+    assert request.contract_version == policy.contract_version
+    assert [spec.phase.value for spec in request.phase_specs] == [
+        "phase1",
+        "phase2",
+        "phase3",
+    ]
+    assert all("phase0" not in spec.asset_selection for spec in request.phase_specs)
+    assert request.tags["scenario_id"] == "phase0_data_readiness_delayed"
+    assert request.tags["runbook_url"] == "https://runbooks.example/phase0"
+    assert request.tags["rerun_request_status"] == "none"
+
+
+def test_started_handoff_does_not_emit_failover_run_request(
+    temporal_sensor_exports: dict[str, Any],
+) -> None:
+    SkipReason = temporal_sensor_exports["SkipReason"]
+    evaluate_temporal_handoff_sensor = temporal_sensor_exports[
+        "evaluate_temporal_handoff_sensor"
+    ]
+    client = RecordingHandoffClient()
+
+    result = evaluate_temporal_handoff_sensor(
+        policy=_temporal_policy(),
+        phase0_run_id="phase0-run-1",
+        dagster_run_id="dagster-run-1",
+        cycle_id="cycle-20260416",
+        tags=_tags(),
+        client=client,
+    )
+
+    assert isinstance(result, SkipReason)
+    assert "started" in result.skip_message
+    assert len(client.requests) == 1
+    assert client.requests[0].phase0_run_id == "phase0-run-1"
+
+
+def test_failed_over_handoff_emits_dagster_only_run_request(
+    temporal_sensor_exports: dict[str, Any],
+) -> None:
+    RunRequest = temporal_sensor_exports["RunRequest"]
+    evaluate_temporal_handoff_sensor = temporal_sensor_exports[
+        "evaluate_temporal_handoff_sensor"
+    ]
+    client = RecordingHandoffClient(
+        TemporalHandoffResult(status="failed_over", reason="Temporal unavailable"),
+    )
+
+    result = evaluate_temporal_handoff_sensor(
+        policy=_temporal_policy(),
+        phase0_run_id="phase0-run-1",
+        dagster_run_id="dagster-run-1",
+        cycle_id="cycle-20260416",
+        tags=_tags(),
+        client=client,
+    )
+
+    assert isinstance(result, RunRequest)
+    assert result.job_name == "daily_cycle_job"
+    assert result.tags["execution_backend"] == "dagster_only"
+    assert result.tags["temporal_failover_of"] == "phase0-run-1"
+    assert result.tags["cycle_id"] == "cycle-20260416"
+    assert result.tags["scenario_id"] == "phase0_data_readiness_delayed"
+
+
+def test_handoff_start_error_emits_failover_when_enabled(
+    temporal_sensor_exports: dict[str, Any],
+) -> None:
+    RunRequest = temporal_sensor_exports["RunRequest"]
+    evaluate_temporal_handoff_sensor = temporal_sensor_exports[
+        "evaluate_temporal_handoff_sensor"
+    ]
+    client = RecordingHandoffClient(error=TemporalHandoffStartError("start failed"))
+
+    result = evaluate_temporal_handoff_sensor(
+        policy=_temporal_policy(),
+        phase0_run_id="phase0-run-1",
+        dagster_run_id="dagster-run-1",
+        cycle_id="cycle-20260416",
+        tags=_tags(),
+        client=client,
+    )
+
+    assert isinstance(result, RunRequest)
+    assert result.job_name == "daily_cycle_job"
+    assert result.tags["temporal_failover_of"] == "phase0-run-1"
+    assert result.tags["temporal_handoff_reason"] == "start failed"
+
+
+def test_dagster_only_policy_skips_temporal_handoff(
+    temporal_sensor_exports: dict[str, Any],
+) -> None:
+    SkipReason = temporal_sensor_exports["SkipReason"]
+    evaluate_temporal_handoff_sensor = temporal_sensor_exports[
+        "evaluate_temporal_handoff_sensor"
+    ]
+
+    result = evaluate_temporal_handoff_sensor(
+        policy=load_gate_policy(LITE_POLICY_PATH),
+        phase0_run_id="phase0-run-1",
+        dagster_run_id="dagster-run-1",
+        cycle_id="cycle-20260416",
+        tags=_tags(),
+        client=RecordingHandoffClient(),
+    )
+
+    assert isinstance(result, SkipReason)
+    assert "dagster_only" in result.skip_message
+
+
+def test_missing_handoff_client_defaults_to_failed_over(
+    temporal_sensor_exports: dict[str, Any],
+) -> None:
+    RunRequest = temporal_sensor_exports["RunRequest"]
+    evaluate_temporal_handoff_sensor = temporal_sensor_exports[
+        "evaluate_temporal_handoff_sensor"
+    ]
+
+    result = evaluate_temporal_handoff_sensor(
+        policy=_temporal_policy(),
+        phase0_run_id="phase0-run-1",
+        dagster_run_id="dagster-run-1",
+        cycle_id="cycle-20260416",
+        tags=_tags(),
+        client=None,
+    )
+
+    assert isinstance(result, RunRequest)
+    assert result.tags["execution_backend"] == "dagster_only"
+    assert "not configured" in result.tags["temporal_handoff_reason"]
+
+
+def _temporal_policy() -> Any:
+    policy = load_gate_policy(LITE_POLICY_PATH)
+    return policy.model_copy(update={"execution_backend": "dagster_plus_temporal"})
+
+
+def _tags() -> Mapping[str, str]:
+    return {
+        "cycle_id": "cycle-20260416",
+        "scenario_id": "phase0_data_readiness_delayed",
+        "runbook_url": "https://runbooks.example/phase0",
+    }

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -82,6 +82,54 @@ def test_build_definitions_collects_p1a_surface(
     assert bundle.read_only is True
 
 
+def test_build_definitions_dagster_only_registers_full_cycle_entrypoints(
+    definitions_exports: dict[str, Any],
+) -> None:
+    build_definitions = definitions_exports["build_definitions"]
+
+    defs = build_definitions(policy_path="config/policy/gate_policy.lite.yaml")
+
+    assert _job_names(defs) == {"daily_cycle_job"}
+    assert _target_name(_schedule_by_name(defs, "daily_cycle_schedule")) == (
+        "daily_cycle_job"
+    )
+    assert _target_name(_sensor_by_name(defs, "data_readiness_sensor")) == (
+        "daily_cycle_job"
+    )
+    assert "temporal_handoff_sensor" not in {
+        sensor.name for sensor in defs.sensors or ()
+    }
+
+
+def test_build_definitions_temporal_backend_registers_phase0_entrypoint(
+    definitions_exports: dict[str, Any],
+    tmp_path: Path,
+) -> None:
+    build_definitions = definitions_exports["build_definitions"]
+    dagster = definitions_exports["dagster"]
+    policy_path = _policy_with_backend(tmp_path, "dagster_plus_temporal")
+
+    defs = build_definitions(
+        module_factories=[_fake_provider(dagster)],
+        policy_path=policy_path,
+    )
+
+    assert _job_names(defs) == {
+        "daily_cycle_phase0_job",
+        "daily_cycle_job",
+    }
+    assert _target_name(_schedule_by_name(defs, "daily_cycle_schedule")) == (
+        "daily_cycle_phase0_job"
+    )
+    assert _target_name(_sensor_by_name(defs, "data_readiness_sensor")) == (
+        "daily_cycle_phase0_job"
+    )
+    assert "temporal_handoff_sensor" in {
+        sensor.name for sensor in defs.sensors or ()
+    }
+    assert "temporal_handoff_client" not in defs.resources
+
+
 def test_build_definitions_backs_data_readiness_sensor_resources(
     definitions_exports: dict[str, Any],
 ) -> None:
@@ -461,6 +509,13 @@ def _sensor_by_name(defs: Any, name: str) -> Any:
     pytest.fail(f"missing sensor {name}")
 
 
+def _schedule_by_name(defs: Any, name: str) -> Any:
+    for schedule in defs.schedules or ():
+        if schedule.name == name:
+            return schedule
+    pytest.fail(f"missing schedule {name}")
+
+
 def _evaluate_sensor_tick(dagster: Any, sensor: Any, defs: Any) -> Any:
     context = dagster.build_sensor_context(definitions=defs)
     if callable(getattr(context, "__enter__", None)):
@@ -480,6 +535,48 @@ def _check_names(defs: Any) -> set[str]:
         if name := getattr(check_def, "name", None):
             names.add(name)
     return names
+
+
+def _job_names(defs: Any) -> set[str]:
+    return {job.name for job in defs.jobs or ()}
+
+
+def _target_name(definition: Any) -> str | None:
+    for attribute_name in ("job_name", "target_name"):
+        value = getattr(definition, attribute_name, None)
+        if isinstance(value, str):
+            return value
+
+    for attribute_name in ("job", "job_def", "_job", "_job_def"):
+        target = getattr(definition, attribute_name, None)
+        name = getattr(target, "name", None)
+        if isinstance(name, str):
+            return name
+
+    targets = getattr(definition, "targets", None)
+    if targets:
+        first_target = next(iter(targets))
+        for attribute_name in ("job_name", "target_name"):
+            value = getattr(first_target, attribute_name, None)
+            if isinstance(value, str):
+                return value
+    return None
+
+
+def _policy_with_backend(tmp_path: Path, backend: str) -> Path:
+    policy_path = tmp_path / f"gate_policy.{backend}.yaml"
+    source_path = (
+        _REPO_ROOT / "config" / "policy" / "gate_policy.lite.yaml"
+    )
+    policy_text = source_path.read_text(encoding="utf-8")
+    policy_path.write_text(
+        policy_text.replace(
+            "execution_backend: dagster_only",
+            f"execution_backend: {backend}",
+        ),
+        encoding="utf-8",
+    )
+    return policy_path
 
 
 def _clear_definition_imports() -> None:


### PR DESCRIPTION
Closes #37

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `scripts/check_boundaries.py`, `src/orchestrator/checks/phase1.py`, `src/orchestrator/checks/phase3.py`, `src/orchestrator/jobs/cycle.py`, `src/orchestrator/resources/infra.py`, `src/orchestrator/sensors/manual_rerun.py`, `src/orchestrator/temporal/workflow.py`, `tests/cli/__init__.py`, `tests/integration/test_daily_cycle_four_phase.py`


---
### 1. 背景与目标
`docs/orchestrator.project-doc.md` §11.4、§12、§21 要求根据 `GatePolicyProfile.execution_backend` 在 Dagster-only 与 Dagster+Temporal 两条执行路径之间切换，并且 Temporal 只接管 Phase 1-3。当前 `src/orchestrator/policy/schema.py` 已经校验 `execution_backend: Literal["dagster_only", "dagster_plus_temporal"]`，但 `src/orchestrator/definitions.py` 固定注册 `[daily_cycle_job]`，`src/orchestrator/jobs/cycle.py::build_daily_cycle_jobs(phase_config)` 也完全忽略配置。目标是在不改变现有上游 provider 接口的前提下，把 policy 驱动的 Phase 0 job、Temporal handoff、Dagster-only failover 接进 Definitions。

### 2. 所属模块
主写入路径：
- `src/orchestrator/jobs/cycle.py`
- `src/orchestrator/definitions.py`
- `src/orchestrator/schedules/daily_cycle.py`
- `src/orchestrator/sensors/data_readiness.py`
- `src/orchestrator/sensors/temporal_handoff.py`（新建）
- `src/orchestrator/sensors/__init__.py`
- `src/orchestrator/temporal/handoff.py`（新建）
- `tests/jobs/test_cycle_backend.py`（新建）
- `tests/sensors/test_temporal_handoff.py`（新建）
- `tests/test_definitions.py`
- `tests/schedules/test_daily_cycle.py`

相邻只读 / 集成路径：
- `src/orchestrator/temporal/models.py`
- `src/orchestrator/temporal/phase_specs.py`
- `src/orchestrator/checks/resources.py`
- `src/orchestrator/policy/loader.py`
- `src/orchestrator/policy/schema.py`
- `src/orchestrator/sensors/manual_rerun.py`
- `tests/integration/test_phase0_minimal_cycle.py`
- `tests/integration/test_phase1_graph_provider_wiring.py`

### 3. 实现范围
- 在 `src/orchestrator/jobs/cycle.py` 新增 `daily_cycle_phase0_job`，selection 只覆盖 `PHASE0_GROUP_NAME`；保留现有 `daily_cycle_job` 作为 Dagster-only full cycle 与 failover job。
- 将 `build_daily_cycle_jobs(phase_config: Mapping[str, Any] | None) -> tuple[object, ...]` 从固定返回改为读取 `phase_config["execution_backend"]`：`dagster_only` 返回 `(daily_cycle_job,)`，`dagster_plus_temporal` 返回 `(daily_cycle_phase0_job, daily_cycle_job)`，其中 `daily_cycle_job` 只作为 failover/manual rerun 目标。
- 在 `src/orchestrator/schedules/daily_cycle.py` 增加 `build_daily_cycle_schedule(job: object, *, name: str = "daily_cycle_schedule") -> 