### PR TITLE
feat(#102): Dagster 1.9 API: AssetExecutionContext annotation rejected in @dbt_assets

### DIFF
--- a/src/orchestrator/jobs/phase0.py
+++ b/src/orchestrator/jobs/phase0.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 from typing import Iterator
 
-from dagster import AssetExecutionContext, ResourceParam, asset
+from dagster import ResourceParam, asset
 from dagster_dbt import DbtCliResource, dbt_assets
 
 from orchestrator.checks.dbt_events import stream_dbt_events_with_gate_handling
@@ -48,7 +48,7 @@ def phase0_readiness_ping() -> str:
 
 @dbt_assets(manifest=_require_dbt_manifest(DBT_MANIFEST_PATH))
 def dbt_phase0_assets(
-    context: AssetExecutionContext,
+    context,
     dbt: DbtCliResource,
     gate_policy: ResourceParam[GatePolicyResource],
 ) -> Iterator[object]:

--- a/src/orchestrator/sensors/temporal_handoff.py
+++ b/src/orchestrator/sensors/temporal_handoff.py
@@ -161,9 +161,6 @@ def build_temporal_handoff_sensor(
     return _temporal_handoff_sensor
 
 
-temporal_handoff_sensor = build_temporal_handoff_sensor()
-
-
 def _failover_run_request(
     *,
     failover_job_name: str,
@@ -557,6 +554,9 @@ def _job_name(job: object) -> str:
     if isinstance(name, str) and name:
         return name
     raise TypeError("Dagster job must expose a non-empty name")
+
+
+temporal_handoff_sensor = build_temporal_handoff_sensor()
 
 
 __all__ = [

--- a/tests/checks/test_llm_health_check.py
+++ b/tests/checks/test_llm_health_check.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
@@ -101,14 +102,16 @@ def test_llm_health_check_passes_when_probe_is_healthy(
         )
 
     assert result.passed is True
-    assert result.metadata["all_critical_targets_available"] == "true"
-    assert result.metadata["target_count"] == "2"
-    assert result.metadata["unavailable_target_count"] == "0"
-    assert result.metadata["providers"] == "backup-llm, fake-llm"
-    assert result.metadata["provider_models"] == (
+    assert _metadata_value(result.metadata, "all_critical_targets_available") == "true"
+    assert _metadata_value(result.metadata, "target_count") == "2"
+    assert _metadata_value(result.metadata, "unavailable_target_count") == "0"
+    assert _metadata_value(result.metadata, "providers") == "backup-llm, fake-llm"
+    assert _metadata_value(result.metadata, "provider_models") == (
         "fake-llm/fast-model, backup-llm/deep-model"
     )
-    provider_statuses = json.loads(result.metadata["provider_statuses"])
+    provider_statuses = json.loads(
+        _metadata_value(result.metadata, "provider_statuses")
+    )
     assert provider_statuses == [
         {
             "error": None,
@@ -162,9 +165,9 @@ def test_llm_health_check_passes_when_only_noncritical_target_is_unavailable(
     )
 
     assert result.passed is True
-    assert result.metadata["all_critical_targets_available"] == "true"
-    assert result.metadata["unavailable_target_count"] == "1"
-    assert result.metadata["unavailable_provider_models"] == (
+    assert _metadata_value(result.metadata, "all_critical_targets_available") == "true"
+    assert _metadata_value(result.metadata, "unavailable_target_count") == "1"
+    assert _metadata_value(result.metadata, "unavailable_provider_models") == (
         "optional-llm/optional-model"
     )
 
@@ -182,9 +185,11 @@ def test_llm_health_check_accepts_provider_status_list_contract(
     )
 
     assert result.passed is True
-    assert result.metadata["summary"] == "2 provider/model target(s) available"
-    assert result.metadata["all_critical_targets_available"] == "true"
-    assert result.metadata["provider_models"] == (
+    assert _metadata_value(result.metadata, "summary") == (
+        "2 provider/model target(s) available"
+    )
+    assert _metadata_value(result.metadata, "all_critical_targets_available") == "true"
+    assert _metadata_value(result.metadata, "provider_models") == (
         "fake-llm/fast-model, backup-llm/deep-model"
     )
 
@@ -221,17 +226,19 @@ def test_llm_health_check_fails_phase0_infra_with_fail_run_action(
     )
 
     assert result.passed is False
-    assert result.metadata["failure_class"] == "infra"
-    assert result.metadata["action"] == "fail_run"
-    assert result.metadata["scenario_id"] == "phase0_llm_health_check_failed"
-    assert result.metadata["providers"] == "backup-llm, fake-llm"
-    assert result.metadata["provider_models"] == (
+    assert _metadata_value(result.metadata, "failure_class") == "infra"
+    assert _metadata_value(result.metadata, "action") == "fail_run"
+    assert _metadata_value(result.metadata, "scenario_id") == (
+        "phase0_llm_health_check_failed"
+    )
+    assert _metadata_value(result.metadata, "providers") == "backup-llm, fake-llm"
+    assert _metadata_value(result.metadata, "provider_models") == (
         "fake-llm/critical-model, backup-llm/fallback-model"
     )
-    assert result.metadata["unavailable_provider_models"] == (
+    assert _metadata_value(result.metadata, "unavailable_provider_models") == (
         "fake-llm/critical-model"
     )
-    assert result.metadata["summary"] == (
+    assert _metadata_value(result.metadata, "summary") == (
         "critical target fake-llm/critical-model unavailable"
     )
 
@@ -292,12 +299,16 @@ def test_llm_health_check_probe_exception_is_policy_classified(
     payload = json.loads(caplog.records[-1].message)
 
     assert result.passed is False
-    assert result.metadata["provider"] == "fake-llm"
-    assert result.metadata["provider_models"] == "fake-llm/unknown"
-    assert result.metadata["summary"] == "llm health probe failed: probe timeout"
-    assert result.metadata["failure_class"] == "infra"
-    assert result.metadata["action"] == "fail_run"
-    assert result.metadata["scenario_id"] == "phase0_llm_health_check_failed"
+    assert _metadata_value(result.metadata, "provider") == "fake-llm"
+    assert _metadata_value(result.metadata, "provider_models") == "fake-llm/unknown"
+    assert _metadata_value(result.metadata, "summary") == (
+        "llm health probe failed: probe timeout"
+    )
+    assert _metadata_value(result.metadata, "failure_class") == "infra"
+    assert _metadata_value(result.metadata, "action") == "fail_run"
+    assert _metadata_value(result.metadata, "scenario_id") == (
+        "phase0_llm_health_check_failed"
+    )
     assert payload["failure_class"] == "infra"
     assert payload["action"] == "fail_run"
     assert payload["scenario_id"] == "phase0_llm_health_check_failed"
@@ -339,3 +350,13 @@ def _check_names(defs: Any) -> set[str]:
         if name := getattr(check_def, "name", None):
             names.add(name)
     return names
+
+
+def _metadata_value(metadata: Mapping[str, object], key: str) -> str:
+    value = metadata[key]
+    text = getattr(value, "text", None)
+    if isinstance(text, str):
+        return text
+    if isinstance(value, str):
+        return value
+    return str(value)

--- a/tests/integration/failure_injection.py
+++ b/tests/integration/failure_injection.py
@@ -484,7 +484,7 @@ def _run_phase0_readiness_failure(
     )
 
     with caplog.at_level(logging.WARNING, logger="orchestrator.alerting.dispatcher"):
-        sensor_result = data_readiness_sensor.evaluation_fn(context)
+        sensor_result = evaluate_sensor(data_readiness_sensor, context)
 
     return FailureInjectionOutcome(
         action=decision.action.value,
@@ -1432,6 +1432,19 @@ def expected_request_from_plan(
     )
 
 
+def evaluate_sensor(sensor_definition: object, context: object) -> object:
+    evaluation_fn = getattr(sensor_definition, "evaluation_fn", None)
+    if evaluation_fn is None:
+        evaluation_fn = getattr(sensor_definition, "_evaluation_fn", None)
+    if evaluation_fn is None:
+        return sensor_definition(context)  # type: ignore[operator]
+
+    result = evaluation_fn(context)
+    if isinstance(result, list) and len(result) == 1:
+        return result[0]
+    return result
+
+
 __all__ = [
     "FailureInjectionCase",
     "FailureInjectionOutcome",
@@ -1454,6 +1467,7 @@ __all__ = [
     "heartbeat_asset_key",
     "last_alert_payload",
     "rerun_request_payloads",
+    "evaluate_sensor",
     "single_alert_for_failed_node",
     "single_evaluation",
 ]

--- a/tests/integration/test_phase0_failure_matrix.py
+++ b/tests/integration/test_phase0_failure_matrix.py
@@ -83,7 +83,7 @@ def test_readiness_not_ready_fails_phase0_alerts_and_skips(
         policy,
     )
     with caplog.at_level(logging.WARNING):
-        result = data_readiness_sensor.evaluation_fn(context)
+        result = _evaluate_sensor(data_readiness_sensor, context)
 
     alert = _alert_payloads(caplog)[-1]
 
@@ -399,3 +399,16 @@ def _heartbeat_asset_key(dbt_phase0_assets: object) -> object:
         if path and path[-1] == "heartbeat":
             return asset_key
     pytest.fail("dbt heartbeat model asset key was not registered")
+
+
+def _evaluate_sensor(sensor_definition: object, context: object) -> object:
+    evaluation_fn = getattr(sensor_definition, "evaluation_fn", None)
+    if evaluation_fn is None:
+        evaluation_fn = getattr(sensor_definition, "_evaluation_fn", None)
+    if evaluation_fn is None:
+        return sensor_definition(context)  # type: ignore[operator]
+
+    result = evaluation_fn(context)
+    if isinstance(result, list) and len(result) == 1:
+        return result[0]
+    return result

--- a/tests/jobs/test_phase0.py
+++ b/tests/jobs/test_phase0.py
@@ -1,3 +1,4 @@
+import ast
 import os
 import sys
 from pathlib import Path
@@ -77,6 +78,30 @@ def test_phase0_readiness_ping_key_is_addressable(
 
     assert phase0_readiness_ping.key == asset_key
     assert asset_key in phase0_readiness_ping.keys
+
+
+def test_dbt_phase0_assets_context_is_unannotated_for_dagster_19() -> None:
+    phase0_path = _REPO_ROOT / "src" / "orchestrator" / "jobs" / "phase0.py"
+    tree = ast.parse(phase0_path.read_text())
+    dbt_asset_function = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "dbt_phase0_assets"
+    )
+    context_arg = dbt_asset_function.args.args[0]
+
+    assert context_arg.arg == "context"
+    assert context_arg.annotation is None
+
+
+def test_dbt_phase0_assets_imports_under_supported_dagster_range(
+    phase0_module: Any,
+) -> None:
+    dagster = pytest.importorskip("dagster", reason="dagster is not installed")
+
+    defs = dagster.Definitions(assets=[phase0_module.dbt_phase0_assets])
+
+    assert isinstance(defs, dagster.Definitions)
 
 
 def test_missing_dbt_manifest_fails_with_prepare_hint(

--- a/tests/jobs/test_phase0.py
+++ b/tests/jobs/test_phase0.py
@@ -1,5 +1,7 @@
 import ast
 import os
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -24,8 +26,7 @@ def asset_key_type() -> Any:
 def phase0_module() -> Any:
     pytest.importorskip("dagster", reason="dagster is not installed")
     pytest.importorskip("dagster_dbt", reason="dagster-dbt is not installed")
-    if not _DBT_MANIFEST_PATH.exists():
-        pytest.skip("dbt manifest is not compiled; run make dbt-compile")
+    _ensure_dbt_manifest()
 
     from orchestrator.jobs import phase0
 
@@ -98,8 +99,23 @@ def test_dbt_phase0_assets_imports_under_supported_dagster_range(
     phase0_module: Any,
 ) -> None:
     dagster = pytest.importorskip("dagster", reason="dagster is not installed")
+    from dagster_dbt import DbtCliResource
 
-    defs = dagster.Definitions(assets=[phase0_module.dbt_phase0_assets])
+    from orchestrator.checks.resources import GatePolicyResource
+
+    defs = dagster.Definitions(
+        assets=[phase0_module.dbt_phase0_assets],
+        resources={
+            "dbt": DbtCliResource(
+                project_dir=str(phase0_module.DBT_PROJECT_DIR),
+                profiles_dir=str(phase0_module.DBT_PROFILES_DIR),
+            ),
+            "gate_policy": GatePolicyResource(
+                policy_path="config/policy/gate_policy.lite.yaml",
+            ),
+        },
+    )
+    dagster.Definitions.validate_loadable(defs)
 
     assert isinstance(defs, dagster.Definitions)
 
@@ -126,3 +142,38 @@ def _clear_phase0_imports() -> None:
             sys.modules.pop(module_name, None)
         elif module_name.startswith("orchestrator.jobs."):
             sys.modules.pop(module_name, None)
+
+
+def _ensure_dbt_manifest() -> None:
+    if _DBT_MANIFEST_PATH.exists():
+        return
+
+    dbt_executable = shutil.which("dbt")
+    if dbt_executable is None:
+        pytest.fail(
+            "dbt manifest is missing and dbt CLI is unavailable; "
+            "install dev dependencies or run make dbt-compile",
+        )
+
+    result = subprocess.run(
+        [
+            dbt_executable,
+            "compile",
+            "--profiles-dir",
+            str(_DBT_PROJECT_DIR),
+            "--project-dir",
+            str(_DBT_PROJECT_DIR),
+        ],
+        cwd=_DBT_PROJECT_DIR,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if result.returncode == 0 and _DBT_MANIFEST_PATH.exists():
+        return
+
+    pytest.fail(
+        "dbt manifest is missing and dbt compile failed.\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}",
+    )

--- a/tests/sensors/test_data_readiness.py
+++ b/tests/sensors/test_data_readiness.py
@@ -67,7 +67,7 @@ def test_data_readiness_sensor_ready_returns_run_request(
     )
 
     with caplog.at_level(logging.WARNING):
-        result = data_readiness_sensor.evaluation_fn(context)
+        result = _evaluate_sensor(data_readiness_sensor, context)
 
     assert isinstance(result, RunRequest)
     assert result.run_key == "cycle-20260416"
@@ -95,7 +95,7 @@ def test_data_readiness_sensor_not_ready_returns_skip_reason(
         },
     )
 
-    result = data_readiness_sensor.evaluation_fn(context)
+    result = _evaluate_sensor(data_readiness_sensor, context)
 
     assert isinstance(result, SkipReason)
     assert "market data delayed" in result.skip_message
@@ -126,7 +126,7 @@ def test_data_readiness_sensor_not_ready_dispatches_policy_alert(
     assert first_policy_row.action is GateAction.FAIL_RUN
 
     with caplog.at_level(logging.WARNING):
-        data_readiness_sensor.evaluation_fn(context)
+        _evaluate_sensor(data_readiness_sensor, context)
 
     payload = _alert_payloads(caplog)[-1]
 
@@ -190,7 +190,7 @@ def test_data_readiness_sensor_rejects_invalid_provider_signal(
     )
 
     with pytest.raises(TypeError, match=message):
-        data_readiness_sensor.evaluation_fn(context)
+        _evaluate_sensor(data_readiness_sensor, context)
 
 
 def test_data_readiness_sensor_name(sensor_exports: dict[str, Any]) -> None:
@@ -264,3 +264,16 @@ def _target_name(definition: Any) -> str | None:
             if isinstance(value, str):
                 return value
     return None
+
+
+def _evaluate_sensor(sensor_definition: Any, context: Any) -> Any:
+    evaluation_fn = getattr(sensor_definition, "evaluation_fn", None)
+    if evaluation_fn is None:
+        evaluation_fn = getattr(sensor_definition, "_evaluation_fn", None)
+    if evaluation_fn is None:
+        return sensor_definition(context)
+
+    result = evaluation_fn(context)
+    if isinstance(result, list) and len(result) == 1:
+        return result[0]
+    return result

--- a/tests/sensors/test_temporal_handoff.py
+++ b/tests/sensors/test_temporal_handoff.py
@@ -260,7 +260,7 @@ def test_temporal_handoff_sensor_uses_client_from_resource_bundle_and_cursors_ru
     )
     sensor_definition = build_temporal_handoff_sensor(policy=_temporal_policy())
 
-    result = sensor_definition.evaluation_fn(context)
+    result = _evaluate_sensor(sensor_definition, context)
 
     assert isinstance(result, SkipReason)
     assert "started" in result.skip_message
@@ -305,7 +305,7 @@ def test_temporal_handoff_sensor_cursor_does_not_reprocess_older_run(
     )
     sensor_definition = build_temporal_handoff_sensor(policy=_temporal_policy())
 
-    result = sensor_definition.evaluation_fn(context)
+    result = _evaluate_sensor(sensor_definition, context)
 
     assert isinstance(result, SkipReason)
     assert "no successful daily_cycle_phase0_job run is ready" in result.skip_message
@@ -334,9 +334,9 @@ def test_temporal_handoff_sensor_processes_unseen_run_at_same_timestamp(
     )
     sensor_definition = build_temporal_handoff_sensor(policy=_temporal_policy())
 
-    first_result = sensor_definition.evaluation_fn(context)
-    second_result = sensor_definition.evaluation_fn(context)
-    third_result = sensor_definition.evaluation_fn(context)
+    first_result = _evaluate_sensor(sensor_definition, context)
+    second_result = _evaluate_sensor(sensor_definition, context)
+    third_result = _evaluate_sensor(sensor_definition, context)
 
     assert isinstance(first_result, SkipReason)
     assert isinstance(second_result, SkipReason)
@@ -376,7 +376,7 @@ def test_temporal_handoff_sensor_legacy_cursor_stops_at_processed_run(
     )
     sensor_definition = build_temporal_handoff_sensor(policy=_temporal_policy())
 
-    result = sensor_definition.evaluation_fn(context)
+    result = _evaluate_sensor(sensor_definition, context)
 
     assert isinstance(result, SkipReason)
     assert "no successful daily_cycle_phase0_job run is ready" in result.skip_message
@@ -438,3 +438,16 @@ class _FakeTemporalSensorContext:
     def update_cursor(self, cursor: str) -> None:
         self.updated_cursor = cursor
         self.cursor = cursor
+
+
+def _evaluate_sensor(sensor_definition: Any, context: Any) -> Any:
+    evaluation_fn = getattr(sensor_definition, "evaluation_fn", None)
+    if evaluation_fn is None:
+        evaluation_fn = getattr(sensor_definition, "_evaluation_fn", None)
+    if evaluation_fn is None:
+        return sensor_definition(context)
+
+    result = evaluation_fn(context)
+    if isinstance(result, list) and len(result) == 1:
+        return result[0]
+    return result


### PR DESCRIPTION
Closes #102

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `scripts/check_boundaries.py`, `src/orchestrator/checks/asset_checks.py`, `src/orchestrator/checks/phase1.py`, `src/orchestrator/checks/phase3.py`, `src/orchestrator/definitions.py`, `src/orchestrator/jobs/phase0.py`, `src/orchestrator/sensors/manual_rerun.py`, `tests/cli/__init__.py`


---
## Background

CI fails with Dagster 1.9.x:

\`\`\`
DagsterInvalidDefinitionError: Cannot annotate \`context\` parameter with type AssetExecutionContext.
\`context\` must be annotated with AssetExecutionContext, AssetCheckExecutionContext, OpExecutionContext, or left blank.
\`\`\`

The error is paradoxical (says must use AssetExecutionContext while rejecting it). Likely a class-identity mismatch — Dagster 1.9 may compare \`is\` against a specific path, and the import path the code uses doesn't match.

## Current code (src/orchestrator/jobs/phase0.py:9, 51)

\`\`\`python
from dagster import AssetExecutionContext, ResourceParam, asset
@dbt_assets(manifest=...)
def dbt_phase0_assets(
    context: AssetExecutionContext,
    ...
)
\`\`\`

## Possible fixes

1. Use \`OpExecutionContext\` instead (older API style for dbt_assets)
2. Or import from \`dagster._core.execution.context.compute\` explicitly
3. Or remove the type annotation entirely (let Dagster infer)

## Constraint

Pyproject is pinned to \`dagster>=1.7,<1.10\`. Don't downgrade further (1.5 would conflict with pydantic v2 used elsewhere).

## Verification

- \`make test\` passes locally
- CI green: https://github.com/shenfanjie5-bit/project-ult-orchestrator/actions