### PR TITLE
[codex] Add M4.6 Ex-3 read model artifact

### DIFF
--- a/artifacts/frontend-api/ex3-graph-signals/CYCLE_20260416.json
+++ b/artifacts/frontend-api/ex3-graph-signals/CYCLE_20260416.json
@@ -1,0 +1,18 @@
+[
+  {
+    "candidate_id": 40,
+    "cycle_id": "CYCLE_20260416",
+    "delta_id": "delta-ex3-bridge",
+    "delta_type": "edge_add",
+    "evidence_refs": [
+      "evidence-ex3-bridge"
+    ],
+    "properties": {
+      "impact_score": 0.91
+    },
+    "relation_type": "supplier_of",
+    "selection_ref": "cycle_candidate_selection:CYCLE_20260416",
+    "source_node": "ENT_STOCK_600519.SH",
+    "target_node": "ENT_STOCK_000001.SZ"
+  }
+]

--- a/src/orchestrator_adapters/p2_dry_run.py
+++ b/src/orchestrator_adapters/p2_dry_run.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 from math import isfinite
 import os
+import re
 from pathlib import Path
 from typing import Any, Protocol, cast
 
@@ -69,19 +70,74 @@ _UNSAFE_EX3_GRAPH_PROPERTY_KEYS = frozenset(
     }
 )
 _UNSAFE_EX3_GRAPH_PROPERTY_KEY_MARKERS = ("blob", "chunk", "light_rag", "lightrag", "raw_text")
+_UNSAFE_EX3_GRAPH_PROPERTY_KEY_COMPACT_MARKERS = (
+    "apikey",
+    "ingest",
+    "metadata",
+    "privateid",
+    "provider",
+    "queueid",
+    "rawpayload",
+    "rawtext",
+    "secretkey",
+    "sourceid",
+    "sourceref",
+    "sourcetext",
+    "sourceuri",
+    "sourceurl",
+    "submitted",
+    "submission",
+    "traceback",
+)
+_UNSAFE_EX3_GRAPH_PROPERTY_KEY_COMPACT_PREFIXES = (
+    "ingest",
+    "private",
+    "provider",
+    "queue",
+    "raw",
+    "secret",
+    "source",
+    "submitted",
+    "submission",
+    "token",
+)
+_UNSAFE_EX3_GRAPH_PROPERTY_KEY_COMPACT_SUFFIXES = (
+    "metadata",
+    "privateid",
+    "queueid",
+    "secretkey",
+    "submittedat",
+    "token",
+)
 _UNSAFE_EX3_GRAPH_PROPERTY_KEY_TOKENS = frozenset(
     {
+        "ingest",
+        "ingested",
+        "ingestion",
+        "key",
+        "keys",
         "log",
         "logs",
+        "metadata",
+        "private",
         "provider",
         "queue",
         "raw",
         "secret",
         "secrets",
         "source",
+        "submission",
+        "submit",
+        "submitted",
+        "submitter",
+        "token",
+        "tokens",
         "traceback",
     }
 )
+_EX3_GRAPH_PROPERTY_ACRONYM_BOUNDARY = re.compile(r"(?<=[A-Z])(?=[A-Z][a-z])")
+_EX3_GRAPH_PROPERTY_CAMEL_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+_EX3_GRAPH_PROPERTY_SEPARATOR = re.compile(r"[^0-9A-Za-z]+")
 _MAX_EX3_GRAPH_SIGNAL_STRING_LENGTH = 2048
 _MAX_EX3_GRAPH_SIGNAL_COLLECTION_ITEMS = 50
 _MAX_EX3_GRAPH_SIGNAL_DEPTH = 4
@@ -1719,37 +1775,31 @@ def _unsafe_ex3_graph_property_key(key: object) -> bool:
     if not isinstance(key, str):
         return True
     stripped = key.strip()
-    normalized = stripped.lower()
-    if not normalized or normalized.startswith("_") or normalized.startswith("private"):
-        return True
-    if normalized in _UNSAFE_EX3_GRAPH_PROPERTY_KEYS:
-        return True
-    if normalized.endswith("_metadata"):
+    if not stripped or stripped.startswith("_"):
         return True
     key_tokens = _ex3_graph_property_key_tokens(stripped)
-    if key_tokens & _UNSAFE_EX3_GRAPH_PROPERTY_KEY_TOKENS:
+    if not key_tokens:
         return True
