### PR TITLE
feat(#111): [milestone-6 review] P0: Missing gate policy now silently changes backend behavior

### DIFF
--- a/src/orchestrator/definitions.py
+++ b/src/orchestrator/definitions.py
@@ -48,7 +48,7 @@ from orchestrator.jobs.phase3 import (
     PHASE3_GROUP_NAME,
     PHASE3_MANIFEST_ASSET_KEY,
 )
-from orchestrator.policy import load_gate_policy
+from orchestrator.policy import GatePolicyProfile, load_gate_policy
 from orchestrator.resources import (
     INFRASTRUCTURE_RESOURCE_PHASES,
     AssetFactoryProvider,
@@ -189,6 +189,27 @@ class _FailClosedDataReadinessResource(ConfigurableResource):
         return _MissingDataReadinessProvider()
 
 
+class _LoadedGatePolicyResource(GatePolicyResource):
+    """Gate policy resource bound to the assembly-time validated profile."""
+
+    def __init__(self, *, policy_path: str, policy: GatePolicyProfile) -> None:
+        super().__init__(policy_path=policy_path)
+        self._policy = policy
+
+    def setup_for_execution(self, context: object) -> None:
+        return None
+
+    @property
+    def policy(self) -> GatePolicyProfile:
+        if self._policy is None:
+            msg = (
+                "gate policy snapshot was not initialized during "
+                "Definitions assembly"
+            )
+            raise RuntimeError(msg)
+        return self._policy
+
+
 def build_definitions(
     module_factories: Iterable[AssetFactoryProvider] | None = None,
     policy_path: str | Path | None = None,
@@ -251,9 +272,13 @@ def build_definitions(
         _FailClosedLLMHealthProbeResource(),
     )
     data_readiness_resource = _data_readiness_resource(resource_bundle.resources)
+    gate_policy_resource = _LoadedGatePolicyResource(
+        policy_path=str(policy_path),
+        policy=policy,
+    )
     resources = _guard_infrastructure_resources(
         {
-            "gate_policy": GatePolicyResource(policy_path=str(policy_path)),
+            "gate_policy": gate_policy_resource,
             "dbt": DbtCliResource(
                 project_dir=str(DBT_PROJECT_DIR),
                 profiles_dir=str(DBT_PROFILES_DIR),
@@ -890,6 +915,8 @@ def _guard_infrastructure_resources(
     for resource_key, phase in INFRASTRUCTURE_RESOURCE_PHASES.items():
         resource = guarded_resources.get(resource_key)
         if resource is None:
+            continue
+        if resource_key == "gate_policy":
             continue
         guarded_resources[resource_key] = guard_infrastructure_resource(
             resource_key,

--- a/src/orchestrator/definitions.py
+++ b/src/orchestrator/definitions.py
@@ -198,14 +198,9 @@ def build_definitions(
             "ORCHESTRATOR_POLICY_PATH",
             DEFAULT_POLICY_PATH,
         )
+    policy = load_gate_policy(policy_path)
+    execution_backend = policy.execution_backend
     module_factory_list = _resolve_module_factories(module_factories)
-    try:
-        policy = load_gate_policy(policy_path)
-    except FileNotFoundError:
-        policy = None
-        execution_backend = "dagster_only"
-    else:
-        execution_backend = policy.execution_backend
     phase_config = {"execution_backend": execution_backend}
     daily_cycle_jobs = build_daily_cycle_jobs(phase_config)
     automatic_cycle_job = daily_cycle_jobs[0]
@@ -213,9 +208,6 @@ def build_definitions(
     data_readiness_sensor = build_data_readiness_sensor(automatic_cycle_job)
     sensors: list[object] = [data_readiness_sensor, manual_rerun_sensor]
     if execution_backend == "dagster_plus_temporal":
-        if policy is None:
-            msg = "temporal backend requires a loadable gate policy"
-            raise RuntimeError(msg)
         sensors.append(build_temporal_handoff_sensor(policy=policy))
 
     resource_bundle = build_resource_bundle(str(policy_path), module_factory_list)

--- a/src/orchestrator/definitions.py
+++ b/src/orchestrator/definitions.py
@@ -231,7 +231,15 @@ def build_definitions(
     if execution_backend == "dagster_plus_temporal":
         sensors.append(build_temporal_handoff_sensor(policy=policy))
 
-    resource_bundle = build_resource_bundle(str(policy_path), module_factory_list)
+    policy_path_str = str(policy_path)
+    resource_bundle = build_resource_bundle(
+        {
+            "config_ref": policy_path_str,
+            "policy_path": policy_path_str,
+            "gate_policy": policy,
+        },
+        module_factory_list,
+    )
     for reserved in _RESERVED_RESOURCE_KEYS:
         if reserved in resource_bundle.resource_keys:
             raise ValueError(f"duplicate resource key: {reserved}")
@@ -273,7 +281,7 @@ def build_definitions(
     )
     data_readiness_resource = _data_readiness_resource(resource_bundle.resources)
     gate_policy_resource = _LoadedGatePolicyResource(
-        policy_path=str(policy_path),
+        policy_path=policy_path_str,
         policy=policy,
     )
     resources = _guard_infrastructure_resources(
@@ -288,7 +296,8 @@ def build_definitions(
             "resource_bundle": resource_bundle,
             **resource_bundle.resources,
         },
-        policy_path=str(policy_path),
+        policy_path=policy_path_str,
+        policy=policy,
     )
 
     return Definitions(
@@ -910,6 +919,7 @@ def _data_readiness_resource(resources: Mapping[str, object]) -> object:
 def _guard_infrastructure_resources(
     resources: Mapping[str, object],
     policy_path: str,
+    policy: GatePolicyProfile,
 ) -> dict[str, object]:
     guarded_resources = dict(resources)
     for resource_key, phase in INFRASTRUCTURE_RESOURCE_PHASES.items():
@@ -923,6 +933,7 @@ def _guard_infrastructure_resources(
             resource,
             phase=phase,
             policy_path=policy_path,
+            policy=policy,
         )
     return guarded_resources
 

--- a/src/orchestrator/definitions.py
+++ b/src/orchestrator/definitions.py
@@ -189,25 +189,53 @@ class _FailClosedDataReadinessResource(ConfigurableResource):
         return _MissingDataReadinessProvider()
 
 
-class _LoadedGatePolicyResource(GatePolicyResource):
-    """Gate policy resource bound to the assembly-time validated profile."""
+# Module-level registry mapping policy_path -> assembly-time
+# GatePolicyProfile snapshot. Kept outside the Pydantic resource class
+# because Pydantic intercepts class-body attributes whose names start with
+# an underscore and turns them into ModelPrivateAttr descriptors, which
+# do not behave as ordinary mutable class attributes.
+_GATE_POLICY_ASSEMBLY_SNAPSHOTS: dict[str, GatePolicyProfile] = {}
 
-    def __init__(self, *, policy_path: str, policy: GatePolicyProfile) -> None:
-        super().__init__(policy_path=policy_path)
-        self._policy = policy
+
+class _LoadedGatePolicyResource(GatePolicyResource):
+    """Gate policy resource bound to the assembly-time validated profile.
+
+    The Dagster Pythonic-config plumbing clones resources at runtime via
+    ``self.__class__(**public_field_values)`` (see
+    ``dagster._config.pythonic_config.resource.ConfigurableResourceFactory.
+    _with_updated_values``). That call only carries Pydantic public fields,
+    so we cannot pass an assembly-time ``GatePolicyProfile`` through a
+    custom ``__init__`` keyword. Instead, we register the validated
+    snapshot under the canonical policy path in
+    ``_GATE_POLICY_ASSEMBLY_SNAPSHOTS`` and look it up from there whenever
+    the resource (or one of its clones) is asked for ``.policy``.
+    ``setup_for_execution`` is overridden to a no-op so the on-disk policy
+    is never silently reloaded after assembly: if the file on disk diverges
+    from the registered snapshot, gate decisions still classify against the
+    snapshot validated by ``build_definitions``.
+    """
+
+    @staticmethod
+    def register_snapshot(
+        policy_path: str,
+        policy: GatePolicyProfile,
+    ) -> None:
+        _GATE_POLICY_ASSEMBLY_SNAPSHOTS[policy_path] = policy
 
     def setup_for_execution(self, context: object) -> None:
         return None
 
     @property
     def policy(self) -> GatePolicyProfile:
-        if self._policy is None:
+        snapshot = _GATE_POLICY_ASSEMBLY_SNAPSHOTS.get(self.policy_path)
+        if snapshot is None:
             msg = (
-                "gate policy snapshot was not initialized during "
+                "gate policy snapshot for "
+                f"{self.policy_path!r} was not initialized during "
                 "Definitions assembly"
             )
             raise RuntimeError(msg)
-        return self._policy
+        return snapshot
 
 
 def build_definitions(
@@ -280,10 +308,8 @@ def build_definitions(
         _FailClosedLLMHealthProbeResource(),
     )
     data_readiness_resource = _data_readiness_resource(resource_bundle.resources)
-    gate_policy_resource = _LoadedGatePolicyResource(
-        policy_path=policy_path_str,
-        policy=policy,
-    )
+    _LoadedGatePolicyResource.register_snapshot(policy_path_str, policy)
+    gate_policy_resource = _LoadedGatePolicyResource(policy_path=policy_path_str)
     resources = _guard_infrastructure_resources(
         {
             "gate_policy": gate_policy_resource,

--- a/src/orchestrator/resources/infra.py
+++ b/src/orchestrator/resources/infra.py
@@ -169,6 +169,7 @@ def guard_infrastructure_resource(
     *,
     phase: PhaseEnum,
     policy_path: str,
+    policy: GatePolicyProfile | None = None,
 ) -> object:
     """Return a Dagster resource that alerts and fails on infra unavailability."""
 
@@ -190,6 +191,7 @@ def guard_infrastructure_resource(
                 resource_key=resource_key,
                 phase=phase,
                 policy_path=policy_path,
+                policy=policy,
                 context=context,
                 exc=exc,
             )
@@ -200,6 +202,7 @@ def guard_infrastructure_resource(
                 value=value,
                 phase=phase,
                 policy_path=policy_path,
+                policy=policy,
                 context=context,
             )
         finally:
@@ -238,6 +241,7 @@ def guard_provider_resource_construction(
             resource_key=resource_key,
             phase=_phase_for_resource_key(resource_key),
             policy_path=_policy_path_from_env_config(env_config),
+            policy=_policy_from_env_config(env_config),
             context=_BundleAssemblyContext(module_factory),
             exc=exc,
         )
@@ -246,7 +250,14 @@ def guard_provider_resource_construction(
 
 
 class _GuardedInfrastructureValue:
-    __slots__ = ("_context", "_phase", "_policy_path", "_resource_key", "_value")
+    __slots__ = (
+        "_context",
+        "_phase",
+        "_policy",
+        "_policy_path",
+        "_resource_key",
+        "_value",
+    )
 
     def __init__(
         self,
@@ -255,12 +266,14 @@ class _GuardedInfrastructureValue:
         value: object,
         phase: PhaseEnum,
         policy_path: str,
+        policy: GatePolicyProfile | None = None,
         context: object,
     ) -> None:
         self._resource_key = resource_key
         self._value = value
         self._phase = phase
         self._policy_path = policy_path
+        self._policy = policy
         self._context = context
 
     def __getattr__(self, name: str) -> object:
@@ -275,6 +288,7 @@ class _GuardedInfrastructureValue:
                 resource_key=self._resource_key,
                 phase=self._phase,
                 policy_path=self._policy_path,
+                policy=self._policy,
                 context=self._context,
                 exc=exc,
             )
@@ -284,6 +298,7 @@ class _GuardedInfrastructureValue:
                 resource_key=self._resource_key,
                 phase=self._phase,
                 policy_path=self._policy_path,
+                policy=self._policy,
                 context=self._context,
                 method=attribute,
             )
@@ -304,6 +319,7 @@ def _guard_method_call(
     resource_key: str,
     phase: PhaseEnum,
     policy_path: str,
+    policy: GatePolicyProfile | None,
     context: object,
     method: Callable[..., object],
 ) -> Callable[..., object]:
@@ -317,6 +333,7 @@ def _guard_method_call(
                 resource_key=resource_key,
                 phase=phase,
                 policy_path=policy_path,
+                policy=policy,
                 context=context,
                 exc=exc,
             )
@@ -402,6 +419,7 @@ def _raise_infrastructure_unavailable(
     resource_key: str,
     phase: PhaseEnum,
     policy_path: str,
+    policy: GatePolicyProfile | None = None,
     context: object,
     exc: BaseException,
 ) -> NoReturn:
@@ -410,11 +428,15 @@ def _raise_infrastructure_unavailable(
         phase=phase,
         reason=_exception_summary(exc),
     )
-    try:
-        policy = load_gate_policy(policy_path)
-    except Exception:
-        decision = _fallback_infrastructure_decision(phase)
-        channels = _FALLBACK_ALERT_CHANNELS
+    if policy is None:
+        try:
+            policy = load_gate_policy(policy_path)
+        except Exception:
+            decision = _fallback_infrastructure_decision(phase)
+            channels = _FALLBACK_ALERT_CHANNELS
+        else:
+            decision = classify_infrastructure_failure(phase, event, policy)
+            channels = policy.alert_channels
     else:
         decision = classify_infrastructure_failure(phase, event, policy)
         channels = policy.alert_channels
@@ -475,6 +497,18 @@ def _policy_path_from_env_config(env_config: Mapping[str, Any] | str | None) -> 
             if isinstance(value, str) and value.strip():
                 return value.strip()
     return ""
+
+
+def _policy_from_env_config(
+    env_config: Mapping[str, Any] | str | None,
+) -> GatePolicyProfile | None:
+    if not isinstance(env_config, Mapping):
+        return None
+    for key in ("gate_policy", "policy"):
+        value = env_config.get(key)
+        if isinstance(value, GatePolicyProfile):
+            return value
+    return None
 
 
 def _fallback_infrastructure_decision(phase: PhaseEnum) -> GateDecision:

--- a/tests/integration/test_infra_hard_stop.py
+++ b/tests/integration/test_infra_hard_stop.py
@@ -63,43 +63,31 @@ def test_daily_cycle_hard_stops_on_guarded_resource_init_failure(
     assert f"fake {failing_resource_key} unavailable" in str(payload["summary"])
 
 
-def test_daily_cycle_alerts_when_gate_policy_resource_load_fails(
+def test_build_definitions_fails_fast_when_gate_policy_path_missing(
     dagster_module: object,
-    dagster_instance: object,
     tmp_dbt_project: Path,
     tmp_path: Path,
-    caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Missing gate policy must raise loudly during Definitions assembly.
+
+    Per issue #111, the prior behavior (catch the FileNotFoundError, default
+    to dagster_only, register the resource and let it surface later) is a
+    silent backend swap that masks misconfiguration. The contract is now
+    fail-fast: build_definitions must validate the policy up front so the
+    backend selection, sensor wiring, and gate classification all derive
+    from the same validated profile.
+    """
     dagster = dagster_module
     missing_policy_path = tmp_path / "missing_gate_policy.yaml"
-    defs = _build_defs(
-        dagster,
-        monkeypatch=monkeypatch,
-        stub_policy_path=str(missing_policy_path),
-        failing_resource_key="none",
-    )
-    dagster.Definitions.validate_loadable(defs)
 
-    with caplog.at_level(logging.WARNING, logger="orchestrator.alerting.dispatcher"):
-        result = defs.get_job_def("daily_cycle_job").execute_in_process(
-            instance=dagster_instance,
-            raise_on_error=False,
-            tags={"cycle_id": "cycle-20260416"},
+    with pytest.raises(FileNotFoundError, match=missing_policy_path.name):
+        _build_defs(
+            dagster,
+            monkeypatch=monkeypatch,
+            stub_policy_path=str(missing_policy_path),
+            failing_resource_key="none",
         )
-
-    materialized_keys = asset_materialization_keys(result)
-    payload = _single_alert_for_resource(caplog.records, "gate_policy")
-
-    assert result.success is False
-    assert dagster.AssetKey(["graph_promotion"]) not in materialized_keys
-    assert payload["phase"] == "phase0"
-    assert payload["failure_class"] == "infra"
-    assert payload["action"] == "fail_run"
-    assert payload["scenario_id"] == "infra_unavailable_hard_stop"
-    assert payload["runbook_url"] == "docs/RUNBOOK_P5.md#phase2-infra-fail_run"
-    assert payload["failed_node"] == "gate_policy"
-    assert missing_policy_path.name in str(payload["summary"])
 
 
 def test_build_definitions_alerts_when_provider_get_resources_fails(

--- a/tests/resources/test_infra_gate.py
+++ b/tests/resources/test_infra_gate.py
@@ -154,6 +154,84 @@ def test_guarded_graph_backend_method_failure_is_classified() -> None:
     )
 
 
+def test_guarded_method_failure_uses_supplied_policy_snapshot(
+    tmp_path: Path,
+) -> None:
+    infra = _infra_module()
+    policy_path = _write_policy(tmp_path, _load_lite_policy_data())
+    policy = load_gate_policy(policy_path)
+    mutated_policy_data = _load_lite_policy_data()
+    for entry in mutated_policy_data["phase_matrix"]:
+        if entry["scenario_id"] == infra.INFRA_UNAVAILABLE_HARD_STOP_SCENARIO_ID:
+            entry["action"] = "repair_manifest"
+            break
+    policy_path.write_text(
+        yaml.safe_dump(mutated_policy_data),
+        encoding="utf-8",
+    )
+
+    class LazyFailingProbe:
+        def check_health(self) -> object:
+            raise RuntimeError("probe timed out")
+
+    guarded = infra._GuardedInfrastructureValue(
+        resource_key="llm_health_probe",
+        value=LazyFailingProbe(),
+        phase=PhaseEnum.PHASE0,
+        policy_path=str(policy_path),
+        policy=policy,
+        context=object(),
+    )
+
+    with pytest.raises(infra.InfrastructureUnavailableError) as exc_info:
+        guarded.check_health()
+
+    assert exc_info.value.event.resource_key == "llm_health_probe"
+    assert exc_info.value.decision.action is GateAction.FAIL_RUN
+    assert exc_info.value.decision.reason == (
+        "Core storage or graph infrastructure is unavailable; hard stop."
+    )
+
+
+def test_provider_resource_construction_failure_uses_supplied_policy_snapshot(
+    tmp_path: Path,
+) -> None:
+    infra = _infra_module()
+    policy_path = _write_policy(tmp_path, _load_lite_policy_data())
+    policy = load_gate_policy(policy_path)
+    mutated_policy_data = _load_lite_policy_data()
+    for entry in mutated_policy_data["phase_matrix"]:
+        if entry["scenario_id"] == infra.INFRA_UNAVAILABLE_HARD_STOP_SCENARIO_ID:
+            entry["action"] = "repair_manifest"
+            break
+    policy_path.write_text(
+        yaml.safe_dump(mutated_policy_data),
+        encoding="utf-8",
+    )
+
+    class BrokenProvider:
+        infrastructure_resource_key = "neo4j_driver"
+
+        def get_resources(self) -> dict[str, object]:
+            raise RuntimeError("neo4j unavailable during bundle assembly")
+
+    with pytest.raises(infra.InfrastructureUnavailableError) as exc_info:
+        infra.guard_provider_resource_construction(
+            BrokenProvider(),
+            env_config={
+                "config_ref": str(policy_path),
+                "policy_path": str(policy_path),
+                "gate_policy": policy,
+            },
+        )
+
+    assert exc_info.value.event.resource_key == "neo4j_driver"
+    assert exc_info.value.decision.action is GateAction.FAIL_RUN
+    assert exc_info.value.decision.reason == (
+        "Core storage or graph infrastructure is unavailable; hard stop."
+    )
+
+
 @pytest.mark.parametrize(
     "surface_name",
     [

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -2,7 +2,7 @@ import importlib
 import sys
 from inspect import signature
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -199,6 +199,41 @@ def test_build_definitions_gate_policy_resource_uses_assembly_snapshot(
 
     assert gate_policy_resource.policy is assembled_policy
     assert gate_policy_resource.policy.execution_backend == "dagster_plus_temporal"
+
+
+def test_build_definitions_guarded_resources_use_assembly_policy_snapshot(
+    definitions_exports: dict[str, Any],
+    tmp_path: Path,
+) -> None:
+    from orchestrator.resources import InfrastructureUnavailableError
+
+    build_definitions = definitions_exports["build_definitions"]
+    dagster = definitions_exports["dagster"]
+    policy_path = _policy_with_backend(tmp_path, "dagster_only")
+
+    defs = build_definitions(
+        module_factories=[
+            _fake_provider(dagster, fail_llm_health_probe=True),
+        ],
+        policy_path=policy_path,
+    )
+
+    _rewrite_infra_hard_stop_action(policy_path, "repair_manifest")
+    resource_iter = defs.resources["llm_health_probe"].resource_fn(
+        SimpleNamespace(run_id="policy-snapshot-regression"),
+    )
+    guarded_probe = next(resource_iter)
+    try:
+        with pytest.raises(InfrastructureUnavailableError) as exc_info:
+            guarded_probe.check_health()
+    finally:
+        resource_iter.close()
+
+    assert exc_info.value.event.resource_key == "llm_health_probe"
+    assert exc_info.value.decision.action.value == "fail_run"
+    assert exc_info.value.decision.reason == (
+        "Core storage or graph infrastructure is unavailable; hard stop."
+    )
 
 
 def test_build_definitions_backs_data_readiness_sensor_resources(
@@ -531,6 +566,7 @@ def _fake_provider(
     *,
     include_graph_gate: bool = True,
     include_graph_consistency_check: bool = True,
+    fail_llm_health_probe: bool = False,
 ) -> object:
     class FakeDataPlatformResource(dagster.ConfigurableResource):
         def create_resource(self, context: object) -> dict[str, str]:
@@ -551,6 +587,8 @@ def _fake_provider(
 
     class FakeLLMHealthProbe:
         def check_health(self) -> FakeLLMHealthReport:
+            if fail_llm_health_probe:
+                raise RuntimeError("fake llm health probe unavailable")
             return FakeLLMHealthReport()
 
     class FakeLLMHealthProbeResource(dagster.ConfigurableResource):
@@ -722,6 +760,23 @@ def _policy_with_backend(tmp_path: Path, backend: str) -> Path:
         encoding="utf-8",
     )
     return policy_path
+
+
+def _rewrite_infra_hard_stop_action(policy_path: Path, action: str) -> None:
+    original = (
+        "  - scenario_id: infra_unavailable_hard_stop\n"
+        "    phase: phase2\n"
+        "    failure_class: infra\n"
+        "    action: fail_run\n"
+    )
+    replacement = original.replace("action: fail_run", f"action: {action}")
+    policy_text = policy_path.read_text(encoding="utf-8")
+    if original not in policy_text:
+        raise AssertionError("infra_unavailable_hard_stop action block not found")
+    policy_path.write_text(
+        policy_text.replace(original, replacement),
+        encoding="utf-8",
+    )
 
 
 def _clear_definition_imports() -> None:

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -170,6 +170,37 @@ def test_build_definitions_temporal_backend_registers_phase0_entrypoint(
     assert defs.resources["resource_bundle"].config_ref == str(policy_path)
 
 
+def test_build_definitions_gate_policy_resource_uses_assembly_snapshot(
+    definitions_exports: dict[str, Any],
+    tmp_path: Path,
+) -> None:
+    build_definitions = definitions_exports["build_definitions"]
+    policy_path = _policy_with_backend(tmp_path, "dagster_plus_temporal")
+
+    defs = build_definitions(policy_path=policy_path)
+    gate_policy_resource = defs.resources["gate_policy"]
+    assembled_policy = gate_policy_resource.policy
+
+    assert assembled_policy.execution_backend == "dagster_plus_temporal"
+
+    policy_path.write_text(
+        policy_path.read_text(encoding="utf-8").replace(
+            "execution_backend: dagster_plus_temporal",
+            "execution_backend: dagster_only",
+        ),
+        encoding="utf-8",
+    )
+    gate_policy_resource.setup_for_execution(object())
+
+    assert gate_policy_resource.policy is assembled_policy
+    assert gate_policy_resource.policy.execution_backend == "dagster_plus_temporal"
+
+    policy_path.unlink()
+
+    assert gate_policy_resource.policy is assembled_policy
+    assert gate_policy_resource.policy.execution_backend == "dagster_plus_temporal"
+
+
 def test_build_definitions_backs_data_readiness_sensor_resources(
     definitions_exports: dict[str, Any],
 ) -> None:

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -6,6 +6,7 @@ from types import ModuleType
 from typing import Any, cast
 
 import pytest
+from pydantic import ValidationError
 
 from orchestrator.checks import DataReadinessSignal
 
@@ -88,8 +89,9 @@ def test_build_definitions_dagster_only_registers_full_cycle_entrypoints(
     definitions_exports: dict[str, Any],
 ) -> None:
     build_definitions = definitions_exports["build_definitions"]
+    policy_path = "config/policy/gate_policy.lite.yaml"
 
-    defs = build_definitions(policy_path="config/policy/gate_policy.lite.yaml")
+    defs = build_definitions(policy_path=policy_path)
 
     assert _job_names(defs) == {"daily_cycle_job"}
     assert _target_name(_schedule_by_name(defs, "daily_cycle_schedule")) == (
@@ -101,6 +103,34 @@ def test_build_definitions_dagster_only_registers_full_cycle_entrypoints(
     assert "temporal_handoff_sensor" not in {
         sensor.name for sensor in defs.sensors or ()
     }
+    assert defs.resources["gate_policy"].policy_path == policy_path
+    assert defs.resources["resource_bundle"].config_ref == policy_path
+
+
+def test_build_definitions_missing_policy_path_fails_during_assembly(
+    definitions_exports: dict[str, Any],
+    tmp_path: Path,
+) -> None:
+    build_definitions = definitions_exports["build_definitions"]
+    missing_policy_path = tmp_path / "missing-gate-policy.yaml"
+
+    with pytest.raises(FileNotFoundError, match="missing-gate-policy.yaml"):
+        build_definitions(policy_path=missing_policy_path)
+
+
+def test_build_definitions_invalid_policy_fails_during_assembly(
+    definitions_exports: dict[str, Any],
+    tmp_path: Path,
+) -> None:
+    build_definitions = definitions_exports["build_definitions"]
+    invalid_policy_path = tmp_path / "invalid-gate-policy.yaml"
+    invalid_policy_path.write_text(
+        "policy_version: invalid-test\nexecution_backend: temporal\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError, match="execution_backend"):
+        build_definitions(policy_path=invalid_policy_path)
 
 
 def test_build_definitions_temporal_backend_registers_phase0_entrypoint(
@@ -136,6 +166,8 @@ def test_build_definitions_temporal_backend_registers_phase0_entrypoint(
         defs,
         "temporal_handoff_sensor",
     ).required_resource_keys <= set(defs.resources)
+    assert defs.resources["gate_policy"].policy_path == str(policy_path)
+    assert defs.resources["resource_bundle"].config_ref == str(policy_path)
 
 
 def test_build_definitions_backs_data_readiness_sensor_resources(


### PR DESCRIPTION
Closes #111

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `scripts/check_boundaries.py`, `src/orchestrator/checks/asset_checks.py`, `src/orchestrator/checks/phase1.py`, `src/orchestrator/checks/phase3.py`, `src/orchestrator/definitions.py`, `src/orchestrator/sensors/manual_rerun.py`, `tests/cli/__init__.py`, `tests/jobs/test_phase0.py`


---
## 背景与目标
Milestone review for milestone-6 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
build_definitions now catches FileNotFoundError from load_gate_policy and defaults execution_backend to dagster_only, but later still wires GatePolicyResource with the missing policy_path and builds the ResourceBundle from the same path. This creates split-brain behavior: schedules/jobs are assembled as dagster_only, Temporal handoff is silently omitted, and gate checks can still fail later when the resource loads the missing policy. It also weakens the project contract that build_definitions loads and validates the Gate policy up front.

## 实现范围
- 修改文件: `src/orchestrator/definitions.py`
- Fail fast on a missing policy by default. If a dev/test fallback is required, make it explicit through a named profile or environment flag, construct a real validated fallback GatePolicyProfile, and add regression tests for missing policy, invalid policy, dagster_only, and dagster_plus_temporal backend selection.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/orchestrator/.venv/bin/python -m pytest
```
