### PR TITLE
[codex] m4.5 ex3 reasoner bridge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   # Existing full-suite lane preserved — installs sibling runtime repos
-  # because Actions checks out only orchestrator, plus shared fixtures.
+  # because Actions checks out only orchestrator.
   ci:
     runs-on: ubuntu-latest
     steps:
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install (full, incl. sibling runtimes + shared fixtures)
-        run: pip install -e ".[dev,shared-fixtures,full-ci]"
+      - name: Install (full, incl. sibling runtimes)
+        run: pip install -e ".[dev,full-ci]"
       - name: Tests
         run: python -m pytest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
     branches: [main]
 
 jobs:
-  # Existing full-suite lane preserved — full extras so legacy + contract
-  # cross-repo + regression all exercise the real fixture corpus.
+  # Existing full-suite lane preserved — installs sibling runtime repos
+  # because Actions checks out only orchestrator, plus shared fixtures.
   ci:
     runs-on: ubuntu-latest
     steps:
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install (full, incl. cross-repo + shared fixtures)
-        run: pip install -e ".[dev,contracts-schemas,shared-fixtures]"
+      - name: Install (full, incl. sibling runtimes + shared fixtures)
+        run: pip install -e ".[dev,shared-fixtures,full-ci]"
       - name: Tests
         run: python -m pytest
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,11 +38,20 @@ contracts-schemas = [
     "project-ult-contracts @ git+https://github.com/shenfanjie5-bit/project-ult-contracts.git@v0.1.2",
 ]
 # Shared regression fixtures bundled with project-ult-audit-eval.
-# Pinned to v0.2.4 (project-wide canonical_entity_id format
+# Pinned to v0.2.5 (project-wide canonical_entity_id format
 # reconciliation: every shared case now uses the runtime-aligned dot
 # form ENT_STOCK_<symbol>.<exchange>; iron rule #6).
 shared-fixtures = [
-    "project-ult-audit-eval @ git+https://github.com/shenfanjie5-bit/project-ult-audit-eval.git@v0.2.4",
+    "project-ult-audit-eval @ git+https://github.com/shenfanjie5-bit/project-ult-audit-eval.git@v0.2.5",
+]
+# Full GitHub Actions lane sibling runtime pins. GitHub Actions checks out
+# only orchestrator, so these direct refs provide the runtime modules.
+full-ci = [
+    "project-ult-contracts @ git+https://github.com/shenfanjie5-bit/project-ult-contracts.git@v0.1.3",
+    "project-ult-main-core @ git+https://github.com/shenfanjie5-bit/project-ult-main-core.git@efaa4f62027401ee85d1a20095ab4f7ff29e6994",
+    "project-ult-data-platform @ git+https://github.com/shenfanjie5-bit/project-ult-data-platform.git@52b8dd50dd8504cb024e46e4bcda5f6a9544628c",
+    "project-ult-graph-engine @ git+https://github.com/shenfanjie5-bit/project-ult-graph-engine.git@9dde6f80af996d661eaf86aef73acbc43f8300e9",
+    "project-ult-reasoner-runtime @ git+https://github.com/shenfanjie5-bit/project-ult-reasoner-runtime.git@025db5ba4b67aaa76545fd0b942e5b8856fcae89",
 ]
 
 [project.scripts]
@@ -60,6 +69,7 @@ addopts = "-q"
 pythonpath = [
     "src",
     "../main-core/src",
+    "../graph-engine",
     "../reasoner-runtime",
     "../contracts/src",
     "../data-platform/src",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,10 @@ shared-fixtures = [
 ]
 # Full GitHub Actions lane sibling runtime pins. GitHub Actions checks out
 # only orchestrator, so these direct refs provide the runtime modules.
+# Keep shared-fixtures on v0.2.5; full-ci needs newer audit replay APIs.
 full-ci = [
     "project-ult-contracts @ git+https://github.com/shenfanjie5-bit/project-ult-contracts.git@v0.1.3",
+    "project-ult-audit-eval @ git+https://github.com/shenfanjie5-bit/project-ult-audit-eval.git@85fcc4725fa5b70c39a57048ceb837951892ab69",
     "project-ult-main-core @ git+https://github.com/shenfanjie5-bit/project-ult-main-core.git@efaa4f62027401ee85d1a20095ab4f7ff29e6994",
     "project-ult-data-platform @ git+https://github.com/shenfanjie5-bit/project-ult-data-platform.git@52b8dd50dd8504cb024e46e4bcda5f6a9544628c",
     "project-ult-graph-engine @ git+https://github.com/shenfanjie5-bit/project-ult-graph-engine.git@9dde6f80af996d661eaf86aef73acbc43f8300e9",

--- a/src/orchestrator_adapters/p2_dry_run.py
+++ b/src/orchestrator_adapters/p2_dry_run.py
@@ -179,6 +179,16 @@ class P2InputProvider(Protocol):
         """Return feature bundles and source evidence for one frozen cycle."""
 
 
+class FrozenSelectionReader(Protocol):
+    """Read frozen data-platform selection rows for one current cycle."""
+
+    def load_frozen_selection_rows(
+        self,
+        cycle_id: str,
+    ) -> tuple[Mapping[str, object], ...]:
+        """Return candidate_queue rows selected for one frozen cycle."""
+
+
 class P2AuditPersistencePort(Protocol):
     """Durable audit/replay persistence boundary for P2 Phase 3 handoff."""
 
@@ -400,8 +410,54 @@ class DefaultReasonerRuntimeGateway:
         )
 
 
+class DataPlatformFrozenSelectionReader:
+    """Default frozen-selection reader over data-platform's repository boundary."""
+
+    def load_frozen_selection_rows(
+        self,
+        cycle_id: str,
+    ) -> tuple[Mapping[str, object], ...]:
+        from data_platform.cycle.repository import _create_engine, _text
+
+        engine = _create_engine()
+        try:
+            with engine.connect() as connection:
+                rows = (
+                    connection.execute(
+                        _text(
+                            """
+                            SELECT
+                                selection.candidate_id,
+                                candidate_queue.payload,
+                                candidate_queue.payload_type,
+                                candidate_queue.submitted_by,
+                                candidate_queue.validation_status
+                            FROM data_platform.cycle_candidate_selection AS selection
+                            JOIN data_platform.candidate_queue AS candidate_queue
+                              ON candidate_queue.id = selection.candidate_id
+                            WHERE selection.cycle_id = :cycle_id
+                            ORDER BY candidate_queue.ingest_seq ASC
+                            """
+                        ),
+                        {"cycle_id": cycle_id},
+                    )
+                    .mappings()
+                    .all()
+                )
+        finally:
+            engine.dispose()
+        return tuple(dict(row) for row in rows)
+
+
 class DataPlatformTushareCurrentCycleInputProvider:
     """Load P2 L1 inputs from frozen candidates and Tushare staging views."""
+
+    def __init__(
+        self,
+        *,
+        frozen_selection_reader: FrozenSelectionReader | None = None,
+    ) -> None:
+        self._frozen_selection_reader = frozen_selection_reader
 
     def load_current_cycle_inputs(
         self,
@@ -410,11 +466,17 @@ class DataPlatformTushareCurrentCycleInputProvider:
         graph_snapshot: str,
     ) -> P2CurrentCycleInputs:
         cycle_date = _cycle_date(cycle_id)
-        selected_candidates = _load_frozen_candidate_symbols(cycle_id)
+        selected_candidates = _load_frozen_candidate_symbols(
+            cycle_id,
+            reader=self._frozen_selection_reader,
+        )
         symbols = tuple(candidate["ts_code"] for candidate in selected_candidates)
         if not symbols:
             raise ValueError("P2 dry-run requires frozen current-cycle Tushare symbols")
-        ex3_graph_signals = _load_frozen_ex3_graph_signals(cycle_id)
+        ex3_graph_signals = _load_frozen_ex3_graph_signals(
+            cycle_id,
+            reader=self._frozen_selection_reader,
+        )
 
         rows = _load_tushare_staging_rows(cycle_date=cycle_date, symbols=symbols)
         rows_by_symbol = {str(row["ts_code"]): row for row in rows}
@@ -470,17 +532,30 @@ class DataPlatformTushareCurrentCycleInputProvider:
 class DataPlatformCanonicalCurrentCycleInputProvider:
     """Load P2 L1 inputs from provider-neutral data-platform canonical rows."""
 
+    def __init__(
+        self,
+        *,
+        frozen_selection_reader: FrozenSelectionReader | None = None,
+    ) -> None:
+        self._frozen_selection_reader = frozen_selection_reader
+
     def load_current_cycle_inputs(
         self,
         *,
         cycle_id: str,
         graph_snapshot: str,
     ) -> P2CurrentCycleInputs:
-        selected_candidates = _load_frozen_candidate_symbols(cycle_id)
+        selected_candidates = _load_frozen_candidate_symbols(
+            cycle_id,
+            reader=self._frozen_selection_reader,
+        )
         candidate_refs = tuple(str(candidate["ts_code"]) for candidate in selected_candidates)
         if not candidate_refs:
             raise ValueError("P2 dry-run requires frozen current-cycle canonical candidates")
-        ex3_graph_signals = _load_frozen_ex3_graph_signals(cycle_id)
+        ex3_graph_signals = _load_frozen_ex3_graph_signals(
+            cycle_id,
+            reader=self._frozen_selection_reader,
+        )
 
         selection_ref = f"cycle_candidate_selection:{cycle_id}"
         from data_platform.cycle import load_current_cycle_inputs
@@ -663,12 +738,15 @@ class P2DryRunAssetFactoryProvider:
         publish_port_factory: Callable[[], P2PublishPort] | None = None,
         audit_persistence_port: P2AuditPersistencePort | None = None,
         phase2_pool_failure_rate_provider: object | None = None,
+        frozen_selection_reader: FrozenSelectionReader | None = None,
         provide_llm_health_probe: bool = True,
         provide_io_manager: bool = True,
         require_cycle_tag: bool = False,
     ) -> None:
         self.reasoner_gateway = reasoner_gateway or DefaultReasonerRuntimeGateway()
