### PR TITLE
[codex] Fix P2 MVP20 manifest handoff pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,8 @@ shared-fixtures = [
 # Keep shared-fixtures on v0.2.5; full-ci needs newer audit replay APIs.
 full-ci = [
     "project-ult-contracts @ git+https://github.com/shenfanjie5-bit/project-ult-contracts.git@v0.1.3",
-    "project-ult-audit-eval @ git+https://github.com/shenfanjie5-bit/project-ult-audit-eval.git@85fcc4725fa5b70c39a57048ceb837951892ab69",
-    "project-ult-main-core @ git+https://github.com/shenfanjie5-bit/project-ult-main-core.git@efaa4f62027401ee85d1a20095ab4f7ff29e6994",
+    "project-ult-audit-eval @ git+https://github.com/shenfanjie5-bit/project-ult-audit-eval.git@a038ce172da711951500296f2c39862da1d53b6b",
+    "project-ult-main-core @ git+https://github.com/shenfanjie5-bit/project-ult-main-core.git@471dcf5e53a38d5be8bbb79113af061fd4e3b462",
     "project-ult-data-platform @ git+https://github.com/shenfanjie5-bit/project-ult-data-platform.git@52b8dd50dd8504cb024e46e4bcda5f6a9544628c",
     "project-ult-graph-engine @ git+https://github.com/shenfanjie5-bit/project-ult-graph-engine.git@9dde6f80af996d661eaf86aef73acbc43f8300e9",
     "project-ult-reasoner-runtime @ git+https://github.com/shenfanjie5-bit/project-ult-reasoner-runtime.git@025db5ba4b67aaa76545fd0b942e5b8856fcae89",

--- a/src/orchestrator_adapters/p2_dry_run.py
+++ b/src/orchestrator_adapters/p2_dry_run.py
@@ -23,6 +23,7 @@ _DEFAULT_HEALTH_TIMEOUT_S = 30.0
 _SOURCE_KIND = "current-cycle"
 _SOURCE_LAYER = "L8"
 _RECOMMENDATION_OBJECT_KEY = "recommendation_snapshot"
+_MVP20_MANIFEST_TARGET_COUNT = 20
 _REQUIRED_RECOMMENDATION_LAYERS = frozenset({"L4", "L6", "L7", "L8"})
 _FORBIDDEN_PROVENANCE_MARKERS = ("smoke", "fixture", "historical")
 _FORBIDDEN_INPUT_MARKERS = (*_FORBIDDEN_PROVENANCE_MARKERS, "synthetic", "ent_p2")
@@ -186,6 +187,7 @@ class P2CurrentCycleInputs:
     """Frozen current-cycle inputs loaded from data-platform for P2 L1."""
 
     feature_bundles: tuple[object, ...]
+    manifest_targets: tuple[str, ...]
     evidence: Mapping[str, object]
 
 
@@ -627,6 +629,7 @@ class DataPlatformTushareCurrentCycleInputProvider:
         )
         return P2CurrentCycleInputs(
             feature_bundles=feature_bundles,
+            manifest_targets=tuple(str(bundle.entity_id) for bundle in feature_bundles),
             evidence=evidence,
         )
 
@@ -675,6 +678,7 @@ class DataPlatformCanonicalCurrentCycleInputProvider:
                 "frozen candidates",
             )
 
+        manifest_targets = _canonical_manifest_targets_from_rows(candidate_refs, rows)
         feature_bundles = tuple(
             _feature_bundle_from_canonical_row(
                 cycle_id=cycle_id,
@@ -684,7 +688,7 @@ class DataPlatformCanonicalCurrentCycleInputProvider:
             )
             for row in rows
         )