-    if any(marker in normalized for marker in ("provider", "queue", "secret", "traceback")):
+    normalized = "_".join(key_tokens)
+    compact = "".join(key_tokens)
+    if normalized in _UNSAFE_EX3_GRAPH_PROPERTY_KEYS:
+        return True
+    if any(marker in compact for marker in _UNSAFE_EX3_GRAPH_PROPERTY_KEY_COMPACT_MARKERS):
+        return True
+    if compact.startswith(_UNSAFE_EX3_GRAPH_PROPERTY_KEY_COMPACT_PREFIXES):
+        return True
+    if compact.endswith(_UNSAFE_EX3_GRAPH_PROPERTY_KEY_COMPACT_SUFFIXES):
+        return True
+    if set(key_tokens) & _UNSAFE_EX3_GRAPH_PROPERTY_KEY_TOKENS:
         return True
     return any(marker in normalized for marker in _UNSAFE_EX3_GRAPH_PROPERTY_KEY_MARKERS)
 
 
-def _ex3_graph_property_key_tokens(key: str) -> set[str]:
-    expanded: list[str] = []
-    previous_was_lower_or_digit = False
-    for character in key:
-        if character.isupper() and previous_was_lower_or_digit:
-            expanded.append("_")
-        expanded.append(character)
-        previous_was_lower_or_digit = character.islower() or character.isdigit()
-    normalized = (
-        "".join(expanded)
-        .lower()
-        .replace("-", "_")
-        .replace(".", "_")
-        .replace(":", "_")
-    )
-    return {token for token in normalized.split("_") if token}
+def _ex3_graph_property_key_tokens(key: str) -> tuple[str, ...]:
+    expanded = _EX3_GRAPH_PROPERTY_ACRONYM_BOUNDARY.sub("_", key)
+    expanded = _EX3_GRAPH_PROPERTY_CAMEL_BOUNDARY.sub("_", expanded)
+    normalized = _EX3_GRAPH_PROPERTY_SEPARATOR.sub("_", expanded).lower()
+    return tuple(token for token in normalized.split("_") if token)
 
 
 def _load_tushare_staging_rows(

--- a/src/orchestrator_adapters/p2_dry_run.py
+++ b/src/orchestrator_adapters/p2_dry_run.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 from math import isfinite
 import os
+from pathlib import Path
 from typing import Any, Protocol, cast
 
 from pydantic import BaseModel, Field
@@ -28,21 +29,59 @@ _LEGACY_INPUT_TABLE_DAILY = "main.stg_daily"
 _LEGACY_INPUT_TABLE_STOCK_BASIC = "main.stg_stock_basic"
 _EX3_PAYLOAD_TYPE = "Ex-3"
 _EX3_QUEUE_ENVELOPE_FIELDS = frozenset({"payload_type", "submitted_by"})
+_FRONTEND_API_ARTIFACT_ROOT_ENV = "ORCHESTRATOR_FRONTEND_API_ARTIFACT_ROOT"
+_FRONTEND_API_EX3_GRAPH_SIGNALS_DIR = "ex3-graph-signals"
+_FRONTEND_API_EX3_GRAPH_SIGNAL_FIELDS = frozenset(
+    {
+        "cycle_id",
+        "candidate_id",
+        "delta_id",
+        "delta_type",
+        "selection_ref",
+        "source_node",
+        "target_node",
+        "relation_type",
+        "properties",
+        "evidence_refs",
+    }
+)
 _UNSAFE_EX3_GRAPH_PROPERTY_KEYS = frozenset(
     {
         "chunk",
+        "candidate_queue_id",
         "ingest_seq",
         "light_rag_artifact",
+        "log",
+        "logs",
         "metadata",
         "payload_type",
+        "private_id",
+        "provider",
+        "queue_id",
         "raw_text",
         "rejection_reason",
+        "secret",
+        "source",
         "submitted_at",
         "submitted_by",
+        "traceback",
         "validation_status",
     }
 )
 _UNSAFE_EX3_GRAPH_PROPERTY_KEY_MARKERS = ("blob", "chunk", "light_rag", "lightrag", "raw_text")
+_UNSAFE_EX3_GRAPH_PROPERTY_KEY_TOKENS = frozenset(
+    {
+        "log",
+        "logs",
+        "provider",
+        "queue",
+        "raw",
+        "secret",
+        "secrets",
+        "source",
+        "traceback",
+    }
+)
 _MAX_EX3_GRAPH_SIGNAL_STRING_LENGTH = 2048
 _MAX_EX3_GRAPH_SIGNAL_COLLECTION_ITEMS = 50
 _MAX_EX3_GRAPH_SIGNAL_DEPTH = 4
@@ -456,8 +495,10 @@ class DataPlatformTushareCurrentCycleInputProvider:
         self,
         *,
         frozen_selection_reader: FrozenSelectionReader | None = None,
+        frontend_api_artifact_root: str | os.PathLike[str] | None = None,
     ) -> None:
         self._frozen_selection_reader = frozen_selection_reader
+        self._frontend_api_artifact_root = frontend_api_artifact_root
 
     def load_current_cycle_inputs(
         self,
@@ -523,6 +564,11 @@ class DataPlatformTushareCurrentCycleInputProvider:
             "partition_date": cycle_date.isoformat(),
             "source": "data-platform:tushare-staging:frozen-candidates",
         }
+        _write_frontend_api_ex3_graph_signals_artifact(
+            cycle_id=cycle_id,
+            graph_signals=ex3_graph_signals,
+            artifact_root=self._frontend_api_artifact_root,
+        )
         return P2CurrentCycleInputs(
             feature_bundles=feature_bundles,
             evidence=evidence,
@@ -536,8 +582,10 @@ class DataPlatformCanonicalCurrentCycleInputProvider:
         self,
         *,
         frozen_selection_reader: FrozenSelectionReader | None = None,
+        frontend_api_artifact_root: str | os.PathLike[str] | None = None,
     ) -> None:
         self._frozen_selection_reader = frozen_selection_reader
+        self._frontend_api_artifact_root = frontend_api_artifact_root
 
     def load_current_cycle_inputs(
         self,
@@ -615,6 +663,11 @@ class DataPlatformCanonicalCurrentCycleInputProvider:
             "lineage_refs": lineage_refs,
         }
         _assert_provider_neutral_input_evidence(evidence)
