### PR TITLE
feat(#102): Dagster 1.9 API: AssetExecutionContext annotation rejected in @dbt_assets

### DIFF
--- a/src/orchestrator/jobs/phase0.py
+++ b/src/orchestrator/jobs/phase0.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 from typing import Iterator
 
-from dagster import AssetExecutionContext, ResourceParam, asset
+from dagster import ResourceParam, asset
 from dagster_dbt import DbtCliResource, dbt_assets
 
 from orchestrator.checks.dbt_events import stream_dbt_events_with_gate_handling
@@ -48,7 +48,7 @@ def phase0_readiness_ping() -> str:
 
 @dbt_assets(manifest=_require_dbt_manifest(DBT_MANIFEST_PATH))
 def dbt_phase0_assets(
-    context: AssetExecutionContext,
+    context,
     dbt: DbtCliResource,
     gate_policy: ResourceParam[GatePolicyResource],
 ) -> Iterator[object]:

--- a/src/orchestrator/sensors/temporal_handoff.py
+++ b/src/orchestrator/sensors/temporal_handoff.py
@@ -160,10 +160,6 @@ def build_temporal_handoff_sensor(
 
     return _temporal_handoff_sensor
 
-
-temporal_handoff_sensor = build_temporal_handoff_sensor()
-
-
 def _failover_run_request(
     *,
     failover_job_name: str,
@@ -557,6 +553,9 @@ def _job_name(job: object) -> str:
     if isinstance(name, str) and name:
         return name
     raise TypeError("Dagster job must expose a non-empty name")
+
+
+temporal_handoff_sensor = build_temporal_handoff_sensor()
 
 
 __all__ = [

--- a/tests/jobs/test_phase0.py
+++ b/tests/jobs/test_phase0.py
@@ -1,3 +1,4 @@
+import ast
 import os
 import sys
 from pathlib import Path
@@ -79,6 +80,15 @@ def test_phase0_readiness_ping_key_is_addressable(
     assert asset_key in phase0_readiness_ping.keys
 
 
+def test_dbt_phase0_assets_context_parameter_is_unannotated() -> None:
+    dbt_phase0_assets = _phase0_source_function("dbt_phase0_assets")
+    context_arg = next(
+        arg for arg in dbt_phase0_assets.args.args if arg.arg == "context"
+    )
+
+    assert context_arg.annotation is None
+
+
 def test_missing_dbt_manifest_fails_with_prepare_hint(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -93,6 +103,18 @@ def test_missing_dbt_manifest_fails_with_prepare_hint(
             __import__("orchestrator.jobs.phase0", fromlist=["phase0"])
     finally:
         _clear_phase0_imports()
+
+
+def _phase0_source_function(name: str) -> ast.FunctionDef:
+    module = ast.parse(
+        (_REPO_ROOT / "src" / "orchestrator" / "jobs" / "phase0.py").read_text(),
+    )
+    for node in module.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+
+    msg = f"{name} is not defined in phase0.py"
+    raise AssertionError(msg)
 
 
 def _clear_phase0_imports() -> None:


### PR DESCRIPTION
Closes #102

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `scripts/check_boundaries.py`, `src/orchestrator/checks/asset_checks.py`, `src/orchestrator/checks/phase1.py`, `src/orchestrator/checks/phase3.py`, `src/orchestrator/definitions.py`, `src/orchestrator/sensors/manual_rerun.py`, `tests/cli/__init__.py`, `tests/jobs/test_phase0.py`


---
## Background

CI fails with Dagster 1.9.x:

\`\`\`
DagsterInvalidDefinitionError: Cannot annotate \`context\` parameter with type AssetExecutionContext.
\`context\` must be annotated with AssetExecutionContext, AssetCheckExecutionContext, OpExecutionContext, or left blank.
\`\`\`

The error is paradoxical (says must use AssetExecutionContext while rejecting it). Likely a class-identity mismatch — Dagster 1.9 may compare \`is\` against a specific path, and the import path the code uses doesn't match.

## Current code (src/orchestrator/jobs/phase0.py:9, 51)

\`\`\`python
from dagster import AssetExecutionContext, ResourceParam, asset
@dbt_assets(manifest=...)
def dbt_phase0_assets(
    context: AssetExecutionContext,
    ...
)
\`\`\`

## Possible fixes

1. Use \`OpExecutionContext\` instead (older API style for dbt_assets)
2. Or import from \`dagster._core.execution.context.compute\` explicitly
3. Or remove the type annotation entirely (let Dagster infer)

## Constraint

Pyproject is pinned to \`dagster>=1.7,<1.10\`. Don't downgrade further (1.5 would conflict with pydantic v2 used elsewhere).

## Verification

- \`make test\` passes locally
- CI green: https://github.com/shenfanjie5-bit/project-ult-orchestrator/actions