-        entity_ids = [str(row["entity_id"]) for row in rows]
+        entity_ids = list(manifest_targets)
         canonical_dataset_refs = sorted(
             {
                 str(dataset_ref)
@@ -726,8 +730,62 @@ class DataPlatformCanonicalCurrentCycleInputProvider:
         )
         return P2CurrentCycleInputs(
             feature_bundles=feature_bundles,
+            manifest_targets=manifest_targets,
             evidence=evidence,
         )
+
+
+def _canonical_manifest_targets_from_rows(
+    candidate_refs: Sequence[str],
+    rows: Sequence[Mapping[str, object]],
+) -> tuple[str, ...]:
+    rows_by_candidate_ref: dict[str, str] = {}
+    for row in rows:
+        entity_id = str(row.get("entity_id", "")).strip()
+        if not entity_id:
+            raise ValueError("P2 canonical current-cycle row requires entity_id")
+
+        lineage_refs = {str(item) for item in _sequence_value(row.get("lineage_refs"))}
+        matched_refs = [
+            candidate_ref
+            for candidate_ref in candidate_refs
+            if f"candidate:{candidate_ref}" in lineage_refs
+        ]
+        if not matched_refs:
+            matched_refs = [
+                candidate_ref
+                for candidate_ref in candidate_refs
+                if entity_id == candidate_ref or entity_id.endswith(candidate_ref)
+            ]
+        if not matched_refs:
+            raise ValueError(
+                "P2 canonical current-cycle row does not match frozen candidate refs: "
+                f"{entity_id}"
+            )
+        if len(matched_refs) > 1:
+            raise ValueError(
+                "P2 canonical current-cycle row ambiguously matches frozen candidate refs: "
+                f"{entity_id}"
+            )
+        candidate_ref = matched_refs[0]
+        if candidate_ref in rows_by_candidate_ref:
+            raise ValueError(
+                "P2 canonical current-cycle rows duplicate frozen candidate ref: "
+                f"{candidate_ref}"
+            )
+        rows_by_candidate_ref[candidate_ref] = entity_id
+
+    missing_refs = [
+        candidate_ref
+        for candidate_ref in candidate_refs
+        if candidate_ref not in rows_by_candidate_ref
+    ]
+    if missing_refs:
+        raise ValueError(
+            "P2 canonical current-cycle inputs missing frozen candidate refs: "
+            + ", ".join(missing_refs)
+        )
+    return tuple(rows_by_candidate_ref[candidate_ref] for candidate_ref in candidate_refs)
 
 
 class AuditEvalPersistencePort:
@@ -870,7 +928,7 @@ class P2DryRunAssetFactoryProvider:
 
         from main_core.common.contexts import AlphaAnalysisContext
         from main_core.l4_world_state import derive_world_state
-        from main_core.l5_universe import select_official_alpha_pool
+        from main_core.l5_universe import select_mvp20_decision_pool
         from main_core.l6_alpha import SinglePromptAnalyzer, analyze_stock
         from main_core.l7_recommendation import generate_recommendations
         from main_core.l8_publish.manifest import commit_formal_objects
@@ -928,10 +986,10 @@ class P2DryRunAssetFactoryProvider:
         @dagster.asset(name=PHASE2_STAGE_KEYS[4], group_name=PHASE2_GROUP_NAME)
         def l5(l4, l3):
             feature_bundles = _feature_bundles_from_inputs(l3)
-            return select_official_alpha_pool(
+            return select_mvp20_decision_pool(
                 l4,
                 feature_bundles,
-                capacity=len(feature_bundles),
+                _manifest_targets_from_inputs(l3),
             )
 
         @dagster.asset(name=PHASE2_STAGE_KEYS[5], group_name=PHASE2_GROUP_NAME)
@@ -1213,6 +1271,29 @@ def _feature_bundles_from_inputs(value: object) -> tuple[object, ...]:
     if not feature_bundles:
         raise ValueError("P2 dry-run requires non-empty current-cycle feature input")
     return feature_bundles
+
+
+def _manifest_targets_from_inputs(value: object) -> tuple[str, ...]:
+    if not isinstance(value, P2CurrentCycleInputs):
+        raise TypeError("P2 manifest targets must come from P2CurrentCycleInputs")
+
+    manifest_targets = value.manifest_targets
+    if not isinstance(manifest_targets, tuple):
+        raise TypeError("P2 manifest_targets must be a typed tuple")
+    if len(manifest_targets) != _MVP20_MANIFEST_TARGET_COUNT:
+        raise ValueError("P2 MVP20 manifest_targets must contain exactly 20 entity ids")
+
+    normalized_targets: list[str] = []
+    seen_targets: set[str] = set()
+    for entity_id in manifest_targets:
+        if not isinstance(entity_id, str) or not entity_id.strip():
+            raise ValueError("P2 manifest_targets must contain non-empty entity ids")
+        normalized_entity_id = entity_id.strip()
+        if normalized_entity_id in seen_targets:
+            raise ValueError("P2 manifest_targets must not contain duplicate entity ids")
+        normalized_targets.append(normalized_entity_id)
+        seen_targets.add(normalized_entity_id)
+    return tuple(normalized_targets)
 
 
 def _input_evidence_from_inputs(value: object) -> Mapping[str, object]:

--- a/tests/integration/test_p2_dry_run_handoff.py
+++ b/tests/integration/test_p2_dry_run_handoff.py
@@ -76,7 +76,8 @@ def test_p2_dry_run_materializes_current_cycle_l8_and_manifest_handoff(
     assert {dagster.AssetKey([stage]) for stage in PHASE2_STAGE_KEYS} <= materialized_keys
     assert dagster.AssetKey([PHASE3_FORMAL_COMMIT_ASSET_KEY]) in materialized_keys
     assert dagster.AssetKey([PHASE3_MANIFEST_ASSET_KEY]) in materialized_keys
-    assert reasoner_recorder.layers == ["L4", "L6", "L6"]
+    assert reasoner_recorder.layers[0] == "L4"
+    assert reasoner_recorder.layers.count("L6") == 20
     assert provenance is not None
     assert provenance["cycle_id"] == "CYCLE_20260416"
     assert provenance["current_cycle_id"] == "CYCLE_20260416"
@@ -101,10 +102,9 @@ def test_p2_dry_run_materializes_current_cycle_l8_and_manifest_handoff(
     assert formal_commit.state.input_evidence["selection_ref"] == (
         "cycle_candidate_selection:CYCLE_20260416"
     )
-    assert formal_commit.state.input_evidence["entity_ids"] == [
-        "ENT_STOCK_600519.SH",
-        "ENT_STOCK_000001.SZ",
-    ]
+    assert formal_commit.state.input_evidence["entity_ids"] == list(
+        _static_manifest_targets()
+    )
     assert formal_commit.state.input_evidence["canonical_dataset_refs"] == [
         "price_bar",
         "security_master",
@@ -115,8 +115,8 @@ def test_p2_dry_run_materializes_current_cycle_l8_and_manifest_handoff(
         for call in publish_recorder.commit_calls
         if call["object_key"] == "official_alpha_pool"
     )
-    committed_entities = set(pool_payload["selected_entities"])
-    assert "ENT_STOCK_600519.SH" in committed_entities
+    committed_entities = tuple(pool_payload["selected_entities"])
+    assert committed_entities == _static_manifest_targets()
     assert "ENT_P2_A" not in committed_entities
     assert "ENT_P2_B" not in committed_entities
 
@@ -149,17 +149,24 @@ def test_p2_dry_run_handoff_uses_data_platform_canonical_provider(
     ) -> tuple[dict[str, object], ...]:
         assert cycle_id == "CYCLE_20260416"
         assert selection_ref == "cycle_candidate_selection:CYCLE_20260416"
-        assert tuple(candidate_ids) == ("600519.SH", "000001.SZ")
+        assert tuple(candidate_ids) == _static_candidate_refs()
         assert as_of_snapshot is None
-        return (
-            _canonical_input_row("ENT_STOCK_600519.SH", 0.012),
-            _canonical_input_row("ENT_STOCK_000001.SZ", -0.004),
+        return tuple(
+            _canonical_input_row(entity_id, 0.012 - (index * 0.001))
+            for index, entity_id in enumerate(_static_manifest_targets())
         )
 
     ex3_graph_signal = _safe_ex3_graph_signal()
     frozen_reader = _FrozenSelectionReader(
         (
-            _frozen_selection_row(10, {"ts_code": "600519.SH"}, payload_type="Ex-1"),
+            *(
+                _frozen_selection_row(
+                    10 + index,
+                    {"ts_code": candidate_ref},
+                    payload_type="Ex-1",
+                )
+                for index, candidate_ref in enumerate(_static_candidate_refs())
+            ),
             _frozen_selection_row(
                 40,
                 {
@@ -169,7 +176,6 @@ def test_p2_dry_run_handoff_uses_data_platform_canonical_provider(
                 },
                 payload_type="Ex-3",
             ),
-            _frozen_selection_row(11, {"ts_code": "000001.SZ"}, payload_type="Ex-1"),
         )
     )
     import data_platform.cycle as data_platform_cycle
@@ -221,17 +227,16 @@ def test_p2_dry_run_handoff_uses_data_platform_canonical_provider(
     committed_entities = set(pool_payload["selected_entities"])
 
     assert result.success is True
-    assert formal_commit.state.input_evidence["candidate_ids"] == [10, 11]
-    assert formal_commit.state.input_evidence["entity_ids"] == [
-        "ENT_STOCK_600519.SH",
-        "ENT_STOCK_000001.SZ",
-    ]
+    assert formal_commit.state.input_evidence["candidate_ids"] == list(range(10, 30))
+    assert formal_commit.state.input_evidence["entity_ids"] == list(
+        _static_manifest_targets()
+    )
     assert formal_commit.state.input_evidence["canonical_snapshot_ids"] == {
         "price_bar": 101,
         "security_master": 202,
     }
     assert _no_source_specific_input_evidence(formal_commit.state.input_evidence)
-    assert committed_entities == {"ENT_STOCK_600519.SH", "ENT_STOCK_000001.SZ"}
+    assert committed_entities == set(_static_manifest_targets())
     assert "ENT_P2_A" not in committed_entities
     assert "ENT_P2_B" not in committed_entities
     assert publish_recorder.manifest_provenance is not None
@@ -248,6 +253,218 @@ def test_p2_dry_run_handoff_uses_data_platform_canonical_provider(
     assert graph_features["same_cycle_ex3_graph_signals"] == [ex3_graph_signal]
     assert _no_unsafe_ex3_graph_signal_fields(graph_features)
     assert json.loads(artifact_path.read_text(encoding="utf-8")) == [ex3_graph_signal]
+
+
+def test_p2_dry_run_l5_uses_exactly_20_manifest_targets(
+    dagster_module: object,
+    dagster_instance: object,
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+) -> None:
+    dagster = dagster_module
+
+    from audit_eval.audit import InMemoryFormalAuditStorageAdapter
+    from orchestrator.definitions import build_definitions
+    from orchestrator_adapters.p2_dry_run import (
+        AuditEvalPersistencePort,
+        DefaultReasonerRuntimeGateway,
+        P2DryRunAssetFactoryProvider,
+    )
+
+    reasoner_recorder = _ReasonerRecorder()
+    publish_recorder = _PublishRecorder()
+    provider = P2DryRunAssetFactoryProvider(
+        reasoner_gateway=DefaultReasonerRuntimeGateway(
+            client_factory=reasoner_recorder.client_factory,
+            health_probe=_reasoner_health_probe(available=True),
+        ),
+        input_provider=_StaticCurrentCycleInputProvider(
+            include_extra_context_bundle=True,
+        ),
+        publish_port_factory=lambda: _FakePublishPort(publish_recorder),
+        audit_persistence_port=AuditEvalPersistencePort(
+            storage_factory=InMemoryFormalAuditStorageAdapter,
+        ),
+    )
+    defs = build_definitions(
+        module_factories=[
+            _fake_phase0_provider(dagster),
+            _fake_phase1_provider(dagster),
+            provider,
+        ],
+        policy_path=stub_policy_path,
+    )
+
+    result = defs.get_job_def("daily_cycle_job").execute_in_process(
+        instance=dagster_instance,
+        tags={"cycle_id": "CYCLE_20260416"},
+    )
+
+    pool_payload = next(
+        call["payload"]
+        for call in publish_recorder.commit_calls
+        if call["object_key"] == "official_alpha_pool"
+    )
+    alpha_payload = next(
+        call["payload"]
+        for call in publish_recorder.commit_calls
+        if call["object_key"] == "alpha_result_snapshot"
+    )
+    recommendation_payload = next(
+        call["payload"]
+        for call in publish_recorder.commit_calls
+        if call["object_key"] == "recommendation_snapshot"
+    )
+    l6_payload_entity_ids = tuple(
+        json.loads(str(call["messages"][1]["content"]))["entity_id"]
+        for call in reasoner_recorder.calls
+        if call["metadata"]["layer"] == "L6"
+    )
+
+    assert result.success is True
+    assert tuple(pool_payload["selected_entities"]) == _static_manifest_targets()
+    assert pool_payload["observation_pool_size"] == 20
+    assert pool_payload["official_alpha_pool_capacity"] == 20
+    assert l6_payload_entity_ids == _static_manifest_targets()
+    assert tuple(item["entity_id"] for item in alpha_payload["items"]) == (
+        _static_manifest_targets()
+    )
+    assert tuple(item["entity_id"] for item in recommendation_payload["items"]) == (
+        _static_manifest_targets()
+    )
+    assert _EXTRA_CONTEXT_ENTITY_ID not in pool_payload["selected_entities"]
+    assert _EXTRA_CONTEXT_ENTITY_ID not in l6_payload_entity_ids
+    assert _EXTRA_CONTEXT_ENTITY_ID not in {
+        item["entity_id"] for item in recommendation_payload["items"]
+    }
+
+
+@pytest.mark.parametrize("target_count", [19, 21])
+def test_p2_dry_run_manifest_target_count_fails_before_publish(
+    target_count: int,
+    dagster_module: object,
+    dagster_instance: object,
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+) -> None:
+    dagster = dagster_module
+
+    from audit_eval.audit import InMemoryFormalAuditStorageAdapter
+    from orchestrator.definitions import build_definitions
+    from orchestrator.jobs.phase2 import PHASE2_STAGE_KEYS
+    from orchestrator.jobs.phase3 import (
+        PHASE3_FORMAL_COMMIT_ASSET_KEY,
+        PHASE3_MANIFEST_ASSET_KEY,
+    )
+    from orchestrator_adapters.p2_dry_run import (
+        AuditEvalPersistencePort,
+        DefaultReasonerRuntimeGateway,
+        P2DryRunAssetFactoryProvider,
+    )
+
+    reasoner_recorder = _ReasonerRecorder()
+    publish_recorder = _PublishRecorder()
+    provider = P2DryRunAssetFactoryProvider(
+        reasoner_gateway=DefaultReasonerRuntimeGateway(
+            client_factory=reasoner_recorder.client_factory,
+            health_probe=_reasoner_health_probe(available=True),
+        ),
+        input_provider=_StaticCurrentCycleInputProvider(
+            manifest_targets=_static_manifest_targets(target_count),
+        ),
+        publish_port_factory=lambda: _FakePublishPort(publish_recorder),
+        audit_persistence_port=AuditEvalPersistencePort(
+            storage_factory=InMemoryFormalAuditStorageAdapter,
+        ),
+    )
+    defs = build_definitions(
+        module_factories=[
+            _fake_phase0_provider(dagster),
+            _fake_phase1_provider(dagster),
+            provider,
+        ],
+        policy_path=stub_policy_path,
+    )
+
+    result = defs.get_job_def("daily_cycle_job").execute_in_process(
+        instance=dagster_instance,
+        raise_on_error=False,
+        tags={"cycle_id": "CYCLE_20260416"},
+    )
+    materialized_keys = asset_materialization_keys(result)
+
+    assert result.success is False
+    assert reasoner_recorder.layers == ["L4"]
+    assert dagster.AssetKey([PHASE2_STAGE_KEYS[7]]) not in materialized_keys
+    assert dagster.AssetKey([PHASE3_FORMAL_COMMIT_ASSET_KEY]) not in materialized_keys
+    assert dagster.AssetKey([PHASE3_MANIFEST_ASSET_KEY]) not in materialized_keys
+    assert publish_recorder.commit_calls == []
+    assert publish_recorder.manifest_provenance is None
+
+
+def test_p2_dry_run_missing_typed_manifest_targets_fails_before_publish(
+    dagster_module: object,
+    dagster_instance: object,
+    stub_policy_path: str,
+    tmp_dbt_project: Path,
+) -> None:
+    dagster = dagster_module
+
+    from audit_eval.audit import InMemoryFormalAuditStorageAdapter
+    from orchestrator.definitions import build_definitions
+    from orchestrator.jobs.phase3 import PHASE3_FORMAL_COMMIT_ASSET_KEY
+    from orchestrator_adapters.p2_dry_run import (
+        AuditEvalPersistencePort,
+        DefaultReasonerRuntimeGateway,
+        P2DryRunAssetFactoryProvider,
+    )
+
+    class LegacySequenceInputProvider:
+        def load_current_cycle_inputs(
+            self,
+            *,
+            cycle_id: str,
+            graph_snapshot: str,
+        ) -> object:
+            typed_inputs = _StaticCurrentCycleInputProvider().load_current_cycle_inputs(
+                cycle_id=cycle_id,
+                graph_snapshot=graph_snapshot,
+            )
+            return typed_inputs.feature_bundles
+
+    publish_recorder = _PublishRecorder()
+    provider = P2DryRunAssetFactoryProvider(
+        reasoner_gateway=DefaultReasonerRuntimeGateway(
+            client_factory=_ReasonerRecorder().client_factory,
+            health_probe=_reasoner_health_probe(available=True),
+        ),
+        input_provider=LegacySequenceInputProvider(),
+        publish_port_factory=lambda: _FakePublishPort(publish_recorder),
+        audit_persistence_port=AuditEvalPersistencePort(
+            storage_factory=InMemoryFormalAuditStorageAdapter,
+        ),
+    )
+    defs = build_definitions(
+        module_factories=[
+            _fake_phase0_provider(dagster),
+            _fake_phase1_provider(dagster),
+            provider,
+        ],
+        policy_path=stub_policy_path,
+    )
+
+    result = defs.get_job_def("daily_cycle_job").execute_in_process(
+        instance=dagster_instance,
+        raise_on_error=False,
+        tags={"cycle_id": "CYCLE_20260416"},
+    )
+
+    assert result.success is False
+    assert dagster.AssetKey(
+        [PHASE3_FORMAL_COMMIT_ASSET_KEY]
+    ) not in asset_materialization_keys(result)
+    assert publish_recorder.commit_calls == []
+    assert publish_recorder.manifest_provenance is None
 
 
 def test_p2_dry_run_hard_stops_without_llm_before_l8_or_publish(
@@ -494,8 +711,8 @@ def test_data_platform_canonical_provider_loads_current_cycle_evidence(
         assert tuple(candidate_ids) == ("600519.SH", "000001.SZ")
         assert as_of_snapshot is None
         return (
-            _canonical_input_row("ENT_STOCK_600519.SH", 0.012),
             _canonical_input_row("ENT_STOCK_000001.SZ", -0.004),
+            _canonical_input_row("ENT_STOCK_600519.SH", 0.012),
         )
 
     frozen_reader = _FrozenSelectionReader(
@@ -523,9 +740,13 @@ def test_data_platform_canonical_provider_loads_current_cycle_evidence(
     )
 
     assert [bundle.entity_id for bundle in inputs.feature_bundles] == [
+        "ENT_STOCK_000001.SZ",
+        "ENT_STOCK_600519.SH",
+    ]
+    assert inputs.manifest_targets == (
         "ENT_STOCK_600519.SH",
         "ENT_STOCK_000001.SZ",
-    ]
+    )
     assert inputs.evidence["candidate_ids"] == [10, 11]
     assert inputs.evidence["entity_ids"] == [
         "ENT_STOCK_600519.SH",
@@ -877,57 +1098,127 @@ class _FakeStructuredClient:
         )
 
 
+_STATIC_MANIFEST_TARGETS = (
+    "ENT_STOCK_600519.SH",
+    "ENT_STOCK_000001.SZ",
+    "ENT_STOCK_000002.SZ",
+    "ENT_STOCK_000003.SZ",
+    "ENT_STOCK_000004.SZ",
+    "ENT_STOCK_000005.SZ",
+    "ENT_STOCK_000006.SZ",
+    "ENT_STOCK_000007.SZ",
+    "ENT_STOCK_000008.SZ",
+    "ENT_STOCK_000009.SZ",
+    "ENT_STOCK_000010.SZ",
+    "ENT_STOCK_000011.SZ",
+    "ENT_STOCK_000012.SZ",
+    "ENT_STOCK_000013.SZ",
+    "ENT_STOCK_000014.SZ",
+    "ENT_STOCK_000015.SZ",
+    "ENT_STOCK_000016.SZ",
+    "ENT_STOCK_000017.SZ",
+    "ENT_STOCK_000018.SZ",
+    "ENT_STOCK_000019.SZ",
+    "ENT_STOCK_000020.SZ",
+)
+_EXTRA_CONTEXT_ENTITY_ID = "ENT_STOCK_999999.SZ"
+
+
+def _static_manifest_targets(count: int = 20) -> tuple[str, ...]:
+    return _STATIC_MANIFEST_TARGETS[:count]
+
+
+def _static_candidate_refs(count: int = 20) -> tuple[str, ...]:
+    return tuple(
+        entity_id.removeprefix("ENT_STOCK_")
+        for entity_id in _static_manifest_targets(count)
+    )
+
+
+def _static_feature_bundle(
+    *,
+    cycle_id: str,
+    graph_snapshot: str,
+    entity_id: str,
+    index: int,
+    candidate_score: float | None = None,
+) -> object:
+    from main_core.common.schemas import FeatureSignalBundle
+
+    score = candidate_score if candidate_score is not None else 0.02 - (index * 0.001)
+    return FeatureSignalBundle(
+        cycle_id=cycle_id,
+        entity_id=entity_id,
+        feature_values={"momentum": score, "close": 1700.0 - index},
+        signal_values={
+            "origin": "canonical-current-cycle",
+            "trade_date": "2026-04-16",
+            "canonical_dataset_refs": ["price_bar", "security_master"],
+            "candidate_score": score,
+        },
+        graph_features={"graph_snapshot_ref": graph_snapshot},
+        feature_weight_multiplier={"momentum": 1.0, "close": 1.0},
+    )
+
+
 class _StaticCurrentCycleInputProvider:
+    def __init__(
+        self,
+        *,
+        manifest_targets: Sequence[str] | None = None,
+        include_extra_context_bundle: bool = False,
+    ) -> None:
+        self._manifest_targets = tuple(manifest_targets or _static_manifest_targets())
+        self._include_extra_context_bundle = include_extra_context_bundle
+
     def load_current_cycle_inputs(
         self,
         *,
         cycle_id: str,
         graph_snapshot: str,
     ) -> object:
-        from main_core.common.schemas import FeatureSignalBundle
         from orchestrator_adapters.p2_dry_run import P2CurrentCycleInputs
 
+        feature_bundles = tuple(
+            _static_feature_bundle(
+                cycle_id=cycle_id,
+                graph_snapshot=graph_snapshot,
+                entity_id=entity_id,
+                index=index,
+            )
+            for index, entity_id in enumerate(self._manifest_targets)
+        )
+        if self._include_extra_context_bundle:
+            feature_bundles = (
+                *feature_bundles,
+                _static_feature_bundle(
+                    cycle_id=cycle_id,
+                    graph_snapshot=graph_snapshot,
+                    entity_id=_EXTRA_CONTEXT_ENTITY_ID,
+                    index=99,
+                    candidate_score=99.0,
+                ),
+            )
+
         return P2CurrentCycleInputs(
-            feature_bundles=(
-                FeatureSignalBundle(
-                    cycle_id=cycle_id,
-                    entity_id="ENT_STOCK_600519.SH",
-                    feature_values={"momentum": 0.012, "close": 1700.0},
-                    signal_values={
-                        "origin": "canonical-current-cycle",
-                        "trade_date": "2026-04-16",
-                        "canonical_dataset_refs": ["price_bar", "security_master"],
-                    },
-                    graph_features={"graph_snapshot_ref": graph_snapshot},
-                    feature_weight_multiplier={"momentum": 1.0, "close": 1.0},
-                ),
-                FeatureSignalBundle(
-                    cycle_id=cycle_id,
-                    entity_id="ENT_STOCK_000001.SZ",
-                    feature_values={"momentum": -0.004, "close": 11.0},
-                    signal_values={
-                        "origin": "canonical-current-cycle",
-                        "trade_date": "2026-04-16",
-                        "canonical_dataset_refs": ["price_bar", "security_master"],
-                    },
-                    graph_features={"graph_snapshot_ref": graph_snapshot},
-                    feature_weight_multiplier={"momentum": 1.0, "close": 1.0},
-                ),
-            ),
+            feature_bundles=feature_bundles,
+            manifest_targets=self._manifest_targets,
             evidence={
                 "cycle_id": cycle_id,
                 "trade_date": "2026-04-16",
                 "selection_ref": f"cycle_candidate_selection:{cycle_id}",
-                "candidate_ids": [10, 11],
-                "entity_ids": ["ENT_STOCK_600519.SH", "ENT_STOCK_000001.SZ"],
+                "candidate_ids": list(range(10, 10 + len(self._manifest_targets))),
+                "entity_ids": list(self._manifest_targets),
                 "canonical_dataset_refs": ["price_bar", "security_master"],
                 "canonical_snapshot_ids": {"price_bar": 101, "security_master": 202},
-                "row_count": 2,
+                "row_count": len(self._manifest_targets),
                 "lineage_refs": [
                     f"cycle:{cycle_id}",
                     f"selection:cycle_candidate_selection:{cycle_id}",
-                    "candidate:10",
-                    "candidate:11",
+                    *[
+                        f"candidate:{candidate_id}"
+                        for candidate_id in range(10, 10 + len(self._manifest_targets))
+                    ],
                     "canonical:price_bar@101",
                     "canonical:security_master@202",
                 ],


### PR DESCRIPTION
## Summary
- add typed P2 manifest_targets and require L5 to read them fail-closed
- switch P2 dry-run L5 to public select_mvp20_decision_pool with explicit MVP20 targets
- update full-ci main-core and audit-eval pins
- expand handoff tests for exact 20 targets, extra context bundles, 19/21/missing target failures, and canonical target ordering

## Validation
- PYTHONPATH=src:../main-core/src:../graph-engine:../reasoner-runtime:../contracts/src:../data-platform/src:../audit-eval/src .venv/bin/python -m pytest -q tests/integration/test_p2_dry_run_handoff.py tests/integration/test_production_daily_cycle_provider.py tests/boundary/test_red_lines.py tests/static/test_boundaries.py
- git diff --check