+        _write_frontend_api_ex3_graph_signals_artifact(
+            cycle_id=cycle_id,
+            graph_signals=ex3_graph_signals,
+            artifact_root=self._frontend_api_artifact_root,
+        )
         return P2CurrentCycleInputs(
             feature_bundles=feature_bundles,
             evidence=evidence,
@@ -739,6 +792,7 @@ class P2DryRunAssetFactoryProvider:
         audit_persistence_port: P2AuditPersistencePort | None = None,
         phase2_pool_failure_rate_provider: object | None = None,
         frozen_selection_reader: FrozenSelectionReader | None = None,
+        frontend_api_artifact_root: str | os.PathLike[str] | None = None,
         provide_llm_health_probe: bool = True,
         provide_io_manager: bool = True,
         require_cycle_tag: bool = False,
@@ -746,6 +800,7 @@ class P2DryRunAssetFactoryProvider:
         self.reasoner_gateway = reasoner_gateway or DefaultReasonerRuntimeGateway()
         self.input_provider = input_provider or DataPlatformCanonicalCurrentCycleInputProvider(
             frozen_selection_reader=frozen_selection_reader,
+            frontend_api_artifact_root=frontend_api_artifact_root,
         )
         self.publish_port_factory = publish_port_factory or DataPlatformIcebergPublishPort
         self.audit_persistence_port = audit_persistence_port or AuditEvalPersistencePort()
@@ -1398,6 +1453,130 @@ def _load_frozen_ex3_graph_signals(
     return tuple(graph_signals)
 
 
+def write_frontend_api_ex3_graph_signals_artifact(
+    cycle_id: str,
+    *,
+    reader: FrozenSelectionReader | None = None,
+    artifact_root: str | os.PathLike[str] | None = None,
+) -> Path:
+    """Write the frontend-api read-only Ex-3 graph signal artifact."""
+
+    graph_signals = _load_frozen_ex3_graph_signals(cycle_id, reader=reader)
+    return _write_frontend_api_ex3_graph_signals_artifact(
+        cycle_id=cycle_id,
+        graph_signals=graph_signals,
+        artifact_root=artifact_root,
+    )
+
+
+def _write_frontend_api_ex3_graph_signals_artifact(
+    *,
+    cycle_id: str,
+    graph_signals: Sequence[Mapping[str, object]],
+    artifact_root: str | os.PathLike[str] | None = None,
+) -> Path:
+    artifact_path = _frontend_api_ex3_graph_signals_artifact_path(
+        cycle_id=cycle_id,
+        artifact_root=artifact_root,
+    )
+    payload = [
+        _frontend_api_ex3_graph_signal(signal, cycle_id=cycle_id)
+        for signal in graph_signals
+    ]
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = artifact_path.with_suffix(artifact_path.suffix + ".tmp")
+    temp_path.write_text(
+        json.dumps(payload, sort_keys=True, indent=2, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    temp_path.replace(artifact_path)
+    return artifact_path
+
+
+def _frontend_api_ex3_graph_signal(
+    signal: Mapping[str, object],
+    *,
+    cycle_id: str,
+) -> dict[str, object]:
+    signal_keys = set(signal)
+    extra_keys = sorted(signal_keys - _FRONTEND_API_EX3_GRAPH_SIGNAL_FIELDS)
+    if extra_keys:
+        msg = "frontend-api Ex-3 artifact signal contains unsafe fields: "
+        raise ValueError(msg + ", ".join(extra_keys))
+    signal_cycle_id = _required_text_field(signal, "cycle_id")
+    if signal_cycle_id != cycle_id:
+        raise ValueError(
+            "frontend-api Ex-3 artifact signal cycle_id must match current cycle"
+        )
+    properties = signal.get("properties")
+    if not isinstance(properties, Mapping):
+        raise ValueError("frontend-api Ex-3 artifact signal properties must be an object")
+    evidence_refs = signal.get("evidence_refs")
+    if (
+        not isinstance(evidence_refs, Sequence)
+        or isinstance(evidence_refs, (str, bytes, bytearray))
+    ):
+        raise ValueError("frontend-api Ex-3 artifact signal evidence_refs must be a list")
+    candidate_id = signal.get("candidate_id")
+    if not isinstance(candidate_id, int) or isinstance(candidate_id, bool):
+        raise ValueError("frontend-api Ex-3 artifact signal candidate_id must be an int")
+    return {
+        "cycle_id": signal_cycle_id,
+        "candidate_id": candidate_id,
+        "delta_id": _required_text_field(signal, "delta_id"),
+        "delta_type": _required_text_field(signal, "delta_type"),
+        "selection_ref": _required_text_field(signal, "selection_ref"),
+        "source_node": _required_text_field(signal, "source_node"),
+        "target_node": _required_text_field(signal, "target_node"),
+        "relation_type": _required_text_field(signal, "relation_type"),
+        "properties": _sanitize_ex3_graph_properties(
+            cast(Mapping[str, object], properties),
+        ),
+        "evidence_refs": [str(ref) for ref in evidence_refs],
+    }
+
+
+def _frontend_api_ex3_graph_signals_artifact_path(
+    *,
+    cycle_id: str,
+    artifact_root: str | os.PathLike[str] | None = None,
+) -> Path:
+    return (
+        _frontend_api_artifact_root(artifact_root)
+        / _FRONTEND_API_EX3_GRAPH_SIGNALS_DIR
+        / _frontend_api_cycle_filename(cycle_id)
+    )
+
+
+def _frontend_api_artifact_root(
+    artifact_root: str | os.PathLike[str] | None = None,
+) -> Path:
+    if artifact_root is not None:
+        return Path(artifact_root)
+    env_root = os.environ.get(_FRONTEND_API_ARTIFACT_ROOT_ENV)
+    if env_root:
+        return Path(env_root)
+    return Path(__file__).resolve().parents[2] / "artifacts" / "frontend-api"
+
+
+def _frontend_api_cycle_filename(cycle_id: str) -> str:
+    if (
+        not cycle_id
+        or "/" in cycle_id
+        or "\\" in cycle_id
+        or cycle_id in {".", ".."}
+    ):
+        raise ValueError("frontend-api Ex-3 artifact cycle_id must be a safe filename")
+    return f"{cycle_id}.json"
+
+
+def _required_text_field(signal: Mapping[str, object], field_name: str) -> str:
+    value = signal.get(field_name)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"frontend-api Ex-3 artifact {field_name} must be non-empty")
+    return value.strip()
+
+
 def _load_frozen_selection_rows(
     cycle_id: str,
     *,
@@ -1539,14 +1718,38 @@ def _safe_ex3_graph_signal_value(value: object, *, depth: int) -> object:
 def _unsafe_ex3_graph_property_key(key: object) -> bool:
     if not isinstance(key, str):
         return True
-    normalized = key.strip().lower()
+    stripped = key.strip()
+    normalized = stripped.lower()
     if not normalized or normalized.startswith("_") or normalized.startswith("private"):
         return True
     if normalized in _UNSAFE_EX3_GRAPH_PROPERTY_KEYS:
         return True
     if normalized.endswith("_metadata"):
         return True
+    key_tokens = _ex3_graph_property_key_tokens(stripped)
+    if key_tokens & _UNSAFE_EX3_GRAPH_PROPERTY_KEY_TOKENS:
+        return True
+    if any(marker in normalized for marker in ("provider", "queue", "secret", "traceback")):
+        return True
     return any(marker in normalized for marker in _UNSAFE_EX3_GRAPH_PROPERTY_KEY_MARKERS)
+
+
+def _ex3_graph_property_key_tokens(key: str) -> set[str]:
+    expanded: list[str] = []
+    previous_was_lower_or_digit = False
+    for character in key:
+        if character.isupper() and previous_was_lower_or_digit:
+            expanded.append("_")
+        expanded.append(character)
+        previous_was_lower_or_digit = character.islower() or character.isdigit()
+    normalized = (
+        "".join(expanded)
+        .lower()
+        .replace("-", "_")
+        .replace(".", "_")
+        .replace(":", "_")
+    )
+    return {token for token in normalized.split("_") if token}
 
 
 def _load_tushare_staging_rows(
@@ -1945,4 +2148,5 @@ __all__ = [
     "P2ReasonerUnavailable",
     "P2WorldStateDeltaPayload",
     "p2_dry_run_provider",
+    "write_frontend_api_ex3_graph_signals_artifact",
 ]

--- a/tests/contract/test_frontend_api_artifacts.py
+++ b/tests/contract/test_frontend_api_artifacts.py
@@ -12,6 +12,7 @@ def test_frontend_api_orchestrator_artifacts_exist() -> None:
     required_paths = [
         ARTIFACT_ROOT / "runs.json",
         ARTIFACT_ROOT / "runs" / "RUN_API4A_001.json",
+        ARTIFACT_ROOT / "ex3-graph-signals" / "CYCLE_20260416.json",
     ]
 
     missing = [str(path) for path in required_paths if not path.exists()]
@@ -41,7 +42,73 @@ def test_frontend_api_orchestrator_run_detail_shape() -> None:
     assert isinstance(payload["metadata"], dict)
 
 
+def test_frontend_api_ex3_graph_signal_artifact_shape() -> None:
+    payload = _load_json_value(
+        ARTIFACT_ROOT / "ex3-graph-signals" / "CYCLE_20260416.json"
+    )
+    allowed_signal_keys = {
+        "cycle_id",
+        "candidate_id",
+        "delta_id",
+        "delta_type",
+        "selection_ref",
+        "source_node",
+        "target_node",
+        "relation_type",
+        "properties",
+        "evidence_refs",
+    }
+
+    assert isinstance(payload, list)
+    assert payload
+    for signal in payload:
+        assert isinstance(signal, dict)
+        assert set(signal) == allowed_signal_keys
+        assert signal["cycle_id"] == "CYCLE_20260416"
+        assert isinstance(signal["candidate_id"], int)
+        assert isinstance(signal["properties"], dict)
+        assert isinstance(signal["evidence_refs"], list)
+        assert not _has_forbidden_property_key(signal["properties"])
+
+
 def _load_json(path: Path) -> dict[str, Any]:
-    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload = _load_json_value(path)
     assert isinstance(payload, dict)
     return payload
+
+
+def _load_json_value(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _has_forbidden_property_key(value: object) -> bool:
+    forbidden_exact = {
+        "candidate_queue_id",
+        "ingest_seq",
+        "log",
+        "logs",
+        "metadata",
+        "private_id",
+        "provider",
+        "queue_id",
+        "raw_text",
+        "secret",
+        "source",
+        "traceback",
+    }
+    forbidden_tokens = {"log", "logs", "provider", "queue", "raw", "secret", "source"}
+    if isinstance(value, dict):
+        for key, item in value.items():
+            normalized = str(key).strip().lower()
+            key_tokens = {
+                token
+                for token in normalized.replace("-", "_").replace(".", "_").split("_")
+                if token
+            }
+            if normalized in forbidden_exact or key_tokens & forbidden_tokens:
+                return True
+            if _has_forbidden_property_key(item):
+                return True
+    if isinstance(value, list):
+        return any(_has_forbidden_property_key(item) for item in value)
+    return False

--- a/tests/integration/test_p2_dry_run_handoff.py
+++ b/tests/integration/test_p2_dry_run_handoff.py
@@ -126,6 +126,7 @@ def test_p2_dry_run_handoff_uses_data_platform_canonical_provider(
     dagster_instance: object,
     stub_policy_path: str,
     tmp_dbt_project: Path,
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     dagster = dagster_module
@@ -182,6 +183,7 @@ def test_p2_dry_run_handoff_uses_data_platform_canonical_provider(
     reasoner_recorder = _ReasonerRecorder()
     publish_recorder = _PublishRecorder()
     audit_storage = InMemoryFormalAuditStorageAdapter()
+    frontend_artifact_root = tmp_path / "frontend-api"
     provider = P2DryRunAssetFactoryProvider(
         reasoner_gateway=DefaultReasonerRuntimeGateway(
             client_factory=reasoner_recorder.client_factory,
@@ -192,6 +194,7 @@ def test_p2_dry_run_handoff_uses_data_platform_canonical_provider(
             storage_factory=lambda: audit_storage,
         ),
         frozen_selection_reader=frozen_reader,
+        frontend_api_artifact_root=frontend_artifact_root,
     )
     assert isinstance(provider.input_provider, DataPlatformCanonicalCurrentCycleInputProvider)
     defs = build_definitions(
@@ -238,9 +241,13 @@ def test_p2_dry_run_handoff_uses_data_platform_canonical_provider(
         if call["metadata"]["layer"] == "L6"
     ]
     graph_features = l6_payloads[0]["context"]["feature_bundle"]["graph_features"]
+    artifact_path = (
+        frontend_artifact_root / "ex3-graph-signals" / "CYCLE_20260416.json"
+    )
     assert graph_features["ex3_graph_signals"] == [ex3_graph_signal]
     assert graph_features["same_cycle_ex3_graph_signals"] == [ex3_graph_signal]
     assert _no_unsafe_ex3_graph_signal_fields(graph_features)
+    assert json.loads(artifact_path.read_text(encoding="utf-8")) == [ex3_graph_signal]
 
 
 def test_p2_dry_run_hard_stops_without_llm_before_l8_or_publish(
@@ -472,6 +479,7 @@ def test_audit_eval_persistence_port_durable_retry_recovers_half_written_audit_r
 
 def test_data_platform_canonical_provider_loads_current_cycle_evidence(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     from orchestrator_adapters import p2_dry_run
 
@@ -493,6 +501,7 @@ def test_data_platform_canonical_provider_loads_current_cycle_evidence(
     frozen_reader = _FrozenSelectionReader(
         (
             _frozen_selection_row(10, {"ts_code": "600519.SH"}, payload_type="Ex-1"),
+            _frozen_selection_row(40, _ex3_graph_delta_payload(), payload_type="Ex-3"),
             _frozen_selection_row(11, {"ts_code": "000001.SZ"}, payload_type="Ex-1"),
         )
     )
@@ -506,6 +515,7 @@ def test_data_platform_canonical_provider_loads_current_cycle_evidence(
 
     input_provider = p2_dry_run.DataPlatformCanonicalCurrentCycleInputProvider(
         frozen_selection_reader=frozen_reader,
+        frontend_api_artifact_root=tmp_path / "frontend-api",
     )
     inputs = input_provider.load_current_cycle_inputs(
         cycle_id="CYCLE_20260416",
@@ -527,6 +537,16 @@ def test_data_platform_canonical_provider_loads_current_cycle_evidence(
         "security_master": 202,
     }
     assert _no_source_specific_input_evidence(inputs.evidence)
+    bundle_payload = inputs.feature_bundles[0].model_dump(mode="json")
+    assert bundle_payload["graph_features"]["same_cycle_ex3_graph_signals"] == [
+        _safe_ex3_graph_signal()
+    ]
+    artifact_path = (
+        tmp_path / "frontend-api" / "ex3-graph-signals" / "CYCLE_20260416.json"
+    )
+    assert json.loads(artifact_path.read_text(encoding="utf-8")) == [
+        _safe_ex3_graph_signal()
+    ]
 
 
 @pytest.mark.parametrize("marker", ["ENT_P2_A", "ENT_P2_B", "synthetic-current-cycle"])
@@ -630,6 +650,105 @@ def test_load_frozen_ex3_graph_signals_sanitizes_accepted_contract_payload() -> 
         },
     )
     assert _no_unsafe_ex3_graph_signal_fields(signals)
+
+
+def test_write_frontend_api_ex3_graph_signals_artifact_sanitizes_payload(
+    tmp_path: Path,
+) -> None:
+    from orchestrator_adapters import p2_dry_run
+
+    ex3_payload = _ex3_graph_delta_payload(
+        properties={
+            "impact_score": 0.91,
+            "safe_details": {
+                "direction": "positive",
+                "source": "drop",
+                "quality": "confirmed",
+            },
+            "provider": "drop",
+            "provider_model": "drop",
+            "providerName": "drop",
+            "source_url": "drop",
+            "sourceUrl": "drop",
+            "raw_payload": "drop",
+            "rawPayload": "drop",
+            "log_lines": ["drop"],
+            "logLines": ["drop"],
+            "secret_key": "drop",
+            "secretKey": "drop",
+            "traceback": "drop",
+            "queue_id": "drop",
+            "queuePrivateId": "drop",
+            "candidate_queue_id": "drop",
+            "private_id": "drop",
+            "metadata": {"drop": True},
+        }
+    )
+    rows = [
+        _frozen_selection_row(30, {"ts_code": "600519.SH"}, payload_type="Ex-1"),
+        _frozen_selection_row(
+            31,
+            ex3_payload,
+            payload_type="Ex-3",
+            validation_status="rejected",
+        ),
+        _frozen_selection_row(32, ex3_payload, payload_type="Ex-3"),
+    ]
+
+    artifact_path = p2_dry_run.write_frontend_api_ex3_graph_signals_artifact(
+        "CYCLE_20260416",
+        reader=_FrozenSelectionReader(rows),
+        artifact_root=tmp_path / "frontend-api",
+    )
+
+    payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert artifact_path == (
+        tmp_path / "frontend-api" / "ex3-graph-signals" / "CYCLE_20260416.json"
+    )
+    assert payload == [
+        {
+            "cycle_id": "CYCLE_20260416",
+            "candidate_id": 32,
+            "delta_id": "delta-ex3-bridge",
+            "delta_type": "edge_add",
+            "selection_ref": "cycle_candidate_selection:CYCLE_20260416",
+            "source_node": "ENT_STOCK_600519.SH",
+            "target_node": "ENT_STOCK_000001.SZ",
+            "relation_type": "supplier_of",
+            "properties": {
+                "impact_score": 0.91,
+                "safe_details": {
+                    "direction": "positive",
+                    "quality": "confirmed",
+                },
+            },
+            "evidence_refs": ["evidence-ex3-bridge"],
+        }
+    ]
+    assert _only_frontend_api_ex3_graph_signal_keys(payload)
+
+
+def test_write_frontend_api_ex3_graph_signals_artifact_rejects_cross_cycle_signal(
+    tmp_path: Path,
+) -> None:
+    from orchestrator_adapters import p2_dry_run
+
+    graph_signal = {
+        **_safe_ex3_graph_signal(),
+        "cycle_id": "CYCLE_20260415",
+    }
+    artifact_root = tmp_path / "frontend-api"
+
+    with pytest.raises(ValueError, match="cycle_id must match current cycle"):
+        p2_dry_run._write_frontend_api_ex3_graph_signals_artifact(
+            cycle_id="CYCLE_20260416",
+            graph_signals=(graph_signal,),
+            artifact_root=artifact_root,
+        )
+
+    assert not (
+        artifact_root / "ex3-graph-signals" / "CYCLE_20260416.json"
+    ).exists()
 
 
 @pytest.mark.parametrize("marker", ["ENT_P2_A", "ENT_P2_B", "synthetic-current-cycle"])
@@ -1106,6 +1225,68 @@ def _no_unsafe_ex3_graph_signal_fields(value: object) -> bool:
             "rejection_reason",
         )
     )
+
+
+def _only_frontend_api_ex3_graph_signal_keys(value: object) -> bool:
+    allowed_signal_keys = {
+        "cycle_id",
+        "candidate_id",
+        "delta_id",
+        "delta_type",
+        "selection_ref",
+        "source_node",
+        "target_node",
+        "relation_type",
+        "properties",
+        "evidence_refs",
+    }
+    if not isinstance(value, list):
+        return False
+    for signal in value:
+        if not isinstance(signal, dict):
+            return False
+        if set(signal) != allowed_signal_keys:
+            return False
+        properties = signal.get("properties")
+        if not isinstance(properties, dict):
+            return False
+        if _has_forbidden_frontend_api_ex3_property_key(properties):
+            return False
+    return True
+
+
+def _has_forbidden_frontend_api_ex3_property_key(value: object) -> bool:
+    forbidden_exact = {
+        "candidate_queue_id",
+        "ingest_seq",
+        "log",
+        "logs",
+        "metadata",
+        "private_id",
+        "provider",
+        "queue_id",
+        "raw_payload",
+        "raw_text",
+        "secret",
+        "source",
+        "traceback",
+    }
+    forbidden_tokens = {"log", "logs", "provider", "queue", "raw", "secret", "source"}
+    if isinstance(value, dict):
+        for key, item in value.items():
+            normalized = str(key).strip().lower()
+            key_tokens = {
+                token
+                for token in normalized.replace("-", "_").replace(".", "_").split("_")
+                if token
+            }
+            if normalized in forbidden_exact or key_tokens & forbidden_tokens:
+                return True
+            if _has_forbidden_frontend_api_ex3_property_key(item):
+                return True
+    if isinstance(value, list):
+        return any(_has_forbidden_frontend_api_ex3_property_key(item) for item in value)
+    return False
 
 
 def _no_source_specific_input_evidence(evidence: Mapping[str, object]) -> bool:

--- a/tests/integration/test_p2_dry_run_handoff.py
+++ b/tests/integration/test_p2_dry_run_handoff.py
@@ -660,11 +660,16 @@ def test_write_frontend_api_ex3_graph_signals_artifact_sanitizes_payload(
     ex3_payload = _ex3_graph_delta_payload(
         properties={
             "impact_score": 0.91,
+            "businessLabel": "relationship strengthened",
             "safe_details": {
                 "direction": "positive",
                 "source": "drop",
                 "quality": "confirmed",
             },
+            "ingestSeq": "drop",
+            "submittedAt": "drop",
+            "fooMetadata": {"drop": True},
+            "candidatePrivateId": "drop",
             "provider": "drop",
             "provider_model": "drop",
             "providerName": "drop",
@@ -716,6 +721,7 @@ def test_write_frontend_api_ex3_graph_signals_artifact_sanitizes_payload(
             "target_node": "ENT_STOCK_000001.SZ",
             "relation_type": "supplier_of",
             "properties": {
+                "businessLabel": "relationship strengthened",
                 "impact_score": 0.91,
                 "safe_details": {
                     "direction": "positive",
@@ -726,6 +732,26 @@ def test_write_frontend_api_ex3_graph_signals_artifact_sanitizes_payload(
         }
     ]
     assert _only_frontend_api_ex3_graph_signal_keys(payload)
+
+
+def test_ex3_graph_property_sanitizer_filters_common_key_variants() -> None:
+    from orchestrator_adapters import p2_dry_run
+
+    assert p2_dry_run._sanitize_ex3_graph_properties(
+        {
+            "confidenceBand": "high",
+            "risk_score": 0.12,
+            "Ingest-Seq": "drop",
+            "Submitted.At": "drop",
+            "FooMetadata": {"drop": True},
+            "candidatePrivateId": "drop",
+            "apiKey": "drop",
+            "source.URL": "drop",
+        }
+    ) == {
+        "confidenceBand": "high",
+        "risk_score": 0.12,
+    }
 
 
 def test_write_frontend_api_ex3_graph_signals_artifact_rejects_cross_cycle_signal(


### PR DESCRIPTION
## Summary

Implements the M4.6 orchestrator write-side read model artifact for frontend-api to consume sanitized same-cycle Ex-3 graph signals.

## Scope

- Adds `artifacts/frontend-api/ex3-graph-signals/{cycle_id}.json` emission from the P2 dry-run current-cycle input providers after current-cycle inputs are successfully constructed.
- Reuses the existing frozen Ex-3 loader and graph signal sanitizer path, with stricter frontend artifact guards for allowed fields, same-cycle `cycle_id`, and forbidden property keys including raw/provider/source/private/log/metadata/secret/queue/traceback variants.
- Adds a sanitized static sample artifact for `CYCLE_20260416` and frontend-api artifact contract coverage.

## Non-goals

- Read-only artifact only; no write API.
- Does not modify `contracts`, `frontend-api`, `assembly`, or other repositories.
- Does not close G4/P5.
- Does not involve financial-doc.

## Evidence

Synthetic/unit evidence only; no live PG dependency.

- `python3 -m py_compile src/orchestrator_adapters/p2_dry_run.py tests/integration/test_p2_dry_run_handoff.py tests/contract/test_frontend_api_artifacts.py`
- `.venv/bin/pytest -rs tests/integration/test_p2_dry_run_handoff.py::test_p2_dry_run_handoff_uses_data_platform_canonical_provider tests/integration/test_p2_dry_run_handoff.py::test_data_platform_canonical_provider_loads_current_cycle_evidence tests/integration/test_p2_dry_run_handoff.py::test_load_frozen_ex3_graph_signals_sanitizes_accepted_contract_payload tests/integration/test_p2_dry_run_handoff.py::test_write_frontend_api_ex3_graph_signals_artifact_sanitizes_payload tests/integration/test_p2_dry_run_handoff.py::test_write_frontend_api_ex3_graph_signals_artifact_rejects_cross_cycle_signal tests/contract/test_frontend_api_artifacts.py` => 8 passed, 1 skipped locally because dbt CLI is not installed
- `git diff --check`