-        self.input_provider = input_provider or DataPlatformCanonicalCurrentCycleInputProvider()
+        self.input_provider = input_provider or DataPlatformCanonicalCurrentCycleInputProvider(
+            frozen_selection_reader=frozen_selection_reader,
+        )
         self.publish_port_factory = publish_port_factory or DataPlatformIcebergPublishPort
         self.audit_persistence_port = audit_persistence_port or AuditEvalPersistencePort()
         self.phase2_pool_failure_rate_provider = phase2_pool_failure_rate_provider
@@ -1250,42 +1328,25 @@ def _non_llm_evidence(cycle_id: str, layer: str, object_key: str) -> P2LayerEvid
     )
 
 
-def _load_frozen_candidate_symbols(cycle_id: str) -> tuple[dict[str, object], ...]:
-    from data_platform.cycle.repository import _create_engine, _text
-
-    engine = _create_engine()
-    try:
-        with engine.connect() as connection:
-            rows = (
-                connection.execute(
-                    _text(
-                        """
-                        SELECT
-                            selection.candidate_id,
-                            candidate_queue.payload,
-                            candidate_queue.submitted_by
-                        FROM data_platform.cycle_candidate_selection AS selection
-                        JOIN data_platform.candidate_queue AS candidate_queue
-                          ON candidate_queue.id = selection.candidate_id
-                        WHERE selection.cycle_id = :cycle_id
-                        ORDER BY candidate_queue.ingest_seq ASC
-                        """
-                    ),
-                    {"cycle_id": cycle_id},
-                )
-                .mappings()
-                .all()
-            )
-    finally:
-        engine.dispose()
-
+def _load_frozen_candidate_symbols(
+    cycle_id: str,
+    *,
+    reader: FrozenSelectionReader | None = None,
+) -> tuple[dict[str, object], ...]:
+    rows = _load_frozen_selection_rows(cycle_id, reader=reader)
     candidates: list[dict[str, object]] = []
     for row in rows:
-        payload = row["payload"]
-        if isinstance(payload, str):
-            payload = json.loads(payload)
-        if not isinstance(payload, Mapping):
-            raise ValueError("P2 frozen candidate payload must be a JSON object")
+        row_payload_type = _selection_row_payload_type(row)
+        if row_payload_type is not None and _is_ex3_payload_type(row_payload_type):
+            continue
+        payload = _selection_payload_mapping(
+            row["payload"],
+            "P2 frozen candidate payload must be a JSON object",
+        )
+        if row_payload_type is None and _is_ex3_payload_type(
+            _payload_envelope_payload_type(payload)
+        ):
+            continue
         ts_code = payload.get("ts_code") or payload.get("entity_id")
         if not isinstance(ts_code, str) or not ts_code.strip():
             raise ValueError("P2 frozen candidate payload requires ts_code")
@@ -1302,40 +1363,29 @@ def _load_frozen_candidate_symbols(cycle_id: str) -> tuple[dict[str, object], ..
     return tuple(candidates)
 
 
-def _load_frozen_ex3_graph_signals(cycle_id: str) -> tuple[dict[str, object], ...]:
-    from data_platform.cycle.repository import _create_engine, _text
-
+def _load_frozen_ex3_graph_signals(
+    cycle_id: str,
+    *,
+    reader: FrozenSelectionReader | None = None,
+) -> tuple[dict[str, object], ...]:
     selection_ref = f"cycle_candidate_selection:{cycle_id}"
-    engine = _create_engine()
-    try:
-        with engine.connect() as connection:
-            rows = (
-                connection.execute(
-                    _text(
-                        """
-                        SELECT
-                            selection.candidate_id,
-                            candidate_queue.payload
-                        FROM data_platform.cycle_candidate_selection AS selection
-                        JOIN data_platform.candidate_queue AS candidate_queue
-                          ON candidate_queue.id = selection.candidate_id
-                        WHERE selection.cycle_id = :cycle_id
-                          AND candidate_queue.payload_type = :payload_type
-                          AND candidate_queue.validation_status = 'accepted'
-                        ORDER BY candidate_queue.ingest_seq ASC
-                        """
-                    ),
-                    {"cycle_id": cycle_id, "payload_type": _EX3_PAYLOAD_TYPE},
-                )
-                .mappings()
-                .all()
-            )
-    finally:
-        engine.dispose()
-
+    rows = _load_frozen_selection_rows(cycle_id, reader=reader)
     graph_signals: list[dict[str, object]] = []
     for row in rows:
-        payload = _ex3_contract_payload(row["payload"])
+        row_payload_type = _selection_row_payload_type(row)
+        if row_payload_type is not None and not _is_ex3_payload_type(row_payload_type):
+            continue
+        if not _is_accepted_selection_row(row):
+            continue
+        payload = _selection_payload_mapping(
+            row["payload"],
+            "P2 frozen Ex-3 graph signal payload must be a JSON object",
+        )
+        if row_payload_type is None and not _is_ex3_payload_type(
+            _payload_envelope_payload_type(payload)
+        ):
+            continue
+        payload = _ex3_contract_payload(payload)
         delta = _validated_ex3_candidate_graph_delta(payload)
         graph_signals.append(
             _ex3_graph_signal_summary(
@@ -1346,6 +1396,47 @@ def _load_frozen_ex3_graph_signals(cycle_id: str) -> tuple[dict[str, object], ..
             )
         )
     return tuple(graph_signals)
+
+
+def _load_frozen_selection_rows(
+    cycle_id: str,
+    *,
+    reader: FrozenSelectionReader | None,
+) -> tuple[Mapping[str, object], ...]:
+    selection_reader = reader or DataPlatformFrozenSelectionReader()
+    return tuple(selection_reader.load_frozen_selection_rows(cycle_id))
+
+
+def _selection_payload_mapping(payload: object, error_message: str) -> Mapping[str, object]:
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+    if not isinstance(payload, Mapping):
+        raise ValueError(error_message)
+    return cast(Mapping[str, object], payload)
+
+
+def _selection_row_payload_type(row: Mapping[str, object]) -> str | None:
+    return _non_empty_text(row.get("payload_type"))
+
+
+def _payload_envelope_payload_type(payload: Mapping[str, object]) -> str | None:
+    return _non_empty_text(payload.get("payload_type"))
+
+
+def _is_ex3_payload_type(payload_type: str | None) -> bool:
+    return payload_type is not None and payload_type.strip().lower() == "ex-3"
+
+
+def _is_accepted_selection_row(row: Mapping[str, object]) -> bool:
+    validation_status = _non_empty_text(row.get("validation_status"))
+    return validation_status is None or validation_status.lower() == "accepted"
+
+
+def _non_empty_text(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
 
 
 def _ex3_contract_payload(payload: object) -> object:
@@ -1376,6 +1467,7 @@ def _ex3_graph_signal_summary(
 ) -> dict[str, object]:
     return {
         "delta_id": str(getattr(delta, "delta_id")),
+        "delta_type": _contract_value(getattr(delta, "delta_type")),
         "source_node": str(getattr(delta, "source_node")),
         "target_node": str(getattr(delta, "target_node")),
         "relation_type": str(getattr(delta, "relation_type")),
@@ -1387,6 +1479,13 @@ def _ex3_graph_signal_summary(
         "candidate_id": candidate_id,
         "selection_ref": selection_ref,
     }
+
+
+def _contract_value(value: object) -> str:
+    enum_value = getattr(value, "value", None)
+    if enum_value is not None:
+        return str(enum_value)
+    return str(value)
 
 
 def _sanitize_ex3_graph_properties(properties: Mapping[str, object]) -> dict[str, object]:
@@ -1828,9 +1927,12 @@ def _model_dump(value: object) -> object:
 
 __all__ = [
     "AuditEvalPersistencePort",
+    "DataPlatformCanonicalCurrentCycleInputProvider",
+    "DataPlatformFrozenSelectionReader",
     "DataPlatformIcebergPublishPort",
     "DataPlatformTushareCurrentCycleInputProvider",
     "DefaultReasonerRuntimeGateway",
+    "FrozenSelectionReader",
     "P2AlphaAnalysisPayload",
     "P2CommittedFormalObjects",
     "P2CurrentCycleInputs",

--- a/src/orchestrator_adapters/p2_dry_run.py
+++ b/src/orchestrator_adapters/p2_dry_run.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from datetime import UTC, date, datetime, time, timedelta
 import hashlib
 import json
+from math import isfinite
 import os
 from typing import Any, Protocol, cast
 
@@ -25,6 +26,27 @@ _FORBIDDEN_PROVENANCE_MARKERS = ("smoke", "fixture", "historical")
 _FORBIDDEN_INPUT_MARKERS = (*_FORBIDDEN_PROVENANCE_MARKERS, "synthetic", "ent_p2")
 _LEGACY_INPUT_TABLE_DAILY = "main.stg_daily"
 _LEGACY_INPUT_TABLE_STOCK_BASIC = "main.stg_stock_basic"
+_EX3_PAYLOAD_TYPE = "Ex-3"
+_EX3_QUEUE_ENVELOPE_FIELDS = frozenset({"payload_type", "submitted_by"})
+_UNSAFE_EX3_GRAPH_PROPERTY_KEYS = frozenset(
+    {
+        "chunk",
+        "ingest_seq",
+        "light_rag_artifact",
+        "metadata",
+        "payload_type",
+        "raw_text",
+        "rejection_reason",
+        "submitted_at",
+        "submitted_by",
+        "validation_status",
+    }
+)
+_UNSAFE_EX3_GRAPH_PROPERTY_KEY_MARKERS = ("blob", "chunk", "light_rag", "lightrag", "raw_text")
+_MAX_EX3_GRAPH_SIGNAL_STRING_LENGTH = 2048
+_MAX_EX3_GRAPH_SIGNAL_COLLECTION_ITEMS = 50
+_MAX_EX3_GRAPH_SIGNAL_DEPTH = 4
+_DROP_EX3_GRAPH_SIGNAL_VALUE = object()
 
 
 class P2ReasonerUnavailable(RuntimeError):
@@ -392,6 +414,7 @@ class DataPlatformTushareCurrentCycleInputProvider:
         symbols = tuple(candidate["ts_code"] for candidate in selected_candidates)
         if not symbols:
             raise ValueError("P2 dry-run requires frozen current-cycle Tushare symbols")
+        ex3_graph_signals = _load_frozen_ex3_graph_signals(cycle_id)
 
         rows = _load_tushare_staging_rows(cycle_date=cycle_date, symbols=symbols)
         rows_by_symbol = {str(row["ts_code"]): row for row in rows}
@@ -407,6 +430,7 @@ class DataPlatformTushareCurrentCycleInputProvider:
                 cycle_id=cycle_id,
                 graph_snapshot=graph_snapshot,
                 row=rows_by_symbol[symbol],
+                ex3_graph_signals=ex3_graph_signals,
             )
             for symbol in symbols
         )
@@ -456,6 +480,7 @@ class DataPlatformCanonicalCurrentCycleInputProvider:
         candidate_refs = tuple(str(candidate["ts_code"]) for candidate in selected_candidates)
         if not candidate_refs:
             raise ValueError("P2 dry-run requires frozen current-cycle canonical candidates")
+        ex3_graph_signals = _load_frozen_ex3_graph_signals(cycle_id)
 
         selection_ref = f"cycle_candidate_selection:{cycle_id}"
         from data_platform.cycle import load_current_cycle_inputs
@@ -476,6 +501,7 @@ class DataPlatformCanonicalCurrentCycleInputProvider:
                 cycle_id=cycle_id,
                 graph_snapshot=graph_snapshot,
                 row=row,
+                ex3_graph_signals=ex3_graph_signals,
             )
             for row in rows
         )
@@ -1276,6 +1302,154 @@ def _load_frozen_candidate_symbols(cycle_id: str) -> tuple[dict[str, object], ..
     return tuple(candidates)
 
 
+def _load_frozen_ex3_graph_signals(cycle_id: str) -> tuple[dict[str, object], ...]:
+    from data_platform.cycle.repository import _create_engine, _text
+
+    selection_ref = f"cycle_candidate_selection:{cycle_id}"
+    engine = _create_engine()
+    try:
+        with engine.connect() as connection:
+            rows = (
+                connection.execute(
+                    _text(
+                        """
+                        SELECT
+                            selection.candidate_id,
+                            candidate_queue.payload
+                        FROM data_platform.cycle_candidate_selection AS selection
+                        JOIN data_platform.candidate_queue AS candidate_queue
+                          ON candidate_queue.id = selection.candidate_id
+                        WHERE selection.cycle_id = :cycle_id
+                          AND candidate_queue.payload_type = :payload_type
+                          AND candidate_queue.validation_status = 'accepted'
+                        ORDER BY candidate_queue.ingest_seq ASC
+                        """
+                    ),
+                    {"cycle_id": cycle_id, "payload_type": _EX3_PAYLOAD_TYPE},
+                )
+                .mappings()
+                .all()
+            )
+    finally:
+        engine.dispose()
+
+    graph_signals: list[dict[str, object]] = []
+    for row in rows:
+        payload = _ex3_contract_payload(row["payload"])
+        delta = _validated_ex3_candidate_graph_delta(payload)
+        graph_signals.append(
+            _ex3_graph_signal_summary(
+                delta,
+                cycle_id=cycle_id,
+                candidate_id=int(row["candidate_id"]),
+                selection_ref=selection_ref,
+            )
+        )
+    return tuple(graph_signals)
+
+
+def _ex3_contract_payload(payload: object) -> object:
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+    if not isinstance(payload, Mapping):
+        raise ValueError("P2 frozen Ex-3 graph signal payload must be a JSON object")
+    return {
+        key: value
+        for key, value in payload.items()
+        if key not in _EX3_QUEUE_ENVELOPE_FIELDS
+    }
+
+
+def _validated_ex3_candidate_graph_delta(payload: object) -> object:
+    from contracts.schemas import CandidateGraphDelta, Ex3CandidateGraphDelta
+
+    candidate_delta = CandidateGraphDelta.model_validate(payload)
+    return Ex3CandidateGraphDelta.model_validate(candidate_delta.model_dump(mode="python"))
+
+
+def _ex3_graph_signal_summary(
+    delta: object,
+    *,
+    cycle_id: str,
+    candidate_id: int,
+    selection_ref: str,
+) -> dict[str, object]:
+    return {
+        "delta_id": str(getattr(delta, "delta_id")),
+        "source_node": str(getattr(delta, "source_node")),
+        "target_node": str(getattr(delta, "target_node")),
+        "relation_type": str(getattr(delta, "relation_type")),
+        "properties": _sanitize_ex3_graph_properties(
+            cast(Mapping[str, object], getattr(delta, "properties"))
+        ),
+        "evidence_refs": [str(ref) for ref in getattr(delta, "evidence")],
+        "cycle_id": cycle_id,
+        "candidate_id": candidate_id,
+        "selection_ref": selection_ref,
+    }
+
+
+def _sanitize_ex3_graph_properties(properties: Mapping[str, object]) -> dict[str, object]:
+    sanitized: dict[str, object] = {}
+    for key, value in properties.items():
+        if _unsafe_ex3_graph_property_key(key):
+            continue
+        safe_value = _safe_ex3_graph_signal_value(value, depth=0)
+        if safe_value is _DROP_EX3_GRAPH_SIGNAL_VALUE:
+            continue
+        sanitized[str(key)] = safe_value
+    return sanitized
+
+
+def _safe_ex3_graph_signal_value(value: object, *, depth: int) -> object:
+    if depth > _MAX_EX3_GRAPH_SIGNAL_DEPTH:
+        return _DROP_EX3_GRAPH_SIGNAL_VALUE
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return value if isfinite(value) else _DROP_EX3_GRAPH_SIGNAL_VALUE
+    if isinstance(value, str):
+        if len(value) > _MAX_EX3_GRAPH_SIGNAL_STRING_LENGTH:
+            return _DROP_EX3_GRAPH_SIGNAL_VALUE
+        return value
+    if isinstance(value, Mapping):
+        safe_mapping: dict[str, object] = {}
+        for index, (key, item) in enumerate(value.items()):
+            if index >= _MAX_EX3_GRAPH_SIGNAL_COLLECTION_ITEMS:
+                break
+            if not isinstance(key, str) or _unsafe_ex3_graph_property_key(key):
+                continue
+            safe_item = _safe_ex3_graph_signal_value(item, depth=depth + 1)
+            if safe_item is not _DROP_EX3_GRAPH_SIGNAL_VALUE:
+                safe_mapping[key] = safe_item
+        return safe_mapping
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        safe_items: list[object] = []
+        for index, item in enumerate(value):
+            if index >= _MAX_EX3_GRAPH_SIGNAL_COLLECTION_ITEMS:
+                break
+            safe_item = _safe_ex3_graph_signal_value(item, depth=depth + 1)
+            if safe_item is not _DROP_EX3_GRAPH_SIGNAL_VALUE:
+                safe_items.append(safe_item)
+        return safe_items
+    return _DROP_EX3_GRAPH_SIGNAL_VALUE
+
+
+def _unsafe_ex3_graph_property_key(key: object) -> bool:
+    if not isinstance(key, str):
+        return True
+    normalized = key.strip().lower()
+    if not normalized or normalized.startswith("_") or normalized.startswith("private"):
+        return True
+    if normalized in _UNSAFE_EX3_GRAPH_PROPERTY_KEYS:
+        return True
+    if normalized.endswith("_metadata"):
+        return True
+    return any(marker in normalized for marker in _UNSAFE_EX3_GRAPH_PROPERTY_KEY_MARKERS)
+
+
 def _load_tushare_staging_rows(
     *,
     cycle_date: date,
@@ -1334,6 +1508,7 @@ def _feature_bundle_from_tushare_row(
     cycle_id: str,
     graph_snapshot: str,
     row: Mapping[str, object],
+    ex3_graph_signals: Sequence[Mapping[str, object]] = (),
 ) -> object:
     ts_code = str(row["ts_code"])
     pct_chg = _float_value(row.get("pct_chg"))
@@ -1364,6 +1539,7 @@ def _feature_bundle_from_tushare_row(
             "industry": row.get("industry"),
             "market": row.get("market"),
         },
+        ex3_graph_signals=ex3_graph_signals,
     )
 
 
@@ -1372,6 +1548,7 @@ def _feature_bundle_from_canonical_row(
     cycle_id: str,
     graph_snapshot: str,
     row: Mapping[str, object],
+    ex3_graph_signals: Sequence[Mapping[str, object]] = (),
 ) -> object:
     entity_id = str(row["entity_id"])
     return_1d = _float_value(row.get("return_1d"))
@@ -1404,6 +1581,7 @@ def _feature_bundle_from_canonical_row(
             "industry": row.get("industry"),
             "market": row.get("market"),
         },
+        ex3_graph_signals=ex3_graph_signals,
     )
 
 
@@ -1415,15 +1593,24 @@ def _feature_bundle(
     *,
     feature_values: Mapping[str, float] | None = None,
     signal_values: Mapping[str, object] | None = None,
+    ex3_graph_signals: Sequence[Mapping[str, object]] = (),
 ) -> object:
     from main_core.common.schemas import FeatureSignalBundle
+
+    graph_signal_summaries = [dict(signal) for signal in ex3_graph_signals]
 
     return FeatureSignalBundle(
         cycle_id=cycle_id,
         entity_id=entity_id,
         feature_values=dict(feature_values or {"momentum": momentum or 0.0}),
         signal_values=dict(signal_values or {"source": "current-cycle-test-input"}),
-        graph_features={"graph_snapshot_ref": graph_snapshot},
+        graph_features={
+            "graph_snapshot_ref": graph_snapshot,
+            "ex3_graph_signals": graph_signal_summaries,
+            "same_cycle_ex3_graph_signals": [
+                dict(signal) for signal in graph_signal_summaries
+            ],
+        },
         feature_weight_multiplier={
             feature_name: 1.0
             for feature_name in dict(feature_values or {"momentum": momentum})

--- a/src/orchestrator_adapters/production_daily_cycle.py
+++ b/src/orchestrator_adapters/production_daily_cycle.py
@@ -411,9 +411,15 @@ def production_daily_cycle_status() -> ProductionDailyCycleProviderStatus:
 
 
 def _default_graph_phase1_provider() -> object:
-    from graph_engine.providers import build_graph_phase1_provider
+    from graph_engine.providers import (
+        build_fail_closed_graph_phase1_provider,
+        build_graph_phase1_provider,
+    )
 
-    return build_graph_phase1_provider()
+    try:
+        return build_graph_phase1_provider()
+    except (EnvironmentError, RuntimeError, ValueError):
+        return build_fail_closed_graph_phase1_provider()
 
 
 def _collect(method_name: str, providers: Sequence[object]) -> tuple[object, ...]:

--- a/src/orchestrator_adapters/production_daily_cycle.py
+++ b/src/orchestrator_adapters/production_daily_cycle.py
@@ -418,7 +418,7 @@ def _default_graph_phase1_provider() -> object:
 
     try:
         return build_graph_phase1_provider()
-    except (EnvironmentError, RuntimeError, ValueError):
+    except EnvironmentError:
         return build_fail_closed_graph_phase1_provider()
 
 

--- a/tests/integration/temporal_parity_fixtures.py
+++ b/tests/integration/temporal_parity_fixtures.py
@@ -433,6 +433,7 @@ class TemporalParityFakeProvider:
         candidate_freeze = assets[PHASE0_CANDIDATE_FREEZE_ASSET_KEY]
         graph_status = assets[PHASE0_GRAPH_STATUS_ASSET_KEY]
         graph_snapshot = assets[PHASE1_GRAPH_SNAPSHOT_ASSET_KEY]
+        l7 = assets[PHASE2_STAGE_KEYS[-2]]
         l8 = assets[PHASE2_STAGE_KEYS[-1]]
         formal_objects_commit = assets[PHASE3_FORMAL_COMMIT_ASSET_KEY]
         cycle_publish_manifest = assets[PHASE3_MANIFEST_ASSET_KEY]

--- a/tests/integration/test_p2_dry_run_handoff.py
+++ b/tests/integration/test_p2_dry_run_handoff.py
@@ -133,20 +133,12 @@ def test_p2_dry_run_handoff_uses_data_platform_canonical_provider(
     from audit_eval.audit import InMemoryFormalAuditStorageAdapter
     from orchestrator.definitions import build_definitions
     from orchestrator.jobs.phase3 import PHASE3_FORMAL_COMMIT_ASSET_KEY
-    from orchestrator_adapters import p2_dry_run
     from orchestrator_adapters.p2_dry_run import (
         AuditEvalPersistencePort,
         DataPlatformCanonicalCurrentCycleInputProvider,
         DefaultReasonerRuntimeGateway,
         P2DryRunAssetFactoryProvider,
     )
-
-    def fake_candidates(cycle_id: str) -> tuple[dict[str, object], ...]:
-        assert cycle_id == "CYCLE_20260416"
-        return (
-            {"candidate_id": 10, "ts_code": "600519.SH", "submitted_by": "candidate-freeze"},
-            {"candidate_id": 11, "ts_code": "000001.SZ", "submitted_by": "candidate-freeze"},
-        )
 
     def fake_current_cycle_inputs(
         cycle_id: str,
@@ -164,13 +156,21 @@ def test_p2_dry_run_handoff_uses_data_platform_canonical_provider(
         )
 
     ex3_graph_signal = _safe_ex3_graph_signal()
-
-    def fake_ex3_graph_signals(cycle_id: str) -> tuple[dict[str, object], ...]:
-        assert cycle_id == "CYCLE_20260416"
-        return (ex3_graph_signal,)
-
-    monkeypatch.setattr(p2_dry_run, "_load_frozen_candidate_symbols", fake_candidates)
-    monkeypatch.setattr(p2_dry_run, "_load_frozen_ex3_graph_signals", fake_ex3_graph_signals)
+    frozen_reader = _FrozenSelectionReader(
+        (
+            _frozen_selection_row(10, {"ts_code": "600519.SH"}, payload_type="Ex-1"),
+            _frozen_selection_row(
+                40,
+                {
+                    **_ex3_graph_delta_payload(),
+                    "payload_type": "Ex-3",
+                    "submitted_by": "candidate-freeze",
+                },
+                payload_type="Ex-3",
+            ),
+            _frozen_selection_row(11, {"ts_code": "000001.SZ"}, payload_type="Ex-1"),
+        )
+    )
     import data_platform.cycle as data_platform_cycle
 
     monkeypatch.setattr(
@@ -191,6 +191,7 @@ def test_p2_dry_run_handoff_uses_data_platform_canonical_provider(
         audit_persistence_port=AuditEvalPersistencePort(
             storage_factory=lambda: audit_storage,
         ),
+        frozen_selection_reader=frozen_reader,
     )
     assert isinstance(provider.input_provider, DataPlatformCanonicalCurrentCycleInputProvider)
     defs = build_definitions(
@@ -474,13 +475,6 @@ def test_data_platform_canonical_provider_loads_current_cycle_evidence(
 ) -> None:
     from orchestrator_adapters import p2_dry_run
 
-    def fake_candidates(cycle_id: str) -> tuple[dict[str, object], ...]:
-        assert cycle_id == "CYCLE_20260416"
-        return (
-            {"candidate_id": 10, "ts_code": "600519.SH", "submitted_by": "candidate-freeze"},
-            {"candidate_id": 11, "ts_code": "000001.SZ", "submitted_by": "candidate-freeze"},
-        )
-
     def fake_current_cycle_inputs(
         cycle_id: str,
         selection_ref: str,
@@ -496,8 +490,12 @@ def test_data_platform_canonical_provider_loads_current_cycle_evidence(
             _canonical_input_row("ENT_STOCK_000001.SZ", -0.004),
         )
 
-    monkeypatch.setattr(p2_dry_run, "_load_frozen_candidate_symbols", fake_candidates)
-    monkeypatch.setattr(p2_dry_run, "_load_frozen_ex3_graph_signals", lambda cycle_id: ())
+    frozen_reader = _FrozenSelectionReader(
+        (
+            _frozen_selection_row(10, {"ts_code": "600519.SH"}, payload_type="Ex-1"),
+            _frozen_selection_row(11, {"ts_code": "000001.SZ"}, payload_type="Ex-1"),
+        )
+    )
     import data_platform.cycle as data_platform_cycle
 
     monkeypatch.setattr(
@@ -506,7 +504,10 @@ def test_data_platform_canonical_provider_loads_current_cycle_evidence(
         fake_current_cycle_inputs,
     )
 
-    inputs = p2_dry_run.DataPlatformCanonicalCurrentCycleInputProvider().load_current_cycle_inputs(
+    input_provider = p2_dry_run.DataPlatformCanonicalCurrentCycleInputProvider(
+        frozen_selection_reader=frozen_reader,
+    )
+    inputs = input_provider.load_current_cycle_inputs(
         cycle_id="CYCLE_20260416",
         graph_snapshot="graph://snapshot/current",
     )
@@ -531,28 +532,51 @@ def test_data_platform_canonical_provider_loads_current_cycle_evidence(
 @pytest.mark.parametrize("marker", ["ENT_P2_A", "ENT_P2_B", "synthetic-current-cycle"])
 def test_load_frozen_candidate_symbols_rejects_synthetic_candidates(
     marker: str,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from data_platform.cycle import repository
+    from orchestrator_adapters import p2_dry_run
+
+    rows = [_frozen_selection_row(1, {"ts_code": marker}, payload_type="Ex-1")]
+
+    with pytest.raises(ValueError, match="synthetic|ENT_P2"):
+        p2_dry_run._load_frozen_candidate_symbols(
+            "CYCLE_20260416",
+            reader=_FrozenSelectionReader(rows),
+        )
+
+
+def test_load_frozen_candidate_symbols_skips_ex3_rows_in_mixed_freeze() -> None:
     from orchestrator_adapters import p2_dry_run
 
     rows = [
-        {
-            "candidate_id": 1,
-            "payload": json.dumps({"ts_code": marker}),
-            "submitted_by": "candidate-freeze",
-        }
+        _frozen_selection_row(10, {"ts_code": "600519.SH"}, payload_type="Ex-1"),
+        _frozen_selection_row(40, _ex3_graph_delta_payload(), payload_type="Ex-3"),
+        _frozen_selection_row(
+            11,
+            {"entity_id": "000001.SZ", "payload_type": "Ex-1"},
+            payload_type=None,
+        ),
+        _frozen_selection_row(
+            41,
+            {
+                **_ex3_graph_delta_payload(delta_id="delta-ex3-envelope"),
+                "payload_type": "Ex-3",
+            },
+            payload_type=None,
+        ),
     ]
-    monkeypatch.setattr(repository, "_create_engine", lambda: _FakeEngine(rows))
 
-    with pytest.raises(ValueError, match="synthetic|ENT_P2"):
-        p2_dry_run._load_frozen_candidate_symbols("CYCLE_20260416")
+    candidates = p2_dry_run._load_frozen_candidate_symbols(
+        "CYCLE_20260416",
+        reader=_FrozenSelectionReader(rows),
+    )
+
+    assert candidates == (
+        {"candidate_id": 10, "ts_code": "600519.SH", "submitted_by": "candidate-freeze"},
+        {"candidate_id": 11, "ts_code": "000001.SZ", "submitted_by": "candidate-freeze"},
+    )
 
 
-def test_load_frozen_ex3_graph_signals_sanitizes_accepted_contract_payload(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from data_platform.cycle import repository
+def test_load_frozen_ex3_graph_signals_sanitizes_accepted_contract_payload() -> None:
     from orchestrator_adapters import p2_dry_run
 
     payload = _ex3_graph_delta_payload(
@@ -567,17 +591,31 @@ def test_load_frozen_ex3_graph_signals_sanitizes_accepted_contract_payload(
             "private_note": "drop",
         }
     )
-    payload["payload_type"] = "Ex-3"
-    payload["submitted_by"] = "candidate-freeze"
-    rows = [{"candidate_id": 40, "payload": json.dumps(payload)}]
-    engine = _FakeEngine(rows)
-    monkeypatch.setattr(repository, "_create_engine", lambda: engine)
+    envelope_payload = {
+        **payload,
+        "payload_type": "Ex-3",
+        "submitted_by": "candidate-freeze",
+    }
+    rows = [
+        _frozen_selection_row(38, envelope_payload, payload_type="Ex-1"),
+        _frozen_selection_row(
+            39,
+            envelope_payload,
+            payload_type=None,
+            validation_status="rejected",
+        ),
+        _frozen_selection_row(40, envelope_payload, payload_type=None),
+    ]
 
-    signals = p2_dry_run._load_frozen_ex3_graph_signals("CYCLE_20260416")
+    signals = p2_dry_run._load_frozen_ex3_graph_signals(
+        "CYCLE_20260416",
+        reader=_FrozenSelectionReader(rows),
+    )
 
     assert signals == (
         {
             "delta_id": "delta-ex3-bridge",
+            "delta_type": "edge_add",
             "source_node": "ENT_STOCK_600519.SH",
             "target_node": "ENT_STOCK_000001.SZ",
             "relation_type": "supplier_of",
@@ -591,11 +629,6 @@ def test_load_frozen_ex3_graph_signals_sanitizes_accepted_contract_payload(
             "selection_ref": "cycle_candidate_selection:CYCLE_20260416",
         },
     )
-    statement, params = engine.connection.executed[0]
-    sql = str(statement)
-    assert params == {"cycle_id": "CYCLE_20260416", "payload_type": "Ex-3"}
-    assert "validation_status = 'accepted'" in sql
-    assert "payload_type = :payload_type" in sql
     assert _no_unsafe_ex3_graph_signal_fields(signals)
 
 
@@ -762,49 +795,16 @@ class _FailingAuditPersistencePort:
         raise RuntimeError("audit storage unavailable")
 
 
-class _FakeEngine:
+class _FrozenSelectionReader:
     def __init__(self, rows: Sequence[Mapping[str, object]]) -> None:
-        self._rows = rows
-        self.connection = _FakeConnection(rows)
-        self.disposed = False
+        self._rows = tuple(dict(row) for row in rows)
 
-    def connect(self) -> object:
-        return self.connection
-
-    def dispose(self) -> None:
-        self.disposed = True
-
-
-class _FakeConnection:
-    def __init__(self, rows: Sequence[Mapping[str, object]]) -> None:
-        self._rows = rows
-        self.executed: list[tuple[object, Mapping[str, object]]] = []
-
-    def __enter__(self) -> "_FakeConnection":
-        return self
-
-    def __exit__(self, *args: object) -> None:
-        return None
-
-    def execute(self, statement: object, parameters: Mapping[str, object]) -> object:
-        assert parameters["cycle_id"] == "CYCLE_20260416"
-        if "payload_type" in parameters:
-            assert parameters["payload_type"] == "Ex-3"
-        else:
-            assert parameters == {"cycle_id": "CYCLE_20260416"}
-        self.executed.append((statement, dict(parameters)))
-        return _FakeResult(self._rows)
-
-
-class _FakeResult:
-    def __init__(self, rows: Sequence[Mapping[str, object]]) -> None:
-        self._rows = rows
-
-    def mappings(self) -> "_FakeResult":
-        return self
-
-    def all(self) -> list[Mapping[str, object]]:
-        return list(self._rows)
+    def load_frozen_selection_rows(
+        self,
+        cycle_id: str,
+    ) -> tuple[Mapping[str, object], ...]:
+        assert cycle_id == "CYCLE_20260416"
+        return self._rows
 
 
 @dataclass
@@ -1040,13 +1040,30 @@ def _canonical_input_row(entity_id: str, return_1d: float) -> dict[str, object]:
     }
 
 
+def _frozen_selection_row(
+    candidate_id: int,
+    payload: Mapping[str, object],
+    *,
+    payload_type: str | None,
+    validation_status: str = "accepted",
+) -> dict[str, object]:
+    return {
+        "candidate_id": candidate_id,
+        "payload": json.dumps(payload),
+        "payload_type": payload_type,
+        "submitted_by": "candidate-freeze",
+        "validation_status": validation_status,
+    }
+
+
 def _ex3_graph_delta_payload(
     *,
+    delta_id: str = "delta-ex3-bridge",
     properties: Mapping[str, object] | None = None,
 ) -> dict[str, object]:
     return {
         "subsystem_id": "subsystem-news",
-        "delta_id": "delta-ex3-bridge",
+        "delta_id": delta_id,
         "delta_type": "edge_add",
         "source_node": "ENT_STOCK_600519.SH",
         "target_node": "ENT_STOCK_000001.SZ",
@@ -1059,6 +1076,7 @@ def _ex3_graph_delta_payload(
 def _safe_ex3_graph_signal() -> dict[str, object]:
     return {
         "delta_id": "delta-ex3-bridge",
+        "delta_type": "edge_add",
         "source_node": "ENT_STOCK_600519.SH",
         "target_node": "ENT_STOCK_000001.SZ",
         "relation_type": "supplier_of",

--- a/tests/integration/test_p2_dry_run_handoff.py
+++ b/tests/integration/test_p2_dry_run_handoff.py
@@ -163,7 +163,14 @@ def test_p2_dry_run_handoff_uses_data_platform_canonical_provider(
             _canonical_input_row("ENT_STOCK_000001.SZ", -0.004),
         )
 
+    ex3_graph_signal = _safe_ex3_graph_signal()
+
+    def fake_ex3_graph_signals(cycle_id: str) -> tuple[dict[str, object], ...]:
+        assert cycle_id == "CYCLE_20260416"
+        return (ex3_graph_signal,)
+
     monkeypatch.setattr(p2_dry_run, "_load_frozen_candidate_symbols", fake_candidates)
+    monkeypatch.setattr(p2_dry_run, "_load_frozen_ex3_graph_signals", fake_ex3_graph_signals)
     import data_platform.cycle as data_platform_cycle
 
     monkeypatch.setattr(
@@ -224,6 +231,15 @@ def test_p2_dry_run_handoff_uses_data_platform_canonical_provider(
     assert "ENT_P2_A" not in committed_entities
     assert "ENT_P2_B" not in committed_entities
     assert publish_recorder.manifest_provenance is not None
+    l6_payloads = [
+        json.loads(str(call["messages"][1]["content"]))
+        for call in reasoner_recorder.calls
+        if call["metadata"]["layer"] == "L6"
+    ]
+    graph_features = l6_payloads[0]["context"]["feature_bundle"]["graph_features"]
+    assert graph_features["ex3_graph_signals"] == [ex3_graph_signal]
+    assert graph_features["same_cycle_ex3_graph_signals"] == [ex3_graph_signal]
+    assert _no_unsafe_ex3_graph_signal_fields(graph_features)
 
 
 def test_p2_dry_run_hard_stops_without_llm_before_l8_or_publish(
@@ -481,6 +497,7 @@ def test_data_platform_canonical_provider_loads_current_cycle_evidence(
         )
 
     monkeypatch.setattr(p2_dry_run, "_load_frozen_candidate_symbols", fake_candidates)
+    monkeypatch.setattr(p2_dry_run, "_load_frozen_ex3_graph_signals", lambda cycle_id: ())
     import data_platform.cycle as data_platform_cycle
 
     monkeypatch.setattr(
@@ -530,6 +547,56 @@ def test_load_frozen_candidate_symbols_rejects_synthetic_candidates(
 
     with pytest.raises(ValueError, match="synthetic|ENT_P2"):
         p2_dry_run._load_frozen_candidate_symbols("CYCLE_20260416")
+
+
+def test_load_frozen_ex3_graph_signals_sanitizes_accepted_contract_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from data_platform.cycle import repository
+    from orchestrator_adapters import p2_dry_run
+
+    payload = _ex3_graph_delta_payload(
+        properties={
+            "impact_score": 0.91,
+            "safe_details": {"direction": "positive", "chunk": "drop"},
+            "raw_text": "drop",
+            "chunk": {"text": "drop"},
+            "light_rag_artifact": {"artifact_id": "drop"},
+            "large_blob": "x" * 4096,
+            "metadata": {"source": "drop"},
+            "private_note": "drop",
+        }
+    )
+    payload["payload_type"] = "Ex-3"
+    payload["submitted_by"] = "candidate-freeze"
+    rows = [{"candidate_id": 40, "payload": json.dumps(payload)}]
+    engine = _FakeEngine(rows)
+    monkeypatch.setattr(repository, "_create_engine", lambda: engine)
+
+    signals = p2_dry_run._load_frozen_ex3_graph_signals("CYCLE_20260416")
+
+    assert signals == (
+        {
+            "delta_id": "delta-ex3-bridge",
+            "source_node": "ENT_STOCK_600519.SH",
+            "target_node": "ENT_STOCK_000001.SZ",
+            "relation_type": "supplier_of",
+            "properties": {
+                "impact_score": 0.91,
+                "safe_details": {"direction": "positive"},
+            },
+            "evidence_refs": ["evidence-ex3-bridge"],
+            "cycle_id": "CYCLE_20260416",
+            "candidate_id": 40,
+            "selection_ref": "cycle_candidate_selection:CYCLE_20260416",
+        },
+    )
+    statement, params = engine.connection.executed[0]
+    sql = str(statement)
+    assert params == {"cycle_id": "CYCLE_20260416", "payload_type": "Ex-3"}
+    assert "validation_status = 'accepted'" in sql
+    assert "payload_type = :payload_type" in sql
+    assert _no_unsafe_ex3_graph_signal_fields(signals)
 
 
 @pytest.mark.parametrize("marker", ["ENT_P2_A", "ENT_P2_B", "synthetic-current-cycle"])
@@ -698,10 +765,11 @@ class _FailingAuditPersistencePort:
 class _FakeEngine:
     def __init__(self, rows: Sequence[Mapping[str, object]]) -> None:
         self._rows = rows
+        self.connection = _FakeConnection(rows)
         self.disposed = False
 
     def connect(self) -> object:
-        return _FakeConnection(self._rows)
+        return self.connection
 
     def dispose(self) -> None:
         self.disposed = True
@@ -710,6 +778,7 @@ class _FakeEngine:
 class _FakeConnection:
     def __init__(self, rows: Sequence[Mapping[str, object]]) -> None:
         self._rows = rows
+        self.executed: list[tuple[object, Mapping[str, object]]] = []
 
     def __enter__(self) -> "_FakeConnection":
         return self
@@ -718,7 +787,12 @@ class _FakeConnection:
         return None
 
     def execute(self, statement: object, parameters: Mapping[str, object]) -> object:
-        assert parameters == {"cycle_id": "CYCLE_20260416"}
+        assert parameters["cycle_id"] == "CYCLE_20260416"
+        if "payload_type" in parameters:
+            assert parameters["payload_type"] == "Ex-3"
+        else:
+            assert parameters == {"cycle_id": "CYCLE_20260416"}
+        self.executed.append((statement, dict(parameters)))
         return _FakeResult(self._rows)
 
 
@@ -964,6 +1038,56 @@ def _canonical_input_row(entity_id: str, return_1d: float) -> dict[str, object]:
             "canonical:security_master@202",
         ],
     }
+
+
+def _ex3_graph_delta_payload(
+    *,
+    properties: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    return {
+        "subsystem_id": "subsystem-news",
+        "delta_id": "delta-ex3-bridge",
+        "delta_type": "edge_add",
+        "source_node": "ENT_STOCK_600519.SH",
+        "target_node": "ENT_STOCK_000001.SZ",
+        "relation_type": "supplier_of",
+        "properties": dict(properties or {"impact_score": 0.91}),
+        "evidence": ["evidence-ex3-bridge"],
+    }
+
+
+def _safe_ex3_graph_signal() -> dict[str, object]:
+    return {
+        "delta_id": "delta-ex3-bridge",
+        "source_node": "ENT_STOCK_600519.SH",
+        "target_node": "ENT_STOCK_000001.SZ",
+        "relation_type": "supplier_of",
+        "properties": {"impact_score": 0.91},
+        "evidence_refs": ["evidence-ex3-bridge"],
+        "cycle_id": "CYCLE_20260416",
+        "candidate_id": 40,
+        "selection_ref": "cycle_candidate_selection:CYCLE_20260416",
+    }
+
+
+def _no_unsafe_ex3_graph_signal_fields(value: object) -> bool:
+    serialized = json.dumps(value, sort_keys=True, default=str).lower()
+    return not any(
+        marker in serialized
+        for marker in (
+            "raw_text",
+            "chunk",
+            "light_rag_artifact",
+            "large_blob",
+            "metadata",
+            "private_note",
+            "payload_type",
+            "submitted_by",
+            "ingest_seq",
+            "validation_status",
+            "rejection_reason",
+        )
+    )
 
 
 def _no_source_specific_input_evidence(evidence: Mapping[str, object]) -> bool:

--- a/tests/integration/test_production_daily_cycle_provider.py
+++ b/tests/integration/test_production_daily_cycle_provider.py
@@ -154,6 +154,45 @@ def test_production_daily_cycle_default_graph_runtime_fails_closed(
         graph_status_provider.get_graph_status(candidate_freeze={}, cycle_id="CYCLE_20260427")
 
 
+def test_default_graph_phase1_provider_falls_back_for_env_misconfiguration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from orchestrator_adapters.production_daily_cycle import _default_graph_phase1_provider
+
+    fail_closed_provider = object()
+
+    def build_graph_phase1_provider() -> object:
+        raise EnvironmentError("Phase 1 runtime requires NEO4J_PASSWORD")
+
+    fake_graph_providers = SimpleNamespace(
+        build_graph_phase1_provider=build_graph_phase1_provider,
+        build_fail_closed_graph_phase1_provider=lambda: fail_closed_provider,
+    )
+    monkeypatch.setitem(sys.modules, "graph_engine.providers", fake_graph_providers)
+
+    assert _default_graph_phase1_provider() is fail_closed_provider
+
+
+@pytest.mark.parametrize("exc_type", [RuntimeError, ValueError])
+def test_default_graph_phase1_provider_propagates_unrelated_builder_errors(
+    exc_type: type[Exception],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from orchestrator_adapters.production_daily_cycle import _default_graph_phase1_provider
+
+    def build_graph_phase1_provider() -> object:
+        raise exc_type("unrelated provider bug")
+
+    fake_graph_providers = SimpleNamespace(
+        build_graph_phase1_provider=build_graph_phase1_provider,
+        build_fail_closed_graph_phase1_provider=lambda: object(),
+    )
+    monkeypatch.setitem(sys.modules, "graph_engine.providers", fake_graph_providers)
+
+    with pytest.raises(exc_type, match="unrelated provider bug"):
+        _default_graph_phase1_provider()
+
+
 def test_production_candidate_freeze_requires_cycle_tag_before_side_effect() -> None:
     from orchestrator_adapters.production_daily_cycle import _require_cycle_id_from_context
 


### PR DESCRIPTION
## Summary
- Add the m4.5 ex3 reasoner bridge handoff path across dry-run and production daily-cycle adapters.
- Cover the bridge handoff behavior with integration coverage.

## Tests
- git diff --check

## Codex local status
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider tests/integration/test_p2_dry_run_handoff.py tests/integration/test_phase2_main_core_wiring.py tests/integration/test_production_daily_cycle_provider.py -q` -> `30 passed, 8 skipped`.
- `git diff --check` clean.
- Skipped caveat/dependency warnings: 8 skips remain dependency-gated; dbt/dagster/sqlglot dependency deprecation warnings were emitted.
- Boundary caveat: `FrozenSelectionReader`/`DataPlatformFrozenSelectionReader` isolates frozen-selection DB access, but the default adapter still encapsulates a data-platform private repository query pending a public reader API.

<!-- codex-local-status:start -->
## Local CI Fix Status
- Commits: `964c3bddb98cc202a7a786c5a8c730e3dde99b95`, `205806b94cc625d715ecfb35071f55ac5a63bc90`.
- Root cause: full `ci` only checked out orchestrator while full integration tests import sibling runtime packages; the original `audit_eval` tag `v0.2.5` lacked the audit/replay persistence API now exercised by P2 tests; Temporal parity fixture referenced `l7` in `_build_checks()` without binding it.
- Fix: full `ci` installs the `full-ci` extra with pinned sibling runtime repos; `full-ci` now pins `project-ult-audit-eval` to `85fcc4725fa5b70c39a57048ceb837951892ab69` for `persist_audit_write_bundle`/`DuckDBReplayRepository`; regression keeps `shared-fixtures` at `v0.2.5`; temporal fixture binds `l7` from generated assets.
- Local validation: copied-worktree Python 3.12 `pip install -e "$tmp/src[dev,full-ci]"` passed and exported required `audit_eval.audit` symbols; audit persistence targeted tests `2 passed`; P2 handoff suite `14 passed, 4 skipped` locally due missing dbt CLI; production blocker `1 passed`; temporal parity `2 passed, 18 skipped` locally due missing dbt CLI; Ex-3 focused tests `2 passed`; `git diff --check` passed.
- Current CI: all GitHub checks pass at head `205806b94cc625d715ecfb35071f55ac5a63bc90`: `ci`, `contract`, `regression`, `smoke`, `test-fast`.
- Residual: `full-ci` still uses the `project-ult-audit-eval` commit pin `85fcc4725fa5b70c39a57048ceb837951892ab69` until a release includes the required audit/replay persistence API.
<!-- codex-local-status:end